### PR TITLE
EID-1136: Create TranslatorService

### DIFF
--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -24,8 +24,12 @@ proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_U
 hubUrl: ${HUB_URL}
 connectorNodeUrl: ${CONNECTOR_NODE_URL}
 connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
-translatorUrl: ${TRANSLATOR_URL}
 redisServerUrl: ${REDIS_SERVER_URI}
+
+translatorService:
+  url: ${TRANSLATOR_URL}
+  client:
+    connectionTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
 
 connectorMetadataConfiguration:
   url: ${CONNECTOR_NODE_METADATA_URL}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
@@ -24,7 +24,7 @@ public class GatewayConfiguration extends Configuration {
     @JsonProperty
     @Valid
     @NotNull
-    private URI translatorUrl;
+    private TranslatorServiceConfiguration translatorService;
 
     @JsonProperty
     @Valid
@@ -78,7 +78,8 @@ public class GatewayConfiguration extends Configuration {
 
     @JsonProperty
     @Valid
-    private URI redisServerUrl;
+    @NotNull
+    private String redisServerUrl = "";
 
     public URI getHubUrl() {
         return hubUrl;
@@ -88,7 +89,7 @@ public class GatewayConfiguration extends Configuration {
         return connectorNodeUrl;
     }
 
-    public URI getTranslatorUrl() { return translatorUrl; }
+    public TranslatorServiceConfiguration getTranslatorServiceConfiguration() { return translatorService; }
 
     public String getProxyNodeEntityId() {
         return proxyNodeEntityId;
@@ -130,7 +131,7 @@ public class GatewayConfiguration extends Configuration {
         return proxyNodeAuthnRequestUrl;
     }
 
-    public URI getRedisServerUrl() {
+    public String getRedisServerUrl() {
         return redisServerUrl;
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/TranslatorService.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/TranslatorService.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.notification;
+
+import org.glassfish.jersey.internal.util.Base64;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.notification.exceptions.hubresponse.TranslatorResponseException;
+import uk.gov.ida.notification.exceptions.saml.SamlParsingException;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.saml.SamlObjectMarshaller;
+import uk.gov.ida.notification.saml.SamlParser;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+
+public class TranslatorService {
+    private final Client translatorClient;
+    private final String translatorUrl;
+    private SamlParser samlParser;
+
+    public TranslatorService(
+            Client translatorClient,
+            String translatorUrl,
+            SamlParser samlParser) {
+        this.translatorClient = translatorClient;
+        this.translatorUrl = translatorUrl;
+        this.samlParser = samlParser;
+    }
+
+    public Response getTranslatedResponse(Response encryptedHubResponse) {
+        try {
+            String samlMessage = new SamlObjectMarshaller().transformToString(encryptedHubResponse);
+            Form form = new Form();
+            form.param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString(samlMessage));
+
+            String response = translatorClient.target(translatorUrl)
+                    .request()
+                    .post(Entity.form(form))
+                    .readEntity(String.class);
+
+            return samlParser.parseSamlString(response);
+        } catch (SamlParsingException e) {
+            throw new TranslatorResponseException(e);
+        }
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/TranslatorServiceConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/TranslatorServiceConfiguration.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.notification;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Configuration;
+import io.dropwizard.client.JerseyClientConfiguration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
+
+public class TranslatorServiceConfiguration extends Configuration {
+    @JsonProperty
+    @Valid
+    @NotNull
+    private URI url;
+
+    @JsonProperty
+    @Valid
+    private JerseyClientConfiguration client = new JerseyClientConfiguration();
+
+    public URI getUrl() {
+        return url;
+    }
+
+    public JerseyClientConfiguration getClient() {
+        return client;
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -1,27 +1,13 @@
 package uk.gov.ida.notification.resources;
 
-import io.dropwizard.client.HttpClientBuilder;
-import io.dropwizard.setup.Environment;
 import io.dropwizard.views.View;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.ResponseHandler;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.BasicResponseHandler;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.message.BasicNameValuePair;
-import org.glassfish.jersey.internal.util.Base64;
 import org.opensaml.saml.saml2.core.Response;
 import uk.gov.ida.notification.SamlFormViewBuilder;
+import uk.gov.ida.notification.TranslatorService;
 import uk.gov.ida.notification.exceptions.hubresponse.HubResponseException;
 import uk.gov.ida.notification.exceptions.hubresponse.InvalidHubResponseException;
-import uk.gov.ida.notification.exceptions.hubresponse.TranslatorResponseException;
-import uk.gov.ida.notification.exceptions.saml.SamlParsingException;
-import uk.gov.ida.notification.saml.SamlFormMessageType;
-import uk.gov.ida.notification.saml.SamlObjectMarshaller;
-import uk.gov.ida.notification.saml.SamlParser;
 import uk.gov.ida.notification.saml.HubResponseContainer;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.saml.validation.HubResponseValidator;
 import uk.gov.ida.notification.saml.validation.components.RequestIdWatcher;
 
@@ -30,11 +16,6 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriBuilder;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Logger;
 
 @Path("/SAML2/SSO/Response")
@@ -43,23 +24,20 @@ public class HubResponseResource {
 
     private final SamlFormViewBuilder samlFormViewBuilder;
     private final String connectorNodeUrl;
+    private final TranslatorService translatorService;
     private HubResponseValidator hubResponseValidator;
-    private Environment environment;
-    private String translatorUrl;
-    private final RequestIdWatcher requestIdWatcher;
+    private RequestIdWatcher requestIdWatcher;
 
     public HubResponseResource(
             SamlFormViewBuilder samlFormViewBuilder,
             String connectorNodeUrl,
+            TranslatorService translatorService,
             HubResponseValidator hubResponseValidator,
-            Environment environment,
-            String translatorUrl,
             RequestIdWatcher requestIdWatcher) {
         this.samlFormViewBuilder = samlFormViewBuilder;
         this.connectorNodeUrl = connectorNodeUrl;
+        this.translatorService = translatorService;
         this.hubResponseValidator = hubResponseValidator;
-        this.environment = environment;
-        this.translatorUrl = translatorUrl;
         this.requestIdWatcher = requestIdWatcher;
     }
 
@@ -70,44 +48,29 @@ public class HubResponseResource {
             @FormParam(SamlFormMessageType.SAML_RESPONSE) Response encryptedHubResponse,
             @FormParam("RelayState") String relayState) {
 
-        CloseableHttpResponse translatorResponse = null;
-
-        try (CloseableHttpClient client = new HttpClientBuilder(environment).build("translator")) {
-
+        try {
             hubResponseValidator.validate(encryptedHubResponse);
+
             if (!requestIdWatcher.haveSeenRequestFor(encryptedHubResponse)) {
                 throw new InvalidHubResponseException(
-                    String.format("Received a Response from Hub for an AuthnRequest we have not seen (ID: %s)", encryptedHubResponse.getInResponseTo()));
+                        String.format("Received a Response from Hub for an AuthnRequest we have not seen (ID: %s)", encryptedHubResponse.getInResponseTo()));
             }
 
             HubResponseContainer hubResponseContainer = HubResponseContainer.from(
                     hubResponseValidator.getValidatedResponse(),
                     hubResponseValidator.getValidatedAssertions()
             );
+
             logHubResponse(hubResponseContainer);
+            Response eidasResponse = translatorService.getTranslatedResponse(encryptedHubResponse);
+            logEidasResponse(eidasResponse);
 
-            String samlMessage = new SamlObjectMarshaller().transformToString(encryptedHubResponse);
-
-            HttpPost httpPost = new HttpPost(UriBuilder.fromUri(translatorUrl).build());
-
-            List<NameValuePair> params = new ArrayList<>();
-            params.add(new BasicNameValuePair(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString(samlMessage)));
-            httpPost.setEntity(new UrlEncodedFormEntity(params));
-
-            translatorResponse = client.execute(httpPost);
-
-            ResponseHandler<String> handler = new BasicResponseHandler();
-            String response = handler.handleResponse(translatorResponse);
-
-            Response samlObject = new SamlParser().parseSamlString(response);
-            logEidasResponse(samlObject);
-
-            return samlFormViewBuilder.buildResponse(connectorNodeUrl, samlObject, "Post eIDAS Response SAML to Connector Node", relayState);
-
-        } catch (UnsupportedEncodingException e) {
-            throw new HubResponseException(e, encryptedHubResponse);
-        } catch (SamlParsingException | IOException e) {
-            throw new TranslatorResponseException(e, translatorResponse);
+            return samlFormViewBuilder.buildResponse(
+                connectorNodeUrl,
+                eidasResponse,
+                "Post eIDAS Response SAML to Connector Node",
+                relayState
+            );
         } catch (Throwable e) {
             throw new HubResponseException(e, encryptedHubResponse);
         }
@@ -123,5 +86,4 @@ public class HubResponseResource {
         LOG.info("[eIDAS Response] ID: " + eidasResponse.getID());
         LOG.info("[eIDAS Response] In response to: " + eidasResponse.getInResponseTo());
     }
-
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/TranslatorServiceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/TranslatorServiceTest.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.notification;
+
+import io.dropwizard.testing.junit.DropwizardClientRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.Response;
+import uk.gov.ida.notification.helpers.HubResponseBuilder;
+import uk.gov.ida.notification.saml.EidasResponseBuilder;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.saml.SamlObjectMarshaller;
+import uk.gov.ida.notification.saml.SamlParser;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+public class TranslatorServiceTest extends SamlInitializedTest {
+    @Path("/translate")
+    public static class TestTranslateResource {
+        private final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
+
+        @POST
+        public String testTranslate(@FormParam(SamlFormMessageType.SAML_RESPONSE) String hubResponse) {
+            return marshaller.transformToString(new EidasResponseBuilder().withId("test").build());
+        }
+    }
+
+    @ClassRule
+    public static final DropwizardClientRule clientRule = new DropwizardClientRule(new TestTranslateResource());
+
+    @Test
+    public void shouldReturnTranslatedResponse() throws Exception {
+        Client client = ClientBuilder.newClient();
+        TranslatorService translatorService = new TranslatorService(
+                client,
+                new URL(clientRule.baseUri() + "/translate").toString(),
+                new SamlParser());
+
+        Response hubResponse = new HubResponseBuilder().build();
+        Response eidasResponse = translatorService.getTranslatedResponse(hubResponse);
+
+        assertEquals(eidasResponse.getID(), "test");
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -7,7 +7,7 @@ import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import se.litsec.eidas.opensaml.common.EidasConstants;
-import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
+import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
@@ -20,7 +20,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-public class EidasAuthnRequestAppRuleTests extends ProxyNodeAppRuleTestBase {
+public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
 
     private SamlParser parser;
     private EidasAuthnRequestBuilder request;

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -21,7 +21,7 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
-import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
+import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.helpers.HubAssertionBuilder;
@@ -59,7 +59,7 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_P
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 
-public class HubResponseAppRuleTests extends ProxyNodeAppRuleTestBase {
+public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
     private static final String PROXY_NODE_ENTITY_ID = "http://proxy-node.uk";
     private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----\n";
     private static final String END_CERT = "\n-----END CERTIFICATE-----";

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/MetadataAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/MetadataAppRuleTests.java
@@ -1,13 +1,13 @@
 package uk.gov.ida.notification.apprule;
 
 import org.junit.Test;
-import uk.gov.ida.notification.apprule.base.ProxyNodeAppRuleTestBase;
+import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 
 import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MetadataAppRuleTests extends ProxyNodeAppRuleTestBase {
+public class MetadataAppRuleTests extends GatewayAppRuleTestBase {
     @Test
     public void shouldConsumeMetadata() throws Exception {
         Response response = proxyNodeAppRule.target("healthcheck", proxyNodeAppRule.getAdminPort())

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -11,7 +11,7 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.security.credential.Credential;
 
 import uk.gov.ida.notification.VerifySamlInitializer;
-import uk.gov.ida.notification.apprule.rules.EidasProxyNodeAppRule;
+import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
 import uk.gov.ida.notification.apprule.rules.MetadataClientRule;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
@@ -35,7 +35,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.Response;
 
-public class ProxyNodeAppRuleTestBase {
+public class GatewayAppRuleTestBase {
 
     protected static final String CONNECTOR_NODE_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
 
@@ -66,7 +66,7 @@ public class ProxyNodeAppRuleTestBase {
     protected final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(countrySigningCredential.getPublicKey(), countrySigningCredential.getPrivateKey(), TEST_RP_PUBLIC_SIGNING_CERT);
 
     @Rule
-    public EidasProxyNodeAppRule proxyNodeAppRule = new EidasProxyNodeAppRule(
+    public GatewayAppRule proxyNodeAppRule = new GatewayAppRule(
             ConfigOverride.config("proxyNodeEntityId", "http://proxy-node.uk"),
             ConfigOverride.config("proxyNodeAuthnRequestUrl", "http://proxy-node/SAML2/SSO/POST"),
             ConfigOverride.config("proxyNodeResponseUrl", "http://proxy-node/SAML2/SSO/Response"),
@@ -74,7 +74,7 @@ public class ProxyNodeAppRuleTestBase {
             ConfigOverride.config("hubUrl", "http://hub"),
             ConfigOverride.config("connectorNodeUrl", "http://connector-node:8080"),
             ConfigOverride.config("connectorNodeIssuerId", "http://connector-node:8080/ConnectorMetadata"),
-            ConfigOverride.config("translatorUrl", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response"),
+            ConfigOverride.config("translatorService.url", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response"),
             ConfigOverride.config("connectorMetadataConfiguration.url", metadataClientRule.baseUri() + "/connector-node/metadata"),
             ConfigOverride.config("connectorMetadataConfiguration.expectedEntityId", "http://connector-node:8080/ConnectorResponderMetadata"),
             ConfigOverride.config("connectorMetadataConfiguration.trustStore.type", "file"),

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/GatewayAppRule.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/GatewayAppRule.java
@@ -17,10 +17,10 @@ import java.util.List;
 
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 
-public class EidasProxyNodeAppRule extends DropwizardAppRule<GatewayConfiguration> {
+public class GatewayAppRule extends DropwizardAppRule<GatewayConfiguration> {
     private Client client;
 
-    public EidasProxyNodeAppRule(ConfigOverride... configOverrides) {
+    public GatewayAppRule(ConfigOverride... configOverrides) {
         super(
             GatewayApplication.class,
             resourceFilePath("config.yml"),
@@ -33,6 +33,7 @@ public class EidasProxyNodeAppRule extends DropwizardAppRule<GatewayConfiguratio
         configOverridesList.add(ConfigOverride.config("server.applicationConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
+        configOverridesList.add(ConfigOverride.config("redisServerUrl", ""));
         return configOverridesList.toArray(new ConfigOverride[0]);
     }
 

--- a/proxy-node-gateway/src/test/resources/config.yml
+++ b/proxy-node-gateway/src/test/resources/config.yml
@@ -22,14 +22,20 @@ proxyNodeResponseUrl: ${PROXY_NODE_RESPONSE_ENDPOINT}
 proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
 
 hubUrl: ${HUB_URL}
-
 connectorNodeUrl: ${CONNECTOR_NODE_URL}
 connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
+redisServerUrl: ${REDIS_SERVER_URI}
+
+translatorService:
+  url: ${TRANSLATOR_URL}
+  client:
+    connectionTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
 
 connectorMetadataConfiguration:
   url: ${CONNECTOR_NODE_METADATA_URL}
   expectedEntityId: ${CONNECTOR_NODE_ENTITY_ID}
   jerseyClientName: connector-metadata-client
+  maxRefreshDelay: ${METADATA_REFRESH_DELAY:-600000}
   trustStore:
     type: ${TRUSTSTORE_TYPES:-encoded}
     store: ${CONNECTOR_NODE_METADATA_TRUSTSTORE}
@@ -39,6 +45,7 @@ hubMetadataConfiguration:
   url: ${HUB_METADATA_URL}
   expectedEntityId: ${HUB_ENTITY_ID}
   jerseyClientName: hub-metadata-client
+  maxRefreshDelay: ${METADATA_REFRESH_DELAY:-600000}
   trustStore:
     type: ${TRUSTSTORE_TYPES:-encoded}
     store: ${HUB_METADATA_TRUSTSTORE}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/hubresponse/TranslatorResponseException.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/hubresponse/TranslatorResponseException.java
@@ -1,17 +1,7 @@
 package uk.gov.ida.notification.exceptions.hubresponse;
 
-import org.apache.http.HttpResponse;
-import javax.ws.rs.WebApplicationException;
-
-public class TranslatorResponseException extends WebApplicationException {
-    private final HttpResponse translatorResponse;
-
-    public TranslatorResponseException(Throwable cause, HttpResponse translatorResponse) {
+public class TranslatorResponseException extends RuntimeException {
+    public TranslatorResponseException(Throwable cause) {
         super(cause);
-        this.translatorResponse = translatorResponse;
-    }
-
-    public HttpResponse getTranslatorResponse() {
-        return translatorResponse;
     }
 }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/TranslatorApplication.java
@@ -164,13 +164,14 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     }
 
     private StorageService createStorageService(TranslatorConfiguration configuration) throws ComponentInitializationException {
-        if (configuration.getRedisServerUrl() != null) {
-            RedisClient client = RedisClient.create(RedisURI.create(configuration.getRedisServerUrl()));
-            StatefulRedisConnection<String, String> connection = client.connect();
-            RedisCommands<String, String> syncCommands = connection.sync();
-            return createRedisCacheStorage("translator-cache-storage", syncCommands);
-        } else {
+        if (configuration.getRedisServerUrl().isEmpty()) {
             return createMemoryCacheStorage("translator-cache-storage");
+        } else {
+            RedisCommands<String, String> sync = RedisClient
+                .create(configuration.getRedisServerUrl())
+                .connect()
+                .sync();
+            return createRedisCacheStorage("translator-cache-storage", sync);
         }
     }
 

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/TranslatorConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.ida.notification;
 
 import io.dropwizard.Configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hibernate.validator.constraints.*;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 
@@ -64,7 +63,8 @@ public class TranslatorConfiguration extends Configuration {
 
     @JsonProperty
     @Valid
-    private URI redisServerUrl;
+    @NotNull
+    private String redisServerUrl = "";
 
     public URI getHubUrl() {
         return hubUrl;
@@ -106,7 +106,7 @@ public class TranslatorConfiguration extends Configuration {
         return proxyNodeResponseUrl;
     }
 
-    public URI getRedisServerUrl() {
+    public String getRedisServerUrl() {
         return redisServerUrl;
     }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/rules/TranslatorAppRule.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/rules/TranslatorAppRule.java
@@ -33,6 +33,7 @@ public class TranslatorAppRule extends DropwizardAppRule<TranslatorConfiguration
         configOverridesList.add(ConfigOverride.config("server.applicationConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
+        configOverridesList.add(ConfigOverride.config("redisServerUrl", ""));
         return configOverridesList.toArray(new ConfigOverride[0]);
     }
 

--- a/proxy-node-translator/src/test/resources/config.yml
+++ b/proxy-node-translator/src/test/resources/config.yml
@@ -1,20 +1,20 @@
 server:
   applicationConnectors:
-  - type: http
-    port: ${PORT:-6600}
+    - type: http
+      port: ${PORT:-6660}
   adminConnectors:
-  - type: http
-    port: ${ADMIN_PORT:-6601}
+    - type: http
+      port: ${ADMIN_PORT:-6661}
 
 logging:
   level: INFO
   loggers:
     uk.gov.ida: DEBUG
   appenders:
-  - type: console
-  - type: file
-    currentLogFilename: logs/proxy-node.log
-    archive: false
+    - type: console
+    - type: file
+      currentLogFilename: logs/translator.log
+      archive: false
 
 proxyNodeEntityId: ${PROXY_NODE_ENTITY_ID}
 proxyNodeResponseUrl: ${PROXY_NODE_RESPONSE_ENDPOINT}
@@ -23,6 +23,8 @@ proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_U
 hubUrl: ${HUB_URL}
 connectorNodeUrl: ${CONNECTOR_NODE_URL}
 connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
+
+redisServerUrl: ${REDIS_SERVER_URI}
 
 connectorMetadataConfiguration:
   url: ${CONNECTOR_NODE_METADATA_URL}


### PR DESCRIPTION
The gateway often times out trying to communicate with the translator
due to the really short (500ms) connection timeout setting on the
default `HttpClient`. I've added a `TranslatorServiceConfiguration`
config class that takes the `url` and a `JerseyClientConfiguration` for
the client used to talk to the translator, allowing us to increase the
timeout.

I also pulled the bit that handles communication with the translator out
into its own class `TranslatorService` which is unit-tested in
`TranslatorServiceTest`.

The prod and test configs had drifted out of sync, so I had to update the
`Application`s and `AppRule`s to account for the `redisServerUrl` parameter.