### PR TITLE
Get required libs from SoftHSM for Translator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
     image: govukverify/proxy-node-translator:latest
     build:
       context: .
-      args:
-        component: proxy-node-translator
+      dockerfile: proxy-node-translator/Dockerfile
   stub-connector:
     image: govukverify/stub-connector:latest
     build:

--- a/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
+++ b/proxy-node-chart/charts/proxy-node-translator/templates/translator-deployment.yaml
@@ -24,8 +24,6 @@ spec:
         - name: proxy-node-pki
           configMap:
             name: proxy-node-pki
-        - name: softhsm-dir
-          emptyDir: {}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "docker_image" (tuple .Chart.Name .) }}
@@ -49,9 +47,6 @@ spec:
         volumeMounts:
           - mountPath: /app/keys/
             name: proxy-node-pki
-            readOnly: true
-          - mountPath: /softhsm
-            name: softhsm-dir
             readOnly: true
         env:
         - name: CONNECTOR_NODE_ENTITY_ID
@@ -142,10 +137,6 @@ spec:
               key: SIGNING_KEY
         - name: PKCS11_PROXY_SOCKET
           value: tcp://{{ .Release.Name }}-hsm:5656
-        - name: SOFT_HSM_LIB_PATH
-          value: /softhsm/libpkcs11-proxy.so
-        - name: KEY_RETRIEVER_SERVICE_NAME
-          value: softHSM
         - name: SOFT_HSM_SIGNING_KEY_PIN
           valueFrom:
             secretKeyRef:
@@ -176,35 +167,3 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-hsm
               key: signingKeySOPIN
-      - name: softhsm
-        image: {{ include "docker_image" (tuple "softhsm" .) }}
-        imagePullPolicy: IfNotPresent
-        ports:
-        - name: pkcs11
-          containerPort: 5656
-        readinessProbe:
-          tcpSocket:
-            port: pkcs11
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        volumeMounts:
-          - mountPath: /app/keys/
-            name: proxy-node-pki
-            readOnly: true
-          - mountPath: /softhsm
-            name: softhsm-dir
-        env:
-        - name: SOFT_HSM_SIGNING_KEY_PIN
-          value: CHANGE-ME-123
-        - name: SOFT_HSM_SIGNING_KEY_LABEL
-          value: vfpn-uk-signing
-        - name: SOFT_HSM_SIGNING_KEY_TOKEN
-          value: vfpn-uk-signing
-        - name: SOFT_HSM_SIGNING_KEY_SLOT
-          value: "0"
-        - name: SOFT_HSM_SIGNING_KEY_ID
-          value: DEF0
-        - name: SOFT_HSM_SIGNING_KEY_SO_PIN
-          value: CHANGE-ME-456
-        - name: KEY_RETRIEVER_SERVICE_NAME
-          value: softHSM

--- a/proxy-node-translator/Dockerfile
+++ b/proxy-node-translator/Dockerfile
@@ -1,1 +1,48 @@
-../Dockerfile
+FROM openjdk:11-jre-slim AS libs
+WORKDIR /app
+ARG version=2.5.0
+
+RUN apt-get update && \
+    apt-get install -y \
+    opensc build-essential wget libsqlite3-dev libssl-dev \
+    cmake libseccomp-dev
+
+RUN wget https://github.com/SUNET/pkcs11-proxy/archive/master.zip && \
+    unzip master.zip && \
+    cd pkcs11-proxy-master && \
+    cmake . && make && make install
+
+FROM gradle:jdk11 AS build
+WORKDIR /app
+USER root
+ENV GRADLE_USER_HOME ~/.gradle
+
+COPY build.gradle build.gradle
+COPY settings.gradle settings.gradle
+COPY proxy-node-shared/ proxy-node-shared/
+
+ARG component=proxy-node-translator
+COPY ${component}/src ${component}/src
+COPY ${component}/build.gradle ${component}/build.gradle
+
+RUN gradle --no-daemon --quiet -p ${component} --parallel install -x test
+ENTRYPOINT ["gradle", "--no-daemon"]
+
+FROM openjdk:11-jre-slim
+WORKDIR /app
+USER root
+
+COPY --from=libs /usr/local/lib/libpkcs11-proxy* /usr/local/lib/
+COPY --from=libs /usr/local/bin/pkcs11-daemon /usr/local/bin/
+
+ARG component=proxy-node-translator
+COPY --from=build /app/${component}/build/install/${component} /app
+
+RUN apt-get update && apt-get install -y dumb-init
+
+ENV CONFIG_FILE config.yml
+ENV COMPONENT $component
+ENV SOFT_HSM_LIB_PATH /usr/local/lib/libpkcs11-proxy.so
+ENV KEY_RETRIEVER_SERVICE_NAME softhsm
+ENTRYPOINT ["dumb-init", "--"]
+CMD "/app/bin/$COMPONENT"

--- a/proxy-node-translator/README.md
+++ b/proxy-node-translator/README.md
@@ -1,0 +1,10 @@
+# Proxy Node Translator
+
+
+## Build
+
+Has to be built from the root directory of that repo. Run:
+
+```sh
+docker build -f proxy-node-translator/Dockerfile .
+```


### PR DESCRIPTION
## What

At the current state, both softHSM and Translator must be running on a
pod together where SoftHSM would share some libs across the
containers... This is weird and undesired. We can capture the required
lib and provide it to the translator container directly, making the
deployment chart smaller.

## How to review

- Code review
- Run locally - see journey through