### PR TITLE
EID-1225: Refactor OpenSAML in stub-connector

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/saml/validation/EidasAuthnRequestValidator.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/saml/validation/EidasAuthnRequestValidator.java
@@ -1,4 +1,9 @@
 package uk.gov.ida.notification.saml.validation;
+import uk.gov.ida.notification.saml.validation.components.RequestIssuerValidator;
+import uk.gov.ida.notification.saml.validation.components.RequestedAttributesValidator;
+import uk.gov.ida.notification.saml.validation.components.SpTypeValidator;
+
+import javax.xml.namespace.QName;
 
 import com.google.common.base.Strings;
 import org.opensaml.core.xml.XMLObject;
@@ -14,11 +19,6 @@ import uk.gov.ida.notification.saml.deprecate.SamlValidationException;
 import uk.gov.ida.notification.saml.validation.components.AssertionConsumerServiceValidator;
 import uk.gov.ida.notification.saml.validation.components.ComparisonValidator;
 import uk.gov.ida.notification.saml.validation.components.LoaValidator;
-import uk.gov.ida.notification.saml.validation.components.RequestIssuerValidator;
-import uk.gov.ida.notification.saml.validation.components.RequestedAttributesValidator;
-import uk.gov.ida.notification.saml.validation.components.SpTypeValidator;
-
-import javax.xml.namespace.QName;
 
 public class EidasAuthnRequestValidator {
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -137,7 +137,7 @@ public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
     }
 
     private AuthnRequest getHubAuthnRequestFromHtml(String html) throws IOException {
-        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, "saml-form", SamlFormMessageType.SAML_REQUEST);
+        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, SamlFormMessageType.SAML_REQUEST);
         return parser.parseSamlString(decodedHubAuthnRequest);
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -166,7 +166,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
     private Response extractEidasResponse(Response hubResponse) throws Exception {
         String html = postHubResponseToProxyNode(hubResponse).readEntity(String.class);
-        String decodedEidasResponse = HtmlHelpers.getValueFromForm(html, "saml-form", SamlFormMessageType.SAML_RESPONSE);
+        String decodedEidasResponse = HtmlHelpers.getValueFromForm(html, SamlFormMessageType.SAML_RESPONSE);
         return new SamlParser().parseSamlString(decodedEidasResponse);
     }
 

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/HtmlHelpers.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/HtmlHelpers.java
@@ -11,12 +11,12 @@ import java.io.IOException;
 import java.net.URL;
 
 public class HtmlHelpers {
-    public static String getValueFromForm(String html, String formName, String inputName) throws IOException {
+    public static String getValueFromForm(String html, String inputName) throws IOException {
         StringWebResponse webResponse = new StringWebResponse(html, new URL("http://localhost"));
         try (final WebClient client = new WebClient()) {
             client.getOptions().setJavaScriptEnabled(false);
             HtmlPage page = HTMLParser.parseHtml(webResponse, client.getCurrentWindow());
-            HtmlForm samlForm = page.getFormByName(formName);
+            HtmlForm samlForm = page.getForms().get(0);
             String encodedEidasResponse = samlForm.getInputByName(inputName).getValueAttribute();
             return Base64.decodeAsString(encodedEidasResponse);
         }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestGenerator.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestGenerator.java
@@ -24,12 +24,6 @@ import uk.gov.ida.notification.saml.SamlObjectSigner;
 import java.util.List;
 
 public class EidasAuthnRequestGenerator {
-    private final SamlObjectSigner signer;
-
-    public EidasAuthnRequestGenerator(SamlObjectSigner signer) {
-        this.signer = signer;
-    }
-
     public AuthnRequest generate(
             String requestID,
             String destination,
@@ -97,8 +91,6 @@ public class EidasAuthnRequestGenerator {
         authnContextClassRef.setAuthnContextClassRef(loa.getUri());
         requestedAuthnContext.getAuthnContextClassRefs().add(authnContextClassRef);
         request.setRequestedAuthnContext(requestedAuthnContext);
-
-        signer.sign(request);
 
         return request;
     }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -6,7 +6,6 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
@@ -14,14 +13,16 @@ import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.security.SecurityException;
 import org.opensaml.security.credential.BasicCredential;
-import uk.gov.ida.notification.SamlFormViewBuilder;
+import org.opensaml.security.x509.BasicX509Credential;
+import org.opensaml.security.x509.X509Credential;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import se.litsec.opensaml.utils.X509CertificateUtils;
 import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.exceptions.mappers.AuthnRequestExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.HubResponseExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
 import uk.gov.ida.notification.saml.ResponseAssertionDecrypter;
-import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.saml.converters.AuthnRequestParameterProvider;
 import uk.gov.ida.notification.saml.converters.ResponseParameterProvider;
 import uk.gov.ida.notification.saml.metadata.Metadata;
@@ -31,6 +32,12 @@ import uk.gov.ida.notification.stubconnector.resources.SendAuthnRequestResource;
 import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 public class StubConnectorApplication extends Application<uk.gov.ida.notification.stubconnector.StubConnectorConfiguration> {
     private Metadata proxyNodeMetadata;
@@ -90,9 +97,9 @@ public class StubConnectorApplication extends Application<uk.gov.ida.notificatio
 
     @Override
     public void run(final StubConnectorConfiguration configuration,
-                    final Environment environment) throws
-            ComponentInitializationException {
+                    final Environment environment) throws Exception {
 
+        proxyNodeMetadata = new Metadata(proxyNodeMetadataResolverBundle.getMetadataCredentialResolver());
         proxyNodeMetadata = new Metadata(proxyNodeMetadataResolverBundle.getMetadataCredentialResolver());
 
         ProxyNodeHealthCheck proxyNodeHealthCheck = new ProxyNodeHealthCheck("stub-connector");
@@ -123,28 +130,21 @@ public class StubConnectorApplication extends Application<uk.gov.ida.notificatio
         environment.jersey().register(new AuthnRequestExceptionMapper());
     }
 
-    private void registerResources(StubConnectorConfiguration configuration, Environment environment) {
-        SamlObjectSigner signer = new SamlObjectSigner(
-                configuration.getSigningKeyPair().getPublicKey().getPublicKey(),
-                configuration.getSigningKeyPair().getPrivateKey().getPrivateKey(),
-                configuration.getSigningKeyPair().getPublicKey().getCert()
-        );
-        SamlFormViewBuilder samlFormViewBuilder = new SamlFormViewBuilder();
-        EidasAuthnRequestGenerator authnRequestGenerator = createEidasAuthnRequestGenerator(signer);
+    private void registerResources(StubConnectorConfiguration configuration, Environment environment) throws CertificateException, MarshallingException, SecurityException, SignatureException {
+        EidasAuthnRequestGenerator authnRequestGenerator = new EidasAuthnRequestGenerator();
+
+        PrivateKey signingKey = configuration.getSigningKeyPair().getPrivateKey().getPrivateKey();
+        String signingCertString = configuration.getSigningKeyPair().getPublicKey().getCert();
+        X509Certificate signingCert = X509CertificateUtils.decodeCertificate(new ByteArrayInputStream(signingCertString.getBytes(StandardCharsets.UTF_8)));
+        X509Credential signingCredential = new BasicX509Credential(signingCert, signingKey);
 
         environment.jersey().register(new SendAuthnRequestResource(
-                configuration,
-                proxyNodeMetadata,
-                authnRequestGenerator,
-                samlFormViewBuilder));
+            configuration,
+            proxyNodeMetadata,
+            authnRequestGenerator,
+            signingCredential));
 
-        try {
-            environment.jersey().register(new MetadataResource(
-                    configuration,
-                    signer));
-        } catch (MarshallingException | SecurityException e) {
-            e.printStackTrace();
-        }
+        environment.jersey().register(new MetadataResource(configuration, signingCredential));
 
         environment.jersey().register(
                 new ReceiveResponseResource(
@@ -171,9 +171,5 @@ public class StubConnectorApplication extends Application<uk.gov.ida.notificatio
             configuration.getPrivateKey().getPrivateKey()
         );
         return new ResponseAssertionDecrypter(decryptionCredential);
-    }
-
-    private EidasAuthnRequestGenerator createEidasAuthnRequestGenerator(SamlObjectSigner signer) {
-        return new EidasAuthnRequestGenerator(signer);
     }
 }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -1,20 +1,36 @@
 package uk.gov.ida.notification.stubconnector.resources;
 
 import io.dropwizard.jersey.sessions.Session;
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import net.shibboleth.utilities.java.support.velocity.VelocityEngine;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.messaging.encoder.MessageEncodingException;
+import org.opensaml.messaging.handler.MessageHandlerException;
+import org.opensaml.saml.common.binding.security.impl.SAMLOutboundProtocolMessageSigningHandler;
+import org.opensaml.saml.common.messaging.context.SAMLEndpointContext;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.saml2.binding.encoding.impl.HTTPPostEncoder;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.security.x509.X509Credential;
+import org.opensaml.xmlsec.SignatureSigningParameters;
+import org.opensaml.xmlsec.context.SecurityParametersContext;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import se.litsec.eidas.opensaml.common.EidasLoaEnum;
 import se.litsec.eidas.opensaml.ext.SPTypeEnumeration;
 import se.litsec.eidas.opensaml.ext.attributes.AttributeConstants;
-import uk.gov.ida.notification.SamlFormViewBuilder;
 import uk.gov.ida.notification.saml.metadata.Metadata;
 import uk.gov.ida.notification.stubconnector.EidasAuthnRequestGenerator;
 import uk.gov.ida.notification.stubconnector.StubConnectorConfiguration;
-import uk.gov.ida.notification.views.SamlFormView;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -24,20 +40,23 @@ public class SendAuthnRequestResource {
     private final StubConnectorConfiguration configuration;
     private final Metadata proxyNodeMetadata;
     private final EidasAuthnRequestGenerator authnRequestGenerator;
-    private final SamlFormViewBuilder samlFormViewBuilder;
+    private final X509Credential signingCredential;
 
-    public SendAuthnRequestResource(StubConnectorConfiguration configuration, Metadata proxyNodeMetadata, EidasAuthnRequestGenerator authnRequestGenerator, SamlFormViewBuilder samlFormViewBuilder) {
+    public SendAuthnRequestResource(StubConnectorConfiguration configuration, Metadata proxyNodeMetadata, EidasAuthnRequestGenerator authnRequestGenerator, X509Credential signingCredential) {
         this.configuration = configuration;
         this.proxyNodeMetadata = proxyNodeMetadata;
         this.authnRequestGenerator = authnRequestGenerator;
-        this.samlFormViewBuilder = samlFormViewBuilder;
+        this.signingCredential = signingCredential;
     }
 
     @GET
-    public SamlFormView setupAuthnRequest(@Session HttpSession session) throws ResolverException {
+    public Response setupAuthnRequest(
+        @Session HttpSession session,
+        @Context HttpServletResponse httpServletResponse
+    ) throws ResolverException, ComponentInitializationException, MessageHandlerException, MessageEncodingException {
         String proxyNodeEntityId = configuration.getProxyNodeMetadataConfiguration().getExpectedEntityId();
-        String ssoUrl = proxyNodeMetadata.getSsoUrl(proxyNodeEntityId);
         String connectorEntityId = configuration.getConnectorNodeBaseUrl() + "/Metadata";
+        Endpoint proxyNodeEndpoint = proxyNodeMetadata.getEndpoint(proxyNodeEntityId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         List<String> requestedAttributes = Arrays.asList(
                 AttributeConstants.EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME,
@@ -52,13 +71,40 @@ public class SendAuthnRequestResource {
 
         AuthnRequest authnRequest = authnRequestGenerator.generate(
                 authnRequestId,
-                ssoUrl,
+                proxyNodeEndpoint.getLocation(),
                 connectorEntityId,
                 SPTypeEnumeration.PUBLIC,
                 requestedAttributes,
                 EidasLoaEnum.LOA_SUBSTANTIAL
         );
 
-        return samlFormViewBuilder.buildRequest(ssoUrl, authnRequest, "Submit to Proxy Node", "relay");
+        SignatureSigningParameters signatureSigningParameters = new SignatureSigningParameters();
+        signatureSigningParameters.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
+        signatureSigningParameters.setSignatureCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+        signatureSigningParameters.setSigningCredential(signingCredential);
+
+        MessageContext context = new MessageContext() {{
+            setMessage(authnRequest);
+
+            getSubcontext(SAMLPeerEntityContext.class, true)
+                .getSubcontext(SAMLEndpointContext.class, true)
+                    .setEndpoint(proxyNodeEndpoint);
+
+            getSubcontext(SecurityParametersContext.class, true)
+                .setSignatureSigningParameters(signatureSigningParameters);
+        }};
+
+        SAMLOutboundProtocolMessageSigningHandler signingHandler = new SAMLOutboundProtocolMessageSigningHandler();
+        signingHandler.initialize();
+        signingHandler.invoke(context);
+
+        HTTPPostEncoder encoder = new HTTPPostEncoder();
+        encoder.setMessageContext(context);
+        encoder.setHttpServletResponse(httpServletResponse);
+        encoder.setVelocityEngine(VelocityEngine.newVelocityEngine());
+        encoder.initialize();
+        encoder.encode();
+
+        return Response.ok().build();
     }
 }

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -66,7 +66,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
 
     private String getAuthnRequestIdFromSession() throws URISyntaxException, IOException, ParserConfigurationException {
         String html = getEidasRequest();
-        String decodedSaml = HtmlHelpers.getValueFromForm(html, "saml-form", "SAMLRequest");
+        String decodedSaml = HtmlHelpers.getValueFromForm(html, "SAMLRequest");
         AuthnRequest request = new SamlParser().parseSamlString(decodedSaml);
         return request.getID();
     }


### PR DESCRIPTION
This is a PR to demonstrate using OpenSAML 3 components.

In `SendAuthnRequestResource`, use `MessageContext`,
`MessageHandler` and `HTTPPostEncoder` to sign `AuthnRequest`
and generate SAML form.

Use `SignatureUtils` from litsec's opensaml-ext instead of
`SamlObjectSigner`.