### PR TITLE
EID-1308: Extract ID and Issuer from AuthnRequest

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -1,15 +1,28 @@
 package uk.gov.ida.notification.eidassaml;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
+import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import se.litsec.opensaml.utils.ObjectUtils;
+
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
 
 @Path("/eidasAuthnRequest")
 @Produces(MediaType.APPLICATION_JSON)
 public class EidasSamlResource {
     @POST
-    public ResponseDto post(RequestDto request) {
-        return new ResponseDto("request_id", "issuer");
+    public ResponseDto post(RequestDto request) throws UnmarshallingException, XMLParserException {
+        AuthnRequest authnRequest = ObjectUtils.unmarshall(
+            new ByteArrayInputStream(Base64.getDecoder().decode(request.authnRequest.getBytes())),
+            AuthnRequest.class);
+
+        return new ResponseDto(
+            authnRequest.getID(),
+            authnRequest.getIssuer().getValue());
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -1,8 +1,14 @@
 package uk.gov.ida.notification.eidassaml;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
+import se.litsec.opensaml.utils.ObjectUtils;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -15,10 +21,21 @@ public class EidasSamlResourceTest {
         .addResource(new EidasSamlResource())
         .build();
 
+    @Before
+    public void setup() throws Exception {
+        InitializationService.initialize();
+    }
+
     @Test
-    public void shouldReturnRequestIdAndIssuer() {
+    public void shouldReturnRequestIdAndIssuer() throws Exception {
+        AuthnRequest authnRequest = ObjectUtils.createSamlObject(AuthnRequest.class);
+        Issuer issuer = ObjectUtils.createSamlObject(Issuer.class);
+        issuer.setValue("issuer");
+        authnRequest.setID("request_id");
+        authnRequest.setIssuer(issuer);
+
         RequestDto request = new RequestDto();
-        request.authnRequest = "pantoufles";
+        request.authnRequest = Base64.encodeAsString(ObjectUtils.toString(authnRequest));
 
         ResponseDto response = resources.target("/eidasAuthnRequest")
             .request(MediaType.APPLICATION_JSON_TYPE)
@@ -26,6 +43,6 @@ public class EidasSamlResourceTest {
             .readEntity(ResponseDto.class);
 
         assertEquals(response.requestId, "request_id");
-        assertEquals(response.requestId, "request_id");
+        assertEquals(response.issuer, "issuer");
     }
 }


### PR DESCRIPTION
Base64-decodes and parses the AuthnRequest before extracting the ID and
Issuer. No validation of the message is being performed at this stage,
that will be implemented in EID-1304/1305.