### PR TITLE
Use `Secrets` not `ConfigMaps`

### DIFF
--- a/generate-secrets.sh
+++ b/generate-secrets.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${DOMAIN:?}"
+: "${RELEASE:?}"
+
+PN_PROJECT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+PKI_DIR=".${DOMAIN}_${RELEASE}_pki"
+PKI_OUTPUT_DIR="${PN_PROJECT_DIR}/${PKI_DIR}"
+
+function generate_pki {
+  pushd "${PN_PROJECT_DIR}/pki"
+    rm -f "${PKI_OUTPUT_DIR}/*"
+    bundle install --quiet
+    bundle exec generate \
+      --hub-entity-id "https://dev-hub.local" \
+      --idp-entity-id "http://stub_idp.acme.org/stub-idp-demo/SSO/POST" \
+      --proxy-node-entity-id "http://proxy-node" \
+      --connector-url "https://${RELEASE}-stub-connector.${DOMAIN}" \
+      --proxy-url "https://${RELEASE}-gateway.${DOMAIN}" \
+      --idp-url "https://${RELEASE}-stub-idp.${DOMAIN}" \
+      --softhsm \
+      --secrets \
+      "${PKI_OUTPUT_DIR}"
+  popd
+}
+
+# Generate PKI if directory is missing
+test -d "${PKI_OUTPUT_DIR}" || {
+  echo "Generating PKI: No PKI directory"
+  generate_pki
+}

--- a/pki/configmap.yaml
+++ b/pki/configmap.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: default

--- a/pki/generate
+++ b/pki/generate
@@ -262,28 +262,28 @@ Dir.chdir(output_dir) do
   if options.do_secrets
     secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'proxy-node-pki'
-      cfg['data'] = proxy_node_vars
+      cfg['data'] = proxy_node_vars.inject({}) { |vars, (key, value)| vars[key] = b64(value); vars }
     end
     create_file('proxy-node-secret.yaml', YAML.dump(secret))
 
     secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'stub-connector-pki'
-      cfg['data'] = stub_connector_vars
+      cfg['data'] = stub_connector_vars.inject({}) { |vars, (key, value)| vars[key] = b64(value); vars }
     end
     create_file('stub-connector-secret.yaml', YAML.dump(secret))
 
     secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'stub-idp-pki'
-      cfg['data'] = stub_idp_vars
+      cfg['data'] = stub_idp_vars.inject({}) { |vars, (key, value)| vars[key] = b64(value); vars }
     end
     create_file('stub-idp-secret.yaml', YAML.dump(secret))
 
     secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'saml-metadata'
       cfg['data'] = {}
-      cfg['data']['hub_metadata_for_proxy_node.xml'] = hub_metadata_for_proxy_node_xml_signed
-      cfg['data']['hub_metadata_for_idp.xml'] = hub_metadata_for_stub_idp_xml_signed
-      cfg['data']['metadata_for_connector_node.xml'] = proxy_node_metadata_xml_signed
+      cfg['data']['hub_metadata_for_proxy_node.xml'] = b64(hub_metadata_for_proxy_node_xml_signed)
+      cfg['data']['hub_metadata_for_idp.xml'] = b64(hub_metadata_for_stub_idp_xml_signed)
+      cfg['data']['metadata_for_connector_node.xml'] = b64(proxy_node_metadata_xml_signed)
     end
     create_file('metadata-secret.yaml', YAML.dump(secret))
   end

--- a/pki/generate
+++ b/pki/generate
@@ -17,7 +17,7 @@ output_dir = ARGV.pop || abort(USAGE)
 SCRIPT_DIR = File.expand_path(File.dirname(__FILE__))
 PROXY_NODE_MANIFEST = File.join(SCRIPT_DIR, 'proxy_node_manifest.yml')
 STUB_IDP_MANIFEST = File.join(SCRIPT_DIR, 'stub_idp_manifest.yml')
-CONFIGMAP = File.join(SCRIPT_DIR, 'configmap.yaml')
+SECRET = File.join(SCRIPT_DIR, 'secret.yaml')
 
 puts <<-EOS
 🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺  🇪🇺🇪🇺    🇪🇺🇪🇺 🇪🇺🇪🇺🇪🇺🇪🇺     🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺    🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺🇪🇺  
