### PR TITLE
BAU: Fixes for PKI generation script

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3'
 
 services:
   proxy-node-gateway:
@@ -91,7 +91,7 @@ services:
       - ./.local_pki:/stub-idp/pki:ro
 
   proxy-node-metadata:
-    image: ruby:2.4.4
+    image: ruby:2.5.3-alpine
     command: ruby -run -ehttpd /srv -p80
     ports:
       - "7000:80"

--- a/pki/Gemfile
+++ b/pki/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 group :development do
-  gem 'verify-metadata-generator', :git => 'git@github.com:alphagov/verify-metadata-generator'
+  gem 'verify-metadata-generator', :git => 'https://github.com/alphagov/verify-metadata-generator'
   gem 'keystores'
   gem 'nokogiri'
 end

--- a/pki/Gemfile.lock
+++ b/pki/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: git@github.com:alphagov/verify-metadata-generator
-  revision: 57d054bc485325a2e696294582c0b4e32d343351
+  remote: https://github.com/alphagov/verify-metadata-generator
+  revision: 47b90464d9c9e11d892d9c04f1d75cd9e9a83877
   specs:
     verify-metadata-generator (0.0.2)
       activemodel
@@ -10,26 +10,26 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (5.1.4)
-      activesupport (= 5.1.4)
-    activesupport (5.1.4)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    concurrent-ruby (1.0.5)
-    i18n (0.9.5)
+    concurrent-ruby (1.1.3)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
-    json-schema (2.8.0)
+    json-schema (2.8.1)
       addressable (>= 2.4)
     keystores (0.4.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -43,4 +43,4 @@ DEPENDENCIES
   verify-metadata-generator!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/pki/metadata.rb
+++ b/pki/metadata.rb
@@ -70,9 +70,10 @@ def generate_proxy_node_metadata(proxy_node_config, ca_cert)
   end
 end
 
-def sign_metadata(metadata_xml, keypair, xmlsectool_path = 'xmlsectool')
+def sign_metadata(metadata_xml, keypair, xmlsectool_path = nil)
+  xmlsectool_path ||= ENV.fetch('XMLSECTOOL', 'xmlsectool')
   puts("Signing metadata with cert #{keypair.cert.subject}")
-  in_tmp_dir('proxy_node_meta') do
+  in_tmp_dir('proxy_node_meta') do |dir|
     cert_file = create_file('metadata.crt', keypair.cert.to_pem)
     key_file = create_file('metadata.key', keypair.key.to_der)
     metadata_file = create_file('metadata.xml', metadata_xml)
@@ -80,10 +81,10 @@ def sign_metadata(metadata_xml, keypair, xmlsectool_path = 'xmlsectool')
     cmd = <<~EOS
     #{xmlsectool_path} \
       --sign \
-      --inFile metadata.xml \
-      --outFile metadata_signed.xml \
-      --certificate metadata.crt \
-      --key metadata.key \
+      --inFile #{dir}/metadata.xml \
+      --outFile #{dir}/metadata_signed.xml \
+      --certificate #{dir}/metadata.crt \
+      --key #{dir}/metadata.key \
       --digest SHA-256
     EOS
 

--- a/pki/utils.rb
+++ b/pki/utils.rb
@@ -10,7 +10,7 @@ end
 def in_tmp_dir(dn)
   Dir.mktmpdir(dn) do |dir|
     puts("-- in_tmp_dir #{dir}")
-    Dir.chdir(dir) { yield }
+    Dir.chdir(dir) { yield(dir) }
   end
 end
 


### PR DESCRIPTION
- Allow specifying path to `xmlsectool` in environment variable
- Use absolute paths in `xmlsectool` command
- Get `verify-metadata-generator` gem via `https://` instead of `git@`
- Make `docker-compose.yml` version less specific for compatibility
- Use alpine ruby image to serve metadata