### PR TITLE
BAU: Split Gradle dependency configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,46 +53,57 @@ subprojects {
     configurations {
         common
         dropwizard
-        saml
-        saml_test
+        opensaml
+        eidas_saml
+        verify_saml
+        verify_saml_test
+        proxy_node_test
         soft_hsm
     }
 
     dependencies {
-        dropwizard (
-                "io.dropwizard:dropwizard-core:${dropwizard_version}",
-                "io.dropwizard:dropwizard-client:${dropwizard_version}",
-                "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}"
-        )
-
-        saml (
-                "org.opensaml:opensaml-core:${opensaml_version}",
-                "org.opensaml:opensaml-saml-impl:${opensaml_version}",
-                "org.opensaml:opensaml-storage-impl:${opensaml_version}",
-                "uk.gov.ida:saml-extensions:${saml_libs_version}",
-                "uk.gov.ida:saml-metadata-bindings:${saml_libs_version}",
-                "uk.gov.ida:saml-security:${saml_libs_version}",
-                "uk.gov.ida:saml-utils:${saml_libs_version}",
-                "se.litsec.eidas:eidas-opensaml3:1.3.1",
-                "se.litsec.opensaml:opensaml3-ext:1.2.2"
-        )
-
-        saml_test (
-                "net.sourceforge.htmlunit:htmlunit:2.28",
-                "uk.gov.ida:common-test-utils:${utils_version}",
-                "uk.gov.ida:saml-metadata-bindings-test:${saml_libs_version}",
-                "io.dropwizard:dropwizard-testing:${dropwizard_version}",
-        )
-
         common (
                 "javax.xml.bind:jaxb-api:2.3.0",
                 "javax.activation:activation:1.1.1",
                 "io.lettuce:lettuce-core:5.1.3.RELEASE",
-                "uk.gov.ida:security-utils:${utils_version}"
+        )
+
+        dropwizard (
+                "io.dropwizard:dropwizard-core:${dropwizard_version}",
+                "io.dropwizard:dropwizard-client:${dropwizard_version}",
+                "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
+        )
+
+        opensaml (
+                "org.opensaml:opensaml-core:${opensaml_version}",
+                "org.opensaml:opensaml-saml-impl:${opensaml_version}",
+                "org.opensaml:opensaml-storage-impl:${opensaml_version}",
+        )
+
+        eidas_saml (
+                "se.litsec.eidas:eidas-opensaml3:1.3.1",
+                "se.litsec.opensaml:opensaml3-ext:1.2.2",
+        )
+
+        verify_saml (
+                "uk.gov.ida:saml-extensions:${saml_libs_version}",
+                "uk.gov.ida:saml-metadata-bindings:${saml_libs_version}",
+                "uk.gov.ida:saml-security:${saml_libs_version}",
+                "uk.gov.ida:saml-utils:${saml_libs_version}",
+                "uk.gov.ida:security-utils:${utils_version}",
+        )
+
+        verify_saml_test (
+                "uk.gov.ida:common-test-utils:${utils_version}",
+                "uk.gov.ida:saml-metadata-bindings-test:${saml_libs_version}",
         )
 
         soft_hsm (
-                "se.swedenconnect.opensaml:opensaml-pkcs11-support:${soft_hsm_version}"
+                "se.swedenconnect.opensaml:opensaml-pkcs11-support:${soft_hsm_version}",
+        )
+
+        proxy_node_test (
+                "net.sourceforge.htmlunit:htmlunit:2.28",
         )
 
         testCompile (
@@ -103,7 +114,7 @@ subprojects {
             "org.mockito:mockito-core:2.23.0",
             "io.dropwizard:dropwizard-testing:${dropwizard_version}",
             "net.sourceforge.htmlunit:htmlunit:2.28",
-            project(':proxy-node-test')
+            project(':proxy-node-test'),
         )
 
     }

--- a/proxy-node-gateway/build.gradle
+++ b/proxy-node-gateway/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile configurations.dropwizard,
-            configurations.saml,
+            configurations.opensaml,
             configurations.common,
             project(':proxy-node-shared')
 }

--- a/proxy-node-shared/build.gradle
+++ b/proxy-node-shared/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     compile configurations.dropwizard,
-            configurations.saml,
+            configurations.opensaml,
+            configurations.eidas_saml,
+            configurations.verify_saml,
             configurations.common
 }
 

--- a/proxy-node-test/build.gradle
+++ b/proxy-node-test/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
-    compile configurations.saml,
-            configurations.saml_test,
+    compile configurations.opensaml,
+            configurations.verify_saml,
+            configurations.verify_saml_test,
             configurations.common,
+            configurations.proxy_node_test,
             project(':proxy-node-shared')
 }
 

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -1,9 +1,12 @@
 dependencies {
     compile configurations.dropwizard,
-            configurations.saml,
+            configurations.opensaml,
+            configurations.verify_saml,
             configurations.common,
             configurations.soft_hsm,
             project(':proxy-node-shared')
+
+    testCompile configurations.verify_saml_test
 }
 
 sourceSets {

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile configurations.dropwizard,
-            configurations.saml,
+            configurations.opensaml,
+            configurations.eidas_saml,
             configurations.common,
             project(':proxy-node-shared')
 }


### PR DESCRIPTION
We're going to be changing the dependencies required by our services, so
I'm separating them by domain (eIDAS, Verify, OpenSAML) to make them easier to remove.

In future we might want to just have per-component dependency
configurations.