### PR TITLE
EID-1155: Dockerize softHSM in Proxy Node Translator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ local_eidas_reference/docker/pki
 local_eidas_reference/gateway
 local_eidas_reference/translator
 .local_pki
+proxy-node-translator/src/dist/proxy_node_signing.*

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ ext {
     dropwizard_version = '1.2.0'
     utils_version = '2.0.0-346'
     saml_libs_version = "${opensaml_version}-160"
+    soft_hsm_version = '1.1.1'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -47,6 +48,7 @@ subprojects {
         dropwizard
         saml
         saml_test
+        soft_hsm
     }
 
     dependencies {
@@ -80,6 +82,10 @@ subprojects {
                 "javax.activation:activation:1.1.1",
                 "io.lettuce:lettuce-core:5.1.3.RELEASE",
                 "uk.gov.ida:security-utils:${utils_version}"
+        )
+
+        soft_hsm (
+                "se.swedenconnect.opensaml:opensaml-pkcs11-support:${soft_hsm_version}"
         )
 
         testCompile (

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,10 +28,19 @@ services:
     volumes:
       - ./.local_pki:/verify-eidas-proxy-node/pki:ro
   proxy-node-translator:
+    depends_on:
+      - soft-hsm
     build:
       context: .
+      dockerfile: translator.softHSM.Dockerfile
       args:
         component: proxy-node-translator
+        softHSMSigningKeyLabel: vfpn-uk-signing
+        softHSMSigningKeyToken: vfpn-uk-signing
+        softHSMSigningKeySlot: 0
+        softHSMSigningKeyId: DEF0
+        softHSMSigningKeyPin: CHANGE-ME-123
+        softHSMSigningKeySoPin: CHANGE-ME-456
     ports:
       - "6300:80"
       - "6661:6661"
@@ -47,9 +56,17 @@ services:
       CONNECTOR_NODE_METADATA_URL: http://stub-connector/Metadata
       CONNECTOR_NODE_ENTITY_ID: http://localhost:5000/Metadata
       REDIS_SERVER_URI: redis://gateway-redis:6379/
+      SOFT_HSM_LIB_PATH: /usr/lib/softhsm/libsofthsm2.so
     env_file: ./.local_pki/proxy_node.env
     volumes:
-    - ./pki:/verify-eidas-proxy-node/pki:ro
+      - ./pki:/verify-eidas-proxy-node/pki:ro
+  soft-hsm:
+    build:
+      context: .
+      dockerfile: softHSM.baseImage.Dockerfile
+      args:
+        baseImage: openjdk:11-jre-slim
+    image: govukverify/soft-hsm
   stub-connector:
     build:
       context: .

--- a/gradle-compose.yaml
+++ b/gradle-compose.yaml
@@ -2,12 +2,17 @@ version: '3'
 
 services:
   docker-gradle:
-    image: gradle:jdk11
+    build:
+      context: .
+      dockerfile: softHSM.baseImage.Dockerfile
+      args:
+        baseImage: gradle:jdk11
     working_dir: /home/gradle/project
     user: root
     entrypoint: gradle --no-daemon
     environment:
       VERIFY_USE_PUBLIC_BINARIES: 'true'
+      SOFT_HSM_LIB_PATH: /usr/lib/softhsm/libsofthsm2.so
     volumes:
       - gradle-cache:/home/gradle/.gradle
       - .:/home/gradle/project

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/pki/generate
+++ b/pki/generate
@@ -62,6 +62,11 @@ def der2pk8(der)
   stdout
 end
 
+def der2p8(der)
+  stdout, status = Open3.capture2('openssl pkcs8 -topk8 -inform DER -outform PEM -nocrypt', stdin_data: der)
+  stdout
+end
+
 def b64(s)
   strip_pem(Base64.encode64(s))
 end
@@ -199,6 +204,13 @@ Dir.chdir(output_dir) do
     create_file('proxy_node_signing.pk8', der2pk8(proxy_signing_keypair.key.to_der))
     create_file('stub_connector_signing.pk8', der2pk8(stub_connector_signing_keypair.key.to_der))
     create_file('stub_connector_encryption.pk8', der2pk8(stub_connector_encryption_keypair.key.to_der))
+  end
+
+  if options.softhsm
+      puts('Creating proxy_node_signing files for softhsm testing...')
+      create_file('proxy_node_signing.crt', proxy_signing_keypair.cert.to_pem)
+      create_file('proxy_node_signing.pk8', der2pk8(proxy_signing_keypair.key.to_der))
+      create_file('../proxy-node-translator/src/dist/proxy_node_signing.p8', der2p8(proxy_signing_keypair.key.to_der))
   end
 
   if options.do_manifests

--- a/pki/options.rb
+++ b/pki/options.rb
@@ -2,7 +2,20 @@ require 'optparse'
 
 USAGE = 'Usage: generate.rb [options] <output directory>'
 
-Options = Struct.new(:hub_entity_id, :idp_entity_id, :proxy_entity_id, :hub_response_url, :idp_sso_url, :proxy_sso_url, :do_files, :do_manifests, :do_env, :xmlsectool_path, :truststore_pass)
+Options =
+    Struct.new(
+        :hub_entity_id,
+        :idp_entity_id,
+        :proxy_entity_id,
+        :hub_response_url,
+        :idp_sso_url,
+        :proxy_sso_url,
+        :do_files,
+        :do_manifests,
+        :do_env,
+        :xmlsectool_path,
+        :truststore_pass,
+        :softhsm)
 
 class Parser
   def self.parse(args)
@@ -33,6 +46,7 @@ class Parser
       opts.on('--env', "Output environment files for Docker Compose") { |_| options.do_env = true }
       opts.on('--xmlsectool PATH', "Path to xmlsectool (default: xmlsectool)") { |s| options.xmlsectool_path = s }
       opts.on('--truststore-pass PASSWORD', "Password for generated truststores (default: marshmallow)") { |s| options.truststore_pass = s }
+      opts.on('--softhsm', "Use softhsm for testing") { |_| options.softhsm = true }
       opts.on('-h', '--help', 'Print help message') { |_| abort(opts.to_s) }
     end
 

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -2,7 +2,16 @@ dependencies {
     compile configurations.dropwizard,
             configurations.saml,
             configurations.common,
+            configurations.soft_hsm,
             project(':proxy-node-shared')
+}
+
+sourceSets {
+    test {
+        resources {
+            srcDir '../.local_pki'
+        }
+    }
 }
 
 group = 'uk.gov.ida.notification.translator'

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/softhsm/SoftHSMIntegrationTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/softhsm/SoftHSMIntegrationTest.java
@@ -1,0 +1,171 @@
+package uk.gov.ida.notification.softhsm;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.security.credential.Credential;
+import se.swedenconnect.opensaml.pkcs11.PKCS11Provider;
+import se.swedenconnect.opensaml.pkcs11.PKCS11ProviderFactory;
+import se.swedenconnect.opensaml.pkcs11.configuration.PKCS11ProviderConfiguration;
+import se.swedenconnect.opensaml.pkcs11.configuration.PKCS11SoftHsmProviderConfiguration;
+import se.swedenconnect.opensaml.pkcs11.configuration.SoftHsmCredentialConfiguration;
+import se.swedenconnect.opensaml.pkcs11.credential.PKCS11Credential;
+import se.swedenconnect.opensaml.pkcs11.providerimpl.PKCS11ProviderInstance;
+import uk.gov.ida.notification.helpers.TestKeyPair;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Tests demonstrating usage of the swedenconnect opensaml-pkcs11 library in conjunction with softHSM.
+ * https://github.com/swedenconnect/opensaml-pkcs11
+ * https://wiki.opendnssec.org/display/SoftHSM/Home
+ * <p>
+ * SoftHSM must be installed locally in order for the tests to run.
+ */
+public class SoftHSMIntegrationTest {
+
+    // Test Certificate Constants
+    private static final String PROXY_NODE_SIGNING_PK_8 = "proxy_node_signing.pk8";
+    private static final String PROXY_NODE_SIGNING_CRT = "proxy_node_signing.crt";
+
+    // Test PKCS11 Constants
+    private static final String PROVIDER_SUN_PKCS_11 = "SunPKCS11";
+
+    // Test Credential Constants
+    private static final String CRED_ALIAS_PREFIX = "vfpn-uk";
+    private static final String CRED_ENV = "dev";
+    private static final String CRED_PIN = "1234";
+    private static final String CRED_SLOT = "0";
+    private static final String CRED_NAME = "vfpn-uk";
+    private static final String CRED_ALIAS = CRED_ALIAS_PREFIX + "-" + CRED_ENV;
+
+    // softHSM Configuration
+    private static String softHSMLibPath = System.getenv("SOFT_HSM_LIB_PATH");
+
+    /**
+     * softHSM tests should only run if softHSM is installed and configured.
+     * Installation and configuration to be indicated by the SOFT_HSM_LIB_PATH environment variable.
+     * softHSM is installed in the Translator Docker image and this variable is set, so the tests
+     * will run on pre-commit.  Running the tests when building locally is effectively excluded
+     * by not setting this environment variable.
+     */
+    @Before
+    public void checkSoftHSMConfigured() {
+        assumeTrue(softHSMLibPath != null && softHSMLibPath.length() > 0);
+    }
+
+    @Test(expected = java.lang.NullPointerException.class)
+    public void shouldThrowExceptionForPKCS11ProviderConfigurationWithoutCredentials() throws Exception {
+
+        PKCS11ProviderConfiguration configuration = createPKCS11SoftHSMProviderConfigurationWithoutCredentials(CRED_SLOT, CRED_NAME);
+        PKCS11Provider pkcs11Provider = getPkcs11ProviderForConfiguration(configuration);
+
+        TestKeyPair signingTestKeyPair = new TestKeyPair(PROXY_NODE_SIGNING_CRT, PROXY_NODE_SIGNING_PK_8);
+        Credential credential = new PKCS11Credential(
+                signingTestKeyPair.certificate,
+                pkcs11Provider.getProviderNameList(),
+                CRED_ALIAS_PREFIX, CRED_PIN);
+    }
+
+    @Test
+    public void shouldCreateCredentialConfigurationList() {
+        PKCS11ProviderConfiguration configuration = createPKCS11SoftHSMProviderConfigurationWithCredentials(CRED_ALIAS, CRED_ENV, CRED_PIN, CRED_SLOT, CRED_NAME);
+        assertNotNull("PKCS11ProviderConfiguration not loaded from credentials", configuration);
+    }
+
+
+    @Test
+    public void shouldCreatePKSC11ProviderFromFactory() throws Exception {
+
+        PKCS11ProviderConfiguration configuration = createPKCS11SoftHSMProviderConfigurationWithCredentials(CRED_ALIAS, CRED_ENV, CRED_PIN, CRED_SLOT, CRED_NAME);
+        PKCS11Provider pkcs11Provider = getPkcs11ProviderForConfiguration(configuration);
+        assertNotNull(pkcs11Provider);
+    }
+
+
+    @Test
+    public void shouldRetrieveCredentialsFromHSM() throws Exception {
+
+        PKCS11ProviderConfiguration configuration = createPKCS11SoftHSMProviderConfigurationWithCredentials(CRED_ALIAS, CRED_ENV, CRED_PIN, "162624334", CRED_NAME);
+        PKCS11Provider pkcs11Provider = getPkcs11ProviderForConfiguration(configuration);
+        TestKeyPair signingTestKeyPair = new TestKeyPair(PROXY_NODE_SIGNING_CRT, PROXY_NODE_SIGNING_PK_8);
+
+        addPrivateKeyToKeyStore(signingTestKeyPair, CRED_ALIAS, CRED_PIN);
+
+        Credential credential = new PKCS11Credential(
+                signingTestKeyPair.certificate,
+                pkcs11Provider.getProviderNameList(),
+                CRED_ALIAS, CRED_PIN);
+
+        assertNotNull(credential.getPrivateKey());
+    }
+
+    private void addPrivateKeyToKeyStore(TestKeyPair signingTestKeyPair, String alias, String pin) throws KeyStoreException, NoSuchProviderException, IOException, NoSuchAlgorithmException, CertificateException {
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS11", PROVIDER_SUN_PKCS_11 + "-" + alias);
+        keyStore.load((InputStream) null, pin.toCharArray());
+
+        Certificate[] chain = {signingTestKeyPair.certificate};
+
+        keyStore.setKeyEntry(alias, signingTestKeyPair.privateKey, pin.toCharArray(), chain);
+        keyStore.store(null);
+    }
+
+
+    private PKCS11Provider getPkcs11ProviderForConfiguration(PKCS11ProviderConfiguration configuration) throws Exception {
+
+        PKCS11ProviderFactory factory = new PKCS11ProviderFactory(configuration,
+                new PKCS11ProviderInstance() {
+                    @Override
+                    public Provider getProviderInstance(String configString) {
+                        Provider sunPKCS11 = Security.getProvider(PROVIDER_SUN_PKCS_11);
+                        // In Java 9+ in-line config data preceded with "--" (or else treated as file path).
+                        sunPKCS11 = sunPKCS11.configure("--" + configString);
+                        return sunPKCS11;
+                    }
+                });
+        return factory.createInstance();
+    }
+
+    private PKCS11ProviderConfiguration createPKCS11SoftHSMProviderConfigurationWithCredentials(String alias, String environment, String pin, String slot, String name) {
+
+        PKCS11SoftHsmProviderConfiguration configuration
+                = new PKCS11SoftHsmProviderConfiguration();
+        List<SoftHsmCredentialConfiguration> credentials = new ArrayList<>();
+        credentials.add(new SoftHsmCredentialConfiguration(
+                alias,
+                PROXY_NODE_SIGNING_PK_8,
+                PROXY_NODE_SIGNING_CRT));
+        configuration.setPin(pin);
+        configuration.setSlot(slot);
+        configuration.setName(alias);
+        configuration.setCredentialConfigurationList(credentials);
+        configuration.setLibrary(softHSMLibPath);
+        return configuration;
+    }
+
+    private PKCS11ProviderConfiguration createPKCS11SoftHSMProviderConfigurationWithoutCredentials(String slot, String name) {
+
+        PKCS11ProviderConfiguration configuration
+                = new PKCS11SoftHsmProviderConfiguration();
+        configuration.setName(name);
+        configuration.setLibrary(softHSMLibPath);
+        configuration.setSlot(slot);
+        configuration.setSlotListIndexMaxRange(4);
+        return configuration;
+    }
+
+}

--- a/softHSM.baseImage.Dockerfile
+++ b/softHSM.baseImage.Dockerfile
@@ -1,0 +1,23 @@
+#
+#   Runtime base Docker Image containing softHSM and OpenSC.
+#
+#   Used as a base for the Translator component in Test environments needing softHSM.
+#
+ARG baseImage
+
+FROM ${baseImage}
+
+USER root
+
+# Install softHSM and dependencies for OpenSC
+RUN apt-get update && apt-get install -y softhsm pcscd libccid libpcsclite-dev libssl-dev libreadline-dev autoconf automake build-essential docbook-xsl xsltproc libtool pkg-config wget
+
+# Download and build OpenSC
+ENV OPEN_SC_VERSION=0.19.0
+RUN wget https://github.com/OpenSC/OpenSC/releases/download/${OPEN_SC_VERSION}/opensc-${OPEN_SC_VERSION}.tar.gz && \
+    tar xfvz opensc-${OPEN_SC_VERSION}.tar.gz && \
+    cd opensc-${OPEN_SC_VERSION} && \
+    ./bootstrap && ./configure --prefix=/usr --sysconfdir=/etc/opensc && \
+    make && make install && \
+    cd .. && rm -rf opensc* && \
+    rm -rf /var/lib/apt/lists/*

--- a/startup.sh
+++ b/startup.sh
@@ -29,7 +29,8 @@ pushd "${PN_PROJECT_DIR}/pki"
     --idp-sso-url "http://localhost:6200/stub-idp-demo/SAML2/SSO" \
     --proxy-sso-url "http://localhost:6100/SAML2/SSO/POST" \
     --env \
-    "${PKI_OUTPUT_DIR}"
+    "${PKI_OUTPUT_DIR}" \
+    --softhsm
 popd
 
 docker-compose up $@ -d

--- a/translator.softHSM.Dockerfile
+++ b/translator.softHSM.Dockerfile
@@ -1,0 +1,61 @@
+#
+#   Docker Image for Translator Component in Test environments only.
+#   Translator depends on softHSM and OpenSC installations in Test environments.
+#
+FROM gradle:jdk11 AS build
+
+WORKDIR /app
+USER root
+ENV GRADLE_USER_HOME ~/.gradle
+
+COPY build.gradle build.gradle
+COPY settings.gradle settings.gradle
+COPY proxy-node-shared/ proxy-node-shared/
+
+ARG component=proxy-node-gateway
+COPY ${component}/src ${component}/src
+COPY ${component}/build.gradle ${component}/build.gradle
+
+RUN gradle --no-daemon --quiet -p ${component} --parallel install -x test
+ENTRYPOINT ["gradle", "--no-daemon"]
+
+# -------------------- Runtime Image --------------------
+FROM govukverify/soft-hsm
+
+# Copy java app from build to runtime image
+WORKDIR /app
+USER root
+
+ARG component
+COPY --from=build /app/${component}/build/install/${component} /app
+
+# Copy test signing keys
+RUN mkdir /app/keys
+COPY --from=build /app/${component}/src/dist/proxy_node_signing.* /app/keys/
+
+# softHSM Environment Variable assignment from ARGS
+ARG softHSMSigningKeyLabel
+ARG softHSMSigningKeyToken
+ARG softHSMSigningKeySlot
+ARG softHSMSigningKeyId
+ARG softHSMSigningKeyPin
+ARG softHSMSigningKeySoPin
+
+ENV SOFT_HSM_SIGNING_KEY_LABEL=${softHSMSigningKeyLabel}
+ENV SOFT_HSM_SIGNING_KEY_TOKEN=${softHSMSigningKeyToken}
+ENV SOFT_HSM_SIGNING_KEY_SLOT=${softHSMSigningKeySlot}
+ENV SOFT_HSM_SIGNING_KEY_ID=${softHSMSigningKeyId}
+ENV SOFT_HSM_SIGNING_KEY_PIN=${softHSMSigningKeyPin}
+ENV SOFT_HSM_SIGNING_KEY_SO_PIN=${softHSMSigningKeySoPin}
+
+# Init softHSM slot
+RUN softhsm2-util --init-token --slot ${softHSMSigningKeySlot} --so-pin ${softHSMSigningKeySoPin} --pin ${softHSMSigningKeyPin} --label ${softHSMSigningKeyLabel}
+
+# Load signing key to softHSM
+RUN softhsm2-util --import /app/keys/proxy_node_signing.p8 --token ${softHSMSigningKeyToken} --label ${softHSMSigningKeyLabel} --id ${softHSMSigningKeyId} --pin ${softHSMSigningKeyPin}
+RUN rm -rf /app/keys/*
+
+ENV CONFIG_FILE config.yml
+ENV COMPONENT $component
+CMD "bin/$COMPONENT"
+


### PR DESCRIPTION
Install softHSM in the Translator container so that the proxy node signing key can be stored in and retrieved from softHSM in test environments.
Modify startup and pki generation scripts to generate the signing key files in a format that can be loaded into softHSM.
Load the signing private key into softHSM in the Dockerfile after installing softHSM so that it is available for use during testing.
Include swedenconnect/opensaml-pkcs11 in the Translator build script so that the library can be used to access keys in softHSM.  Integration tests provided to prove that softHSM and swedenconnect/opensaml-pkcs11 are installed and usable in the container (built from translator.softHSM.Dockerfile).
The docker-compose files have been modified to use the new translator.softHSM.Dockerfile, and include additional arguments and environment variables used to load the key(s) into softHSM.
The pre-commit.sh script for Proxy Node uses a separate docker-compose file and image to compile and test the code.  This container does not use the individual proxy node component containers to run the tests, meaning that the softHSM installation was missing for pre-commit.  As such a new Dockerfile has been created to build this 'docker-gradle' service (pre-commit.softHSM.Dockerfile) which includes the softHSM installation too.  This means that the softHSM integration tests are still able to run under pre-commit.

In summary, these changes install and test softHSM and swedenconnect/opensaml-pkcs11 in the Translator Docker container, and prove the ability to load our test keys into softHSM.

The use of a key retrieved from softHSM to sign messages in the proxy node is to be implemented in a subsequent task EID-1160.