### PR TITLE
EID-1257 proxy node to validate hub response with hub signing cert

### DIFF
--- a/pki/generate
+++ b/pki/generate
@@ -99,18 +99,18 @@ stub_connector_signing_keypair = sub_keypair(root_keypair, 'Stub Connector Signi
 # Stub Connector Encryption
 stub_connector_encryption_keypair = sub_keypair(root_keypair, 'Stub Connector Encryption', USAGE_ENCRYPTION)
 
-# Generate Hub Metadata
-hub_config = {
+# Generate Hub Metadata for Proxy Node
+hub_config_for_proxy_node = {
   'id' => 'VERIFY-HUB',
-  'entity_id' => options.hub_entity_id,
+  'entity_id' => options.idp_entity_id,
   'assertion_consumer_service_uri' => "#{options.proxy_url}/SAML2/SSO/Response/POST",
   'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'http://dev-hub.local' },
   'signing_certificates' => [
-    { 'name' => 'hub_signing', 'x509' => strip_pem(hub_signing_keypair.cert.to_pem) }
+    { 'name' => 'hub_signing', 'x509' => strip_pem(idp_signing_keypair.cert.to_pem) }
   ],
   'encryption_certificate' => { 'name' => 'hub_encryption', 'x509' => strip_pem(hub_encryption_keypair.cert.to_pem) }
 }
-stub_idp_config = {
+stub_idp_config_for_proxy_node = {
   'id' => 'stub-idp-demo',
   'entity_id' => options.idp_entity_id,
   'sso_uri' => "#{options.idp_url}/SAML2/SSO",
@@ -120,8 +120,33 @@ stub_idp_config = {
   ],
   'enabled' => true
 }
-hub_metadata_xml = generate_hub_metadata(hub_config, [stub_idp_config], root_keypair.cert)
-hub_metadata_xml_signed = sign_metadata(hub_metadata_xml, hub_meta_keypair, options.xmlsectool_path)
+hub_metadata_for_proxy_node_xml = generate_hub_metadata(hub_config_for_proxy_node, [stub_idp_config_for_proxy_node], root_keypair.cert)
+hub_metadata_for_proxy_node_xml_signed = sign_metadata(hub_metadata_for_proxy_node_xml, hub_meta_keypair, options.xmlsectool_path)
+
+# Generate Hub Metadata for Stub IDP
+hub_config_for_idp = {
+    'id' => 'VERIFY-HUB',
+    'entity_id' => options.hub_entity_id,
+    'assertion_consumer_service_uri' => "#{options.proxy_url}/SAML2/SSO/Response/POST",
+    'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'http://dev-hub.local' },
+    'signing_certificates' => [
+        { 'name' => 'hub_signing', 'x509' => strip_pem(hub_signing_keypair.cert.to_pem) }
+    ],
+    'encryption_certificate' => { 'name' => 'hub_encryption', 'x509' => strip_pem(hub_encryption_keypair.cert.to_pem) }
+}
+
+stub_idp_config = {
+    'id' => 'stub-idp-demo',
+    'entity_id' => options.hub_entity_id,
+    'sso_uri' => "#{options.idp_url}/SAML2/SSO",
+    'organization' => { 'name' => 'stub-idp-demo', 'display_name' => 'Stub IDP', 'url' => options.idp_url },
+    'signing_certificates' => [
+        { 'x509' => strip_pem(hub_signing_keypair.cert.to_pem) }
+    ],
+    'enabled' => true
+}
+hub_metadata_for_stub_idp_xml = generate_hub_metadata(hub_config_for_idp, [stub_idp_config], root_keypair.cert)
+hub_metadata_for_stub_idp_xml_signed = sign_metadata(hub_metadata_for_stub_idp_xml, hub_meta_keypair, options.xmlsectool_path)
 
 # Generate Proxy Node Metadata
 proxy_node_config = {
@@ -142,7 +167,8 @@ Dir.mkdir(output_dir) unless Dir.exist?(output_dir)
 Dir.chdir(output_dir) do
   create_truststore('ida_metadata_truststore.ts', options.truststore_pass, {'root_ca' => root_keypair.cert})
 
-  create_file('metadata_for_hub.xml', hub_metadata_xml_signed)
+  create_file('hub_metadata_for_proxy_node.xml', hub_metadata_for_proxy_node_xml_signed)
+  create_file('hub_metadata_for_idp.xml', hub_metadata_for_stub_idp_xml_signed)
   create_file('metadata_for_connector_node.xml', proxy_node_metadata_xml_signed)
 
   metadata_truststore = File.open('ida_metadata_truststore.ts', 'rb').read
@@ -258,7 +284,8 @@ Dir.chdir(output_dir) do
     configmap = YAML.load_file(CONFIGMAP).tap do |cfg|
       cfg['metadata']['name'] = 'saml-metadata'
       cfg['data'] = {}
-      cfg['data']['metadata_for_hub.xml'] = hub_metadata_xml_signed
+      cfg['data']['hub_metadata_for_proxy_node.xml'] = hub_metadata_for_proxy_node_xml_signed
+      cfg['data']['hub_metadata_for_idp.xml'] = hub_metadata_for_stub_idp_xml_signed
       cfg['data']['metadata_for_connector_node.xml'] = proxy_node_metadata_xml_signed
     end
     create_file('metadata-configmap.yaml', YAML.dump(configmap))

--- a/proxy-node-chart/charts/proxy-node-gateway/templates/gateway-deployment.yaml
+++ b/proxy-node-chart/charts/proxy-node-gateway/templates/gateway-deployment.yaml
@@ -101,7 +101,7 @@ spec:
               name: proxy-node-pki
               key: HUB_METADATA_TRUSTSTORE_PASSWORD
         - name: HUB_METADATA_URL
-          value: http://{{ .Release.Name }}-stub-metadata/metadata_for_hub.xml
+          value: http://{{ .Release.Name }}-stub-metadata/hub_metadata_for_proxy_node.xml
         - name: HUB_URL
           valueFrom:
             configMapKeyRef:

--- a/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
+++ b/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
@@ -114,7 +114,7 @@ spec:
               name: proxy-node-pki 
               key: HUB_METADATA_TRUSTSTORE_PASSWORD
         - name: HUB_METADATA_URL
-          value: http://{{ .Release.Name }}-stub-metadata/metadata_for_hub.xml
+          value: http://{{ .Release.Name }}-stub-metadata/hub_metadata_for_proxy_node.xml
         - name: HUB_URL
           value: http://localhost:6200/stub-idp-demo/SAML2/SSO
         - name: PORT

--- a/proxy-node-chart/charts/stub-connector/templates/stub-idp-deployment.yaml
+++ b/proxy-node-chart/charts/stub-connector/templates/stub-idp-deployment.yaml
@@ -69,7 +69,7 @@ spec:
               name: stub-idp-pki 
               key: METADATA_TRUSTSTORE_PASSWORD
         - name: METADATA_URL
-          value: http://{{ .Release.Name }}-stub-metadata/metadata_for_hub.xml
+          value: http://{{ .Release.Name }}-stub-metadata/hub_metadata_for_idp.xml
         - name: PORT
           value: "80"
         - name: STUB_COUNTRY_SIGNING_CERT

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -15,7 +15,11 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.w3c.dom.Element;
 import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
-import uk.gov.ida.notification.helpers.*;
+import uk.gov.ida.notification.helpers.BasicCredentialBuilder;
+import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
+import uk.gov.ida.notification.helpers.HtmlHelpers;
+import uk.gov.ida.notification.helpers.HubAssertionBuilder;
+import uk.gov.ida.notification.helpers.HubResponseBuilder;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
 import uk.gov.ida.notification.saml.ResponseAssertionDecrypter;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
@@ -32,9 +36,18 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.Assert.*;
-import static org.opensaml.saml.saml2.core.StatusCode.*;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.opensaml.saml.saml2.core.StatusCode.AUTHN_FAILED;
+import static org.opensaml.saml.saml2.core.StatusCode.NO_AUTHN_CONTEXT;
+import static org.opensaml.saml.saml2.core.StatusCode.REQUESTER;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_PRIMARY_PRIVATE_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 
 public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
     private static final String PROXY_NODE_ENTITY_ID = "http://proxy-node.uk";

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidator.java
@@ -3,6 +3,7 @@ package uk.gov.ida.notification.saml.deprecate;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.saml.security.AssertionDecrypter;
 import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
 import uk.gov.ida.saml.security.validators.ValidatedAssertions;
@@ -47,7 +48,7 @@ public class IdpResponseValidator {
         responseFromIdpValidator.validate(response);
         responseDestinationValidator.validate(response.getDestination());
 
-        validatedResponse = samlResponseSignatureValidator.validate(response, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+        validatedResponse = samlResponseSignatureValidator.validate(response, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         List<Assertion> decryptedAssertions = assertionDecrypter.decryptAssertions(validatedResponse);
         validatedAssertions = samlAssertionsSignatureValidator.validate(decryptedAssertions, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidatorTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidatorTest.java
@@ -49,5 +49,4 @@ public class IdpResponseValidatorTest {
         responseValidator.validate(response);
         verify(samlResponseSignatureValidator).validate(response, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
     }
-
 }

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidatorTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/deprecate/IdpResponseValidatorTest.java
@@ -1,0 +1,53 @@
+package uk.gov.ida.notification.saml.deprecate;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.saml.security.AssertionDecrypter;
+import uk.gov.ida.saml.security.SamlAssertionsSignatureValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlResponseSignatureValidator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IdpResponseValidatorTest {
+
+    private IdpResponseValidator responseValidator;
+
+    @Mock
+    private SamlResponseSignatureValidator samlResponseSignatureValidator;
+    @Mock
+    private AssertionDecrypter assertionDecrypter;
+    @Mock
+    private SamlAssertionsSignatureValidator samlAssertionsSignatureValidator;
+    @Mock
+    private EncryptedResponseFromIdpValidator responseFromIdpValidator;
+    @Mock
+    private DestinationValidator responseDestinationValidator;
+    @Mock
+    private ResponseAssertionsFromIdpValidator responseAssertionsFromIdpValidator;
+
+    @Before
+    public void setUp() {
+        responseValidator = new IdpResponseValidator(
+                samlResponseSignatureValidator,
+                assertionDecrypter,
+                samlAssertionsSignatureValidator,
+                responseFromIdpValidator,
+                responseDestinationValidator,
+                responseAssertionsFromIdpValidator);
+    }
+
+    @Test
+    public void testThatSamlResponseSignatureValidatorUsesSPSSODescriptorRoleForValidation() {
+        Response response = mock(Response.class);
+        responseValidator.validate(response);
+        verify(samlResponseSignatureValidator).validate(response, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
+    }
+
+}

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/BasicCredentialBuilder.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/BasicCredentialBuilder.java
@@ -1,0 +1,54 @@
+package uk.gov.ida.notification.helpers;
+
+import org.bouncycastle.util.Strings;
+import org.glassfish.jersey.internal.util.Base64;
+import org.opensaml.security.credential.BasicCredential;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
+
+public class BasicCredentialBuilder {
+
+    private static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----\n";
+    private static final String END_CERT = "\n-----END CERTIFICATE-----";
+
+    private String publicSigningCert;
+    private String privateSigningKey;
+
+    private BasicCredentialBuilder() {
+    }
+
+    public static BasicCredentialBuilder instance() {
+        return new BasicCredentialBuilder();
+    }
+
+    // String publicSigningCert, String privateSigningKey
+    public BasicCredentialBuilder withPublicSigningCert(String publicSigningCert) {
+
+        this.publicSigningCert = publicSigningCert;
+        return this;
+    }
+
+    public BasicCredentialBuilder withPrivateSigningKey(String privateSigningKey) {
+        this.privateSigningKey = privateSigningKey;
+        return this;
+    }
+
+    public BasicCredential build() throws Exception {
+        String publicCert = BEGIN_CERT + publicSigningCert + END_CERT;
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(publicCert.getBytes(StandardCharsets.UTF_8));
+        X509Certificate x509certificate = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(byteArrayInputStream);
+
+        PublicKey publicKey = x509certificate.getPublicKey();
+        PrivateKey privateKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(Base64.decode(Strings.toByteArray(privateSigningKey))));
+
+        return new BasicCredential(publicKey, privateKey);
+    }
+
+}

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/BasicCredentialBuilder.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/BasicCredentialBuilder.java
@@ -28,9 +28,7 @@ public class BasicCredentialBuilder {
         return new BasicCredentialBuilder();
     }
 
-    // String publicSigningCert, String privateSigningKey
     public BasicCredentialBuilder withPublicSigningCert(String publicSigningCert) {
-
         this.publicSigningCert = publicSigningCert;
         return this;
     }
@@ -44,10 +42,8 @@ public class BasicCredentialBuilder {
         String publicCert = BEGIN_CERT + publicSigningCert + END_CERT;
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(publicCert.getBytes(StandardCharsets.UTF_8));
         X509Certificate x509certificate = (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(byteArrayInputStream);
-
         PublicKey publicKey = x509certificate.getPublicKey();
         PrivateKey privateKey = KeyFactory.getInstance("RSA").generatePrivate(new PKCS8EncodedKeySpec(Base64.decode(Strings.toByteArray(privateSigningKey))));
-
         return new BasicCredential(publicKey, privateKey);
     }
 


### PR DESCRIPTION
Proxy Node must validate the Hub SAML response using the Hub signing cert published in Hub metadata.

Presently, the current stubbed connector and IDP journey kicked off by ./startup.sh signs the response to Proxy Node with a stub **IDP** signing cert. There is no Hub in this federation.

When the Proxy Node verifies the signature of the SAML response from Hub,
it looks up the Hub signing cert in metadata published by the Hub. This lookup filters the entries by entity id and *role* QName.

In the BAU Verify Hub this cert is found using the **SPSSODescriptor** QName role. However in the stubbed federation, which has no Hub, and stubbed Hub metadata, the role for this cert is published as IDPSSODescriptor.

This PR updates the filter used for finding the Hub signing cert in Hub metadata, to use the SPSSODescriptor
(see IdpResponseValidator).

Additionally, when generating PKI, the stubbed Hub metadata hub_metadata.xml is removed, replacing with `hub_metadata_for_proxy_node.xml` and `hub_metadata_for_idp.xml` which have valid certs for the stubbed journey.
(see generate ruby script, and helm charts).

The PKI setup for Integration testing is also updated.