### PR TITLE
Replace Minikube and use the docker-machine Kubernetes

### DIFF
--- a/shutdown.sh
+++ b/shutdown.sh
@@ -3,5 +3,10 @@ set -ueo pipefail
 
 PN_PROJECT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-minikube stop
-minikube delete
+NODE_NAME=$(kubectl get nodes -o json | jq -r '.items[0].spec.externalID')
+
+kubectl delete deployment --all
+
+kubectl drain $NODE_NAME
+sleep 5
+kubectl uncordon $NODE_NAME


### PR DESCRIPTION
This replaces Minikube with the built in Kubernetes that is included with the desktop version of Docker.

To switch use this config.
```
kubectl config use-context docker-for-desktop
docker-machine create default
docker-machine env default
```