### PR TITLE
bau - Set expiry of connector metadata to a year

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/MetadataResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/MetadataResource.java
@@ -64,7 +64,7 @@ public class MetadataResource {
 
         EntityDescriptor entityDescriptor = SamlBuilder.build(EntityDescriptor.DEFAULT_ELEMENT_NAME);
         entityDescriptor.setEntityID(connectorConfiguration.getConnectorNodeBaseUrl() + "/Metadata");
-        entityDescriptor.setValidUntil(DateTime.now().plusDays(1));
+        entityDescriptor.setValidUntil(DateTime.now().plusDays(365));
         entityDescriptor.getRoleDescriptors().add(spSsoDescriptor);
 
         SignatureUtils.sign(entityDescriptor, signingCredential);


### PR DESCRIPTION
- This will mean that whilst we use the stub in staging, we don't need to
respin it each day.