@@ -259,33 +259,33 @@ Dir.chdir(output_dir) do
     create_file('stub_idp.manifest.yml', YAML.dump(stub_idp_manifest))
   end
 
-  if options.do_configmaps
-    configmap = YAML.load_file(CONFIGMAP).tap do |cfg|
+  if options.do_secrets
+    secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'proxy-node-pki'
       cfg['data'] = proxy_node_vars
     end
-    create_file('proxy-node-configmap.yaml', YAML.dump(configmap))
+    create_file('proxy-node-secret.yaml', YAML.dump(secret))
 
-    configmap = YAML.load_file(CONFIGMAP).tap do |cfg|
+    secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'stub-connector-pki'
       cfg['data'] = stub_connector_vars
     end
-    create_file('stub-connector-configmap.yaml', YAML.dump(configmap))
+    create_file('stub-connector-secret.yaml', YAML.dump(secret))
 
-    configmap = YAML.load_file(CONFIGMAP).tap do |cfg|
+    secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'stub-idp-pki'
       cfg['data'] = stub_idp_vars
     end
-    create_file('stub-idp-configmap.yaml', YAML.dump(configmap))
+    create_file('stub-idp-secret.yaml', YAML.dump(secret))
 
-    configmap = YAML.load_file(CONFIGMAP).tap do |cfg|
+    secret = YAML.load_file(SECRET).tap do |cfg|
       cfg['metadata']['name'] = 'saml-metadata'
       cfg['data'] = {}
       cfg['data']['hub_metadata_for_proxy_node.xml'] = hub_metadata_for_proxy_node_xml_signed
       cfg['data']['hub_metadata_for_idp.xml'] = hub_metadata_for_stub_idp_xml_signed
       cfg['data']['metadata_for_connector_node.xml'] = proxy_node_metadata_xml_signed
     end
-    create_file('metadata-configmap.yaml', YAML.dump(configmap))
+    create_file('metadata-secret.yaml', YAML.dump(secret))
   end
 
   if options.do_env

--- a/pki/options.rb
+++ b/pki/options.rb
@@ -12,7 +12,7 @@ Options =
     :connector_url,
     :do_files,
     :do_manifests,
-    :do_configmaps,
+    :do_secrets,
     :do_env,
     :xmlsectool_path,
     :truststore_pass,
@@ -46,7 +46,7 @@ class Parser
       opts.on('--connector-url URL', 'Stub connector base URL') { |s| options.connector_url = s }
       opts.on('--files', 'Set to output keys, certs and truststores') { |_| options.do_files = true }
       opts.on('--manifests', 'Set to output CF manifests with PKI inlined') { |_| options.do_manifests = true }
-      opts.on('--configmaps', 'Set to output Kubernetes ConfigMaps with PKI inlined') { |_| options.do_configmaps = true }
+      opts.on('--secrets', 'Set to output Kubernetes Secrets with PKI inlined') { |_| options.do_secrets = true }
       opts.on('--env', 'Output environment files for Docker Compose') { |_| options.do_env = true }
       opts.on('--xmlsectool PATH', 'Path to xmlsectool (default: xmlsectool)') { |s| options.xmlsectool_path = s }
       opts.on('--truststore-pass PASSWORD', 'Password for generated truststores (default: marshmallow)') { |s| options.truststore_pass = s }

--- a/pki/secret.yaml
+++ b/pki/secret.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: my-secret

--- a/proxy-node-chart/charts/proxy-node-gateway/templates/gateway-deployment.yaml
+++ b/proxy-node-chart/charts/proxy-node-gateway/templates/gateway-deployment.yaml
@@ -43,68 +43,68 @@ spec:
         env:
         - name: CONNECTOR_NODE_ENTITY_ID
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_ENTITY_ID
         - name: CONNECTOR_NODE_ISSUER_ID
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_ISSUER_ID
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_METADATA_TRUSTSTORE
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
         - name: CONNECTOR_NODE_METADATA_URL
           value: http://{{ .Release.Name }}-stub-connector/Metadata
         - name: CONNECTOR_NODE_URL
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_URL
         - name: HUB_ENTITY_ID
           value: http://stub_idp.acme.org/stub-idp-demo/SSO/POST
         - name: HUB_FACING_ENCRYPTION_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_FACING_ENCRYPTION_CERT
         - name: HUB_FACING_ENCRYPTION_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_FACING_ENCRYPTION_KEY
         - name: HUB_FACING_SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_FACING_SIGNING_CERT
         - name: HUB_FACING_SIGNING_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_FACING_SIGNING_KEY
         - name: HUB_METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_METADATA_TRUSTSTORE
         - name: HUB_METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_METADATA_TRUSTSTORE_PASSWORD
         - name: HUB_METADATA_URL
           value: http://{{ .Release.Name }}-stub-metadata/hub_metadata_for_proxy_node.xml
         - name: HUB_URL
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: HUB_URL
         - name: METADATA_REFRESH_DELAY
@@ -113,7 +113,7 @@ spec:
           value: "80"
         - name: PROXY_NODE_AUTHN_REQUEST_ENDPOINT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: PROXY_NODE_AUTHN_REQUEST_ENDPOINT
         - name: PROXY_NODE_ENTITY_ID
@@ -122,19 +122,19 @@ spec:
           value: http://{{ .Release.Name }}-stub-metadata/metadata_for_connector_node.xml
         - name: PROXY_NODE_RESPONSE_ENDPOINT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: PROXY_NODE_RESPONSE_ENDPOINT
         - name: REDIS_SERVER_URI
           value: redis://{{ .Release.Name }}-gateway-redis:6379/
         - name: SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: SIGNING_CERT
         - name: SIGNING_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: SIGNING_KEY
         - name: TRANSLATOR_URL

--- a/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
+++ b/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
@@ -22,8 +22,8 @@ spec:
       restartPolicy: Always
       volumes:
         - name: proxy-node-pki
-          configMap:
-            name: proxy-node-pki
+          secret:
+            secretName: proxy-node-pki
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "docker_image" (tuple .Chart.Name .) }}
@@ -51,61 +51,61 @@ spec:
         env:
         - name: CONNECTOR_NODE_ENTITY_ID
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_ENTITY_ID
         - name: CONNECTOR_NODE_ISSUER_ID
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_ISSUER_ID
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: CONNECTOR_NODE_METADATA_TRUSTSTORE
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
         - name: CONNECTOR_NODE_METADATA_URL
           value: http://{{ .Release.Name }}-stub-connector/Metadata
         - name: CONNECTOR_NODE_URL
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: CONNECTOR_NODE_URL
         - name: HUB_ENTITY_ID
           value: http://stub_idp.acme.org/stub-idp-demo/SSO/POST
         - name: HUB_FACING_ENCRYPTION_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_FACING_ENCRYPTION_CERT
         - name: HUB_FACING_ENCRYPTION_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_FACING_ENCRYPTION_KEY
         - name: HUB_FACING_SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_FACING_SIGNING_CERT
         - name: HUB_FACING_SIGNING_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_FACING_SIGNING_KEY
         - name: HUB_METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_METADATA_TRUSTSTORE
         - name: HUB_METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: HUB_METADATA_TRUSTSTORE_PASSWORD
         - name: HUB_METADATA_URL
@@ -120,19 +120,19 @@ spec:
           value: http://{{ .Release.Name }}-stub-metadata/metadata_for_connector_node.xml
         - name: PROXY_NODE_RESPONSE_ENDPOINT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki
               key: PROXY_NODE_RESPONSE_ENDPOINT
         - name: REDIS_SERVER_URI
           value: redis://{{ .Release.Name }}-gateway-redis:6379/
         - name: SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: SIGNING_CERT
         - name: SIGNING_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: proxy-node-pki 
               key: SIGNING_KEY
         - name: PKCS11_PROXY_SOCKET

--- a/proxy-node-chart/charts/softhsm/templates/softhsm-deployment.yaml
+++ b/proxy-node-chart/charts/softhsm/templates/softhsm-deployment.yaml
@@ -68,5 +68,5 @@ spec:
               key: signingKeySOPIN
       volumes:
         - name: proxy-node-pki
-          configMap:
-            name: proxy-node-pki
+          secret:
+            secretName: proxy-node-pki

--- a/proxy-node-chart/charts/stub-connector/templates/stub-connector-deployment.yaml
+++ b/proxy-node-chart/charts/stub-connector/templates/stub-connector-deployment.yaml
@@ -43,45 +43,45 @@ spec:
         env:
         - name: CONNECTOR_NODE_BASE_URL
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: CONNECTOR_NODE_BASE_URL
         - name: ENCRYPTION_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: ENCRYPTION_CERT
         - name: ENCRYPTION_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: ENCRYPTION_KEY
         - name: PORT
           value: "80"
         - name: PROXY_NODE_ENTITY_ID
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: PROXY_NODE_ENTITY_ID
         - name: PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL
           value: http://{{ .Release.Name }}-stub-metadata/metadata_for_connector_node.xml
         - name: PROXY_NODE_METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: PROXY_NODE_METADATA_TRUSTSTORE
         - name: PROXY_NODE_METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: PROXY_NODE_METADATA_TRUSTSTORE_PASSWORD
         - name: SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: SIGNING_CERT
         - name: SIGNING_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-connector-pki
               key: SIGNING_KEY

--- a/proxy-node-chart/charts/stub-connector/templates/stub-idp-deployment.yaml
+++ b/proxy-node-chart/charts/stub-connector/templates/stub-idp-deployment.yaml
@@ -60,12 +60,12 @@ spec:
           value: https://dev-hub.local
         - name: METADATA_TRUSTSTORE
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: METADATA_TRUSTSTORE
         - name: METADATA_TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: METADATA_TRUSTSTORE_PASSWORD
         - name: METADATA_URL
@@ -74,12 +74,12 @@ spec:
           value: "80"
         - name: STUB_COUNTRY_SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: STUB_COUNTRY_SIGNING_CERT
         - name: STUB_COUNTRY_SIGNING_PRIVATE_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: STUB_COUNTRY_SIGNING_PRIVATE_KEY
         - name: STUB_IDPS_FILE_PATH
@@ -88,17 +88,17 @@ spec:
           value: "true"
         - name: STUB_IDP_SIGNING_CERT
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: STUB_IDP_SIGNING_CERT
         - name: STUB_IDP_SIGNING_PRIVATE_KEY
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: STUB_IDP_SIGNING_PRIVATE_KEY
         - name: TRUSTSTORE_PASSWORD
           valueFrom:
-            configMapKeyRef:
+            secretKeyRef:
               name: stub-idp-pki 
               key: METADATA_TRUSTSTORE_PASSWORD
         - name: TRUSTSTORE_TYPE

--- a/proxy-node-chart/charts/stub-connector/templates/stub-metadata-deployment.yaml
+++ b/proxy-node-chart/charts/stub-connector/templates/stub-metadata-deployment.yaml
@@ -37,5 +37,5 @@ spec:
       restartPolicy: Always
       volumes:
       - name: saml-metadata
-        configMap:
-          name: saml-metadata
+        secret:
+          secretName: saml-metadata

--- a/startup.sh
+++ b/startup.sh
@@ -67,7 +67,7 @@ function generate_pki {
       --proxy-url "http://$(minikube ip):31200" \
       --idp-url "http://$(minikube ip):31300" \
       --softhsm \
-      --configmaps \
+      --secrets \
       "${PKI_OUTPUT_DIR}"
 
     minikube ip > "$MINIKUBE_IP"


### PR DESCRIPTION
## What

It's essentially the same thing, however these are in fact secrets. In
the future, we'd be looking into sealing the secrets for the K8s cluster
as they will contain Trust Stores provided from the Hub.

Now that we're generating K8s secrets, we need to be referencing a
correct thing to be mounted.

I've created a separate script for secret generation...

It's essentially the same piece of technology that is used in the
startup script, however torn down version that will do that only.

We have to Base64 all the secrets. Some double Base64....

The startup script is generating the secrets for the local deployment. I
don't want it to break the thing, but I also don't think I want to
refactor it bearing in mind that the script is already a pain.

For now, it's duplicated...

## How to review

- Run `./startup.sh`
- See the journey through