### PR TITLE
Make methods common so they can be used between classes

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionFactory.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionFactory.java
@@ -1,0 +1,38 @@
+package uk.gov.ida.notification.saml;
+
+import org.opensaml.storage.ReplayCache;
+import se.litsec.opensaml.saml2.common.response.MessageReplayChecker;
+import uk.gov.ida.notification.saml.validation.components.DuplicateAssertionChecker;
+import uk.gov.ida.saml.core.validators.assertion.AssertionAttributeStatementValidator;
+import uk.gov.ida.saml.core.validators.assertion.AuthnStatementAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.DuplicateAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.IPAddressValidator;
+import uk.gov.ida.saml.core.validators.assertion.IdentityProviderAssertionValidator;
+import uk.gov.ida.saml.core.validators.assertion.MatchingDatasetAssertionValidator;
+import uk.gov.ida.saml.core.validators.subject.AssertionSubjectValidator;
+import uk.gov.ida.saml.core.validators.subjectconfirmation.AssertionSubjectConfirmationValidator;
+import uk.gov.ida.saml.hub.validators.response.idp.components.ResponseAssertionsFromIdpValidator;
+import uk.gov.ida.saml.security.validators.issuer.IssuerValidator;
+
+import static uk.gov.ida.notification.saml.validation.components.MessageReplayCheckerFactory.createMessageReplayChecker;
+
+public class ResponseAssertionFactory {
+
+    public static ResponseAssertionsFromIdpValidator createResponseAssertionsFromIdpValidator(String application, String proxyNodeEntityId, ReplayCache cache) throws Exception {
+        IdentityProviderAssertionValidator assertionValidator = new IdentityProviderAssertionValidator(
+                new IssuerValidator(),
+                new AssertionSubjectValidator(),
+                new AssertionAttributeStatementValidator(),
+                new AssertionSubjectConfirmationValidator()
+        );
+        MessageReplayChecker messageReplayChecker = createMessageReplayChecker(application + ":" + ResponseAssertionsFromIdpValidator.class.getName(), cache);
+        DuplicateAssertionValidator duplicateAssertionValidator = new DuplicateAssertionChecker(messageReplayChecker);
+        return new ResponseAssertionsFromIdpValidator(
+                assertionValidator,
+                new MatchingDatasetAssertionValidator(duplicateAssertionValidator),
+                new AuthnStatementAssertionValidator(duplicateAssertionValidator),
+                new IPAddressValidator(),
+                proxyNodeEntityId
+        );
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
@@ -1,0 +1,29 @@
+package uk.gov.ida.notification.saml;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
+import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
+import uk.gov.ida.notification.saml.metadata.MetadataCredentialResolverInitializer;
+import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
+import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
+
+public class SamlSignatureValidatorFactory {
+
+
+    public static SamlMessageSignatureValidator createSamlMessageSignatureValidator(MetadataResolverBundle hubMetadataResolverBundle) throws ComponentInitializationException {
+        MetadataCredentialResolver hubMetadataCredentialResolver = new MetadataCredentialResolverInitializer(hubMetadataResolverBundle.getMetadataResolver()).initialize();
+        KeyInfoCredentialResolver keyInfoCredentialResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
+        ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine = new ExplicitKeySignatureTrustEngine(hubMetadataCredentialResolver, keyInfoCredentialResolver);
+        MetadataBackedSignatureValidator metadataBackedSignatureValidator = MetadataBackedSignatureValidator.withoutCertificateChainValidation(explicitKeySignatureTrustEngine);
+        return new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
+    }
+
+    public static SamlRequestSignatureValidator createSamlRequestSignatureValidator(MetadataResolverBundle hubMetadataResolverBundle) throws ComponentInitializationException {
+        SamlMessageSignatureValidator samlMessageSignatureValidator = createSamlMessageSignatureValidator(hubMetadataResolverBundle);
+        return new SamlRequestSignatureValidator(samlMessageSignatureValidator);
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/metadata/MetadataFactory.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/metadata/MetadataFactory.java
@@ -1,0 +1,13 @@
+package uk.gov.ida.notification.saml.metadata;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+
+public class MetadataFactory {
+
+    public static Metadata createMetadataFromBundle(MetadataResolverBundle bundle) throws ComponentInitializationException {
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverInitializer(bundle.getMetadataResolver()).initialize();
+        return new Metadata(metadataCredentialResolver);
+    }
+}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -12,7 +12,6 @@ import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import org.opensaml.security.SecurityException;
 import org.opensaml.security.credential.BasicCredential;
 import uk.gov.ida.notification.SamlFormViewBuilder;
@@ -25,13 +24,14 @@ import uk.gov.ida.notification.saml.ResponseAssertionDecrypter;
 import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.saml.converters.ResponseParameterProvider;
 import uk.gov.ida.notification.saml.metadata.Metadata;
-import uk.gov.ida.notification.saml.metadata.MetadataCredentialResolverInitializer;
 import uk.gov.ida.notification.stubconnector.resources.MetadataResource;
 import uk.gov.ida.notification.stubconnector.resources.ReceiveResponseResource;
 import uk.gov.ida.notification.stubconnector.resources.SendAuthnRequestResource;
 import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+
+import static uk.gov.ida.notification.saml.metadata.MetadataFactory.createMetadataFromBundle;
 
 public class StubConnectorApplication extends Application<uk.gov.ida.notification.stubconnector.StubConnectorConfiguration> {
     private Metadata proxyNodeMetadata;
@@ -94,7 +94,7 @@ public class StubConnectorApplication extends Application<uk.gov.ida.notificatio
                     final Environment environment) throws
             ComponentInitializationException {
 
-        proxyNodeMetadata = createMetadata(proxyNodeMetadataResolverBundle);
+        proxyNodeMetadata = createMetadataFromBundle(proxyNodeMetadataResolverBundle);
 
         ProxyNodeHealthCheck proxyNodeHealthCheck = new ProxyNodeHealthCheck("stub-connector");
         environment.healthChecks().register(proxyNodeHealthCheck.getName(), proxyNodeHealthCheck);
@@ -161,11 +161,6 @@ public class StubConnectorApplication extends Application<uk.gov.ida.notificatio
         );
 
         environment.healthChecks().register(metadataHealthCheck.getName(), metadataHealthCheck);
-    }
-
-    private Metadata createMetadata(MetadataResolverBundle bundle) throws ComponentInitializationException {
-        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverInitializer(bundle.getMetadataResolver()).initialize();
-        return new Metadata(metadataCredentialResolver);
     }
 
     private ResponseAssertionDecrypter createDecrypter(KeyPairConfiguration configuration) {


### PR DESCRIPTION
- Remove request references from the Translator service
- Move common classes to factories 
- Remove unused methods