### PR TITLE
EID-1274: destination of the authn request must be set in stub connector

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactory.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactory.java
@@ -63,6 +63,7 @@ public class EidasAuthnRequestContextFactory {
         issuer.setFormat(NameIDType.ENTITY);
         issuer.setValue(connectorEntityId);
         request.setIssuer(issuer);
+        request.setDestination(destinationEndpoint.getLocation());
 
         Extensions extensions = SamlBuilder.build(Extensions.DEFAULT_ELEMENT_NAME);
 

--- a/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.notification.stubconnector;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.opensaml.security.credential.Credential;
+import se.litsec.eidas.opensaml.common.EidasLoaEnum;
+import se.litsec.eidas.opensaml.ext.SPTypeEnumeration;
+import uk.gov.ida.notification.VerifySamlInitializer;
+
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EidasAuthnRequestContextFactoryTest {
+
+    private EidasAuthnRequestContextFactory factory;
+
+    @BeforeClass
+    public static void classSetup() throws Throwable {
+        InitializationService.initialize();
+        VerifySamlInitializer.init();
+    }
+
+    @Before
+    public void setUp() {
+        factory = new EidasAuthnRequestContextFactory();
+    }
+
+    @Test
+    public void testThatEidasAuthnRequestSetsARequestDestination() {
+        Credential signingCredential = mock(Credential.class);
+        Endpoint destinationEndpoint = mock(Endpoint.class);
+        when(destinationEndpoint.getLocation()).thenReturn("a location");
+        try {
+            factory.generate(
+                    destinationEndpoint,
+                    "a connecter entity id",
+                    SPTypeEnumeration.PUBLIC,
+                    new ArrayList<String>(),
+                    EidasLoaEnum.LOA_SUBSTANTIAL,
+                    signingCredential);
+        } catch (Exception e) {
+            // expected
+        }
+        verify(destinationEndpoint).getLocation();
+    }
+}


### PR DESCRIPTION
EID-1274: To avoid error in PN gateway: "Bad Authn Request from Connector Node: SAML Validation Specification: Destination should not be absent", the destination of the request must be set in stub connector.

Note that call to `destinationEndpoint.getLocation()` is null-safe when traced back to creator of `destinationEndpoint`.