### PR TITLE
EID-1255 - Remove validation to check expected recipient id

### DIFF
--- a/pki/Gemfile.lock
+++ b/pki/Gemfile.lock
@@ -17,18 +17,18 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
+    addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    concurrent-ruby (1.1.3)
-    i18n (1.1.1)
+    concurrent-ruby (1.1.4)
+    i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     keystores (0.4.0)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
-    nokogiri (1.8.2)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     public_suffix (3.0.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -43,4 +43,4 @@ DEPENDENCIES
   verify-metadata-generator!
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/AssertionSubjectConfirmationValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/AssertionSubjectConfirmationValidator.java
@@ -4,12 +4,12 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
 public class AssertionSubjectConfirmationValidator extends BasicAssertionSubjectConfirmationValidator {
 
     public void validate(
             SubjectConfirmation subjectConfirmation,
-            String requestId,
-            String expectedRecipientId) {
+            String requestId) {
 
         super.validate(subjectConfirmation);
 
@@ -17,10 +17,6 @@ public class AssertionSubjectConfirmationValidator extends BasicAssertionSubject
 
         if (!subjectConfirmationData.getInResponseTo().equals(requestId)) {
             SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.notMatchInResponseTo(subjectConfirmationData.getInResponseTo(), requestId);
-            throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
-        }
-        if (!subjectConfirmationData.getRecipient().equals(expectedRecipientId)) {
-            SamlValidationSpecificationFailure failure = SamlTransformationErrorFactory.incorrectRecipientFormat(subjectConfirmationData.getRecipient(), expectedRecipientId);
             throw new SamlTransformationErrorException(failure.getErrorMessage(), failure.getLogLevel());
         }
     }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/BasicAssertionSubjectConfirmationValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/BasicAssertionSubjectConfirmationValidator.java
@@ -5,6 +5,7 @@ import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
 import uk.gov.ida.saml.core.validation.SamlValidationSpecificationFailure;
+
 public class BasicAssertionSubjectConfirmationValidator {
 
     public void validate(SubjectConfirmation subjectConfirmation) {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/IdentityProviderAssertionValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/IdentityProviderAssertionValidator.java
@@ -70,17 +70,16 @@ public class IdentityProviderAssertionValidator extends AssertionValidator {
 
         ensurePresenceOfBearerSubjectConfirmation(assertion);
 
-        validateAllBearerSubjectConfirmations(assertion, requestId, expectedRecipientId);
+        validateAllBearerSubjectConfirmations(assertion, requestId);
     }
 
     private void validateAllBearerSubjectConfirmations(
             Assertion assertion,
-            String requestId,
-            String expectedRecipientId) {
+            String requestId) {
 
         for (SubjectConfirmation subjectConfirmation : assertion.getSubject().getSubjectConfirmations()) {
             if (SubjectConfirmation.METHOD_BEARER.equals(subjectConfirmation.getMethod())) {
-                subjectConfirmationValidator.validate(subjectConfirmation, requestId, expectedRecipientId);
+                subjectConfirmationValidator.validate(subjectConfirmation, requestId);
             }
         }
     }


### PR DESCRIPTION
- Update bundle in pki
- Remove validation to check the expected recipient id of the subject. The recipient
of the subject is set for the hub by the idp and doesn't change in the hub so when it
reaches the proxy node, the recipient id of the subject is still the hub. Therefore
this validation will fail when connected to the Hub.
- This is the same behaviour as the MSA.