### PR TITLE
BAU: Refactored acceptance tests to work again with the k8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ proxy-node-translator/src/dist/proxy_node_signing.*
 .local_yaml
 .components.yml
 .helm_values.yml
+testreport/

--- a/proxy-node-acceptance-tests/Dockerfile
+++ b/proxy-node-acceptance-tests/Dockerfile
@@ -6,5 +6,6 @@ COPY Gemfile.lock Gemfile.lock
 RUN bundle install
 
 COPY features /features
+COPY wait-for-it.sh /
 
-ENTRYPOINT ["bundle", "exec", "cucumber", "--strict"]
+ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "--strict"]

--- a/proxy-node-acceptance-tests/docker-compose.yml
+++ b/proxy-node-acceptance-tests/docker-compose.yml
@@ -3,8 +3,16 @@ version: '3.4'
 services:
   selenium-hub:
     image: selenium/standalone-firefox
+    container_name: selenium-hub
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4444/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
-  acceptane-tests:
+  acceptance-tests:
     build: .
     depends_on:
       - selenium-hub
+    environment:
+      - STUB_CONNECTOR_URL=${STUB_CONNECTOR_URL}

--- a/proxy-node-acceptance-tests/features/support/env.rb
+++ b/proxy-node-acceptance-tests/features/support/env.rb
@@ -9,18 +9,24 @@ end
 show_browser = ENV['SHOW_BROWSER'] == 'true'
 
 ### Driver config ###
+if ENV['TEST_ENV'] == 'local' || show_browser
 
-if ENV['TEST_ENV'] == 'local' || ENV['SHOW_BROWSER']
-  Capybara.register_driver :firefox_driver do |app|
-    options = ::Selenium::WebDriver::Firefox::Options.new
-    options.args << '--headless' unless show_browser
+  if ENV['BROWSER'] == 'chrome'
+    Capybara.register_driver :selenium do |app|
+      Capybara::Selenium::Driver.new(app, :browser => :chrome)
+    end
+  else
+    Capybara.register_driver :firefox_driver do |app|
+      options = ::Selenium::WebDriver::Firefox::Options.new
+      options.args << '--headless' unless show_browser
 
-    Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+      Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
+    end
+
+    Capybara.javascript_driver = :firefox_driver
   end
-
-  Capybara.javascript_driver = :firefox_driver
 else
-  selenium_hub_url = 'http://selenium-hub:4444/wd/hub'
+  selenium_hub_url = ENV['HUB'] || 'http://selenium-hub:4444/wd/hub'
   Capybara.register_driver :selenium_remote_firefox do |app|
     Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
   end
@@ -30,7 +36,7 @@ end
 
 Capybara.default_driver = Capybara.javascript_driver
 
-### Screenshot config ###
+## Screenshot config ###
 
 ## screenshots saved under test name + date
 Capybara::Screenshot.register_filename_prefix_formatter(:cucumber) do |failing_test|

--- a/proxy-node-acceptance-tests/run-tests-with-docker.sh
+++ b/proxy-node-acceptance-tests/run-tests-with-docker.sh
@@ -4,10 +4,7 @@ set -u
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-docker-compose run \
-               -e TEST_ENV=${TEST_ENV:-"local"} \
-               acceptance-tests -f pretty -f junit -o testreport/ "$@"
-exit_status=$?
+export STUB_CONNECTOR_URL="http://$(minikube ip):31100/Request"
+docker-compose up --abort-on-container-exit
 docker cp $(docker ps -a -q -f name="acceptance-tests"):/testreport .
 docker-compose down
-exit $exit_status

--- a/proxy-node-acceptance-tests/wait-for-it.sh
+++ b/proxy-node-acceptance-tests/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
Refactored the acceptance tests so that will work with the new Kubernetes cluster.

The acceptance test container waits for Selenium hub to be up before starting its tests now (it users the ['wait-for-it.sh'](https://github.com/vishnubob/wait-for-it) script todo that.

I've also enabled it so we can run the tests under Chrome instead of Firefox if needed.