### PR TITLE
EID-1163: Add more timeout options to translator client

### DIFF
--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -31,7 +31,9 @@ replayChecker:
 translatorService:
   url: ${TRANSLATOR_URL}
   client:
+    timeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
     connectionTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
+    connectionRequestTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
 
 connectorMetadataConfiguration:
   url: ${CONNECTOR_NODE_METADATA_URL}


### PR DESCRIPTION
The `connectionTimeout` alone wasn't enough to deal with the slowness
of speaking to the translator when it first starts up.