### PR TITLE
EID-1304 - Set up the ESP the eidas authn request validator

### DIFF
--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -10,3 +10,18 @@ logging:
   level: INFO
   appenders:
     - type: logstash-console
+
+connectorMetadataConfiguration:
+  url: ${CONNECTOR_NODE_METADATA_URL:-http://DefaultNotUsed}
+  expectedEntityId: ${CONNECTOR_NODE_ENTITY_ID:-DefaultNotUsed}
+  jerseyClientName: connector-metadata-client
+  maxRefreshDelay: ${METADATA_REFRESH_DELAY:-600000}
+  trustStore:
+    type: ${TRUSTSTORE_TYPES:-encoded}
+    store: ${CONNECTOR_NODE_METADATA_TRUSTSTORE:-DefaultNotUsed}
+    password: ${CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD:-DefaultNotUsed}
+
+replayChecker:
+  redisUrl: ${REDIS_SERVER_URI:-http://DefaultNotUsed}
+
+proxyNodeAuthnRequestUrl: ${PROXY_NODE_AUTHN_REQUEST_ENDPOINT:-DefaultNotUsed}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -7,18 +7,34 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
-import uk.gov.ida.dropwizard.logstash.LogstashBundle;
+import se.litsec.opensaml.saml2.common.response.MessageReplayChecker;
 import uk.gov.ida.notification.VerifySamlInitializer;
+import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.AssertionConsumerServiceValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.ComparisonValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestIssuerValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestedAttributesValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.SpTypeValidator;
+import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
+import uk.gov.ida.notification.saml.validation.components.LoaValidator;
+import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
+import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 
 public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
-    @Override
-    public void run(EidasSamlConfiguration configuration, Environment environment) {
 
-        environment.jersey().register(new EidasSamlResource());
-    }
+    private MetadataResolverBundle<EidasSamlConfiguration> connectorMetadataResolverBundle;
 
-    public static void main() throws Exception {
-        new EidasSamlApplication().run("server", "config.yml");
+    public static void main(final String[] args) throws Exception {
+        if (args == null || args.length == 0) {
+            String configFile = System.getenv("CONFIG_FILE");
+
+            if (configFile == null) {
+                throw new RuntimeException("CONFIG_FILE environment variable should be set with path to configuration file");
+            }
+            new EidasSamlApplication().run("server", configFile);
+        } else {
+            new EidasSamlApplication().run(args);
+        }
     }
 
     public void initialize(final Bootstrap<EidasSamlConfiguration> bootstrap) {
@@ -37,6 +53,33 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
 
         VerifySamlInitializer.init();
 
+
+        connectorMetadataResolverBundle = new MetadataResolverBundle<>(EidasSamlConfiguration::getConnectorMetadataConfiguration);
+        
+        bootstrap.addBundle(connectorMetadataResolverBundle);
         bootstrap.addBundle(new LogstashBundle());
+    }
+
+    @Override
+    public void run(EidasSamlConfiguration configuration, Environment environment) throws Exception {
+        EidasAuthnRequestValidator eidasAuthnRequestValidator = createEidasAuthnRequestValidator(configuration, connectorMetadataResolverBundle);
+        environment.jersey().register(new EidasSamlResource());
+    }
+
+    private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlConfiguration configuration, MetadataResolverBundle hubMetadataResolverBundle) throws Exception {
+        MessageReplayChecker replayChecker = configuration.getReplayChecker().createMessageReplayChecker("eidas-saml-parser");
+        DestinationValidator destinationValidator = new DestinationValidator(
+                configuration.getProxyNodeAuthnRequestUrl(), configuration.getProxyNodeAuthnRequestUrl().getPath());
+
+        return new EidasAuthnRequestValidator(
+                new RequestIssuerValidator(),
+                new SpTypeValidator(),
+                new LoaValidator(),
+                new RequestedAttributesValidator(),
+                replayChecker,
+                new ComparisonValidator(),
+                destinationValidator,
+                new AssertionConsumerServiceValidator(hubMetadataResolverBundle.getMetadataResolver())
+        );
     }
 }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlConfiguration.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlConfiguration.java
@@ -1,6 +1,39 @@
 package uk.gov.ida.notification.eidassaml;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import uk.gov.ida.notification.configuration.ReplayCheckerConfiguration;
+import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.net.URI;
 
 public class EidasSamlConfiguration extends Configuration {
+
+    @JsonProperty
+    @Valid
+    @NotNull
+    private URI proxyNodeAuthnRequestUrl;
+
+    @JsonProperty
+    @Valid
+    private ReplayCheckerConfiguration replayChecker = new ReplayCheckerConfiguration();
+
+    @JsonProperty
+    @Valid
+    @NotNull
+    private TrustStoreBackedMetadataConfiguration connectorMetadataConfiguration;
+
+    public ReplayCheckerConfiguration getReplayChecker() {
+        return replayChecker;
+    }
+
+    public TrustStoreBackedMetadataConfiguration getConnectorMetadataConfiguration() {
+        return connectorMetadataConfiguration;
+    }
+
+    public URI getProxyNodeAuthnRequestUrl() {
+        return proxyNodeAuthnRequestUrl;
+    }
 }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -15,6 +15,10 @@ import java.util.Base64;
 @Path("/eidasAuthnRequest")
 @Produces(MediaType.APPLICATION_JSON)
 public class EidasSamlResource {
+
+    public EidasSamlResource() {
+    }
+
     @POST
     public ResponseDto post(RequestDto request) throws UnmarshallingException, XMLParserException {
         AuthnRequest authnRequest = ObjectUtils.unmarshall(

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/EidasAuthnRequestValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/EidasAuthnRequestValidator.java
@@ -1,0 +1,106 @@
+package uk.gov.ida.notification.eidassaml.saml.validation;
+
+import com.google.common.base.Strings;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import se.litsec.eidas.opensaml.ext.RequestedAttributes;
+import se.litsec.eidas.opensaml.ext.SPType;
+import se.litsec.opensaml.saml2.common.response.MessageReplayChecker;
+import se.litsec.opensaml.saml2.common.response.MessageReplayException;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.AssertionConsumerServiceValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.ComparisonValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestIssuerValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestedAttributesValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.SpTypeValidator;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
+import uk.gov.ida.notification.saml.deprecate.SamlValidationException;
+import uk.gov.ida.notification.saml.validation.components.LoaValidator;
+
+import javax.xml.namespace.QName;
+
+public class EidasAuthnRequestValidator {
+
+    private SpTypeValidator spTypeValidator;
+    private LoaValidator loaValidator;
+    private RequestedAttributesValidator requestedAttributesValidator;
+    private RequestIssuerValidator requestIssuerValidator;
+    private final MessageReplayChecker messageReplayChecker;
+    private final ComparisonValidator comparisonValidator;
+    private final DestinationValidator destinationValidator;
+    private final AssertionConsumerServiceValidator assertionConsumerServiceValidator;
+
+    public EidasAuthnRequestValidator(RequestIssuerValidator requestIssuerValidator,
+                                      SpTypeValidator spTypeValidator,
+                                      LoaValidator loaValidator,
+                                      RequestedAttributesValidator requestedAttributesValidator,
+                                      MessageReplayChecker duplicateAuthnRequestValidator,
+                                      ComparisonValidator comparisonValidator,
+                                      DestinationValidator destinationValidator,
+                                      AssertionConsumerServiceValidator assertionConsumerServiceValidator) {
+        this.requestIssuerValidator = requestIssuerValidator;
+        this.spTypeValidator = spTypeValidator;
+        this.loaValidator = loaValidator;
+        this.requestedAttributesValidator = requestedAttributesValidator;
+        this.messageReplayChecker = duplicateAuthnRequestValidator;
+        this.comparisonValidator = comparisonValidator;
+        this.destinationValidator = destinationValidator;
+        this.assertionConsumerServiceValidator = assertionConsumerServiceValidator;
+    }
+
+    public void validate(AuthnRequest request) {
+        if (request == null) {
+            throw new InvalidAuthnRequestException("Null request");
+        }
+
+        if (Strings.isNullOrEmpty(request.getID())) {
+            throw new InvalidAuthnRequestException("Missing Request ID");
+        }
+
+        if (request.getExtensions() == null) {
+            throw new InvalidAuthnRequestException("Missing Extensions");
+        }
+
+        if (request.isPassive()) {
+            throw new InvalidAuthnRequestException("Request should not require zero user interaction (isPassive should be missing or false)");
+        }
+
+        if (!request.isForceAuthn()) {
+            throw new InvalidAuthnRequestException("Request should require fresh authentication (forceAuthn should be true)");
+        }
+
+        if (!Strings.isNullOrEmpty(request.getProtocolBinding())) {
+            throw new InvalidAuthnRequestException("Request should not specify protocol binding");
+        }
+
+        if (request.getVersion() != SAMLVersion.VERSION_20) {
+            throw new InvalidAuthnRequestException("SAML Version should be " + SAMLVersion.VERSION_20.toString());
+        }
+
+        SPType spTypeElement = (SPType) getExtension(request, SPType.DEFAULT_ELEMENT_NAME);
+        RequestedAttributes requestedAttributesElement = (RequestedAttributes) getExtension(request, RequestedAttributes.DEFAULT_ELEMENT_NAME);
+
+        requestIssuerValidator.validate(request.getIssuer());
+        spTypeValidator.validate(spTypeElement);
+        loaValidator.validate(request.getRequestedAuthnContext());
+        requestedAttributesValidator.validate(requestedAttributesElement);
+        assertionConsumerServiceValidator.validate(request);
+        comparisonValidator.validate(request.getRequestedAuthnContext());
+
+        try {
+            messageReplayChecker.checkReplay(request.getID());
+            destinationValidator.validate(request.getDestination());
+        } catch (SamlValidationException | MessageReplayException e) {
+            throw new InvalidAuthnRequestException(e.getMessage(), e);
+        }
+    }
+
+    private XMLObject getExtension(AuthnRequest request, QName elementName) {
+        return request.getExtensions()
+                .getUnknownXMLObjects(elementName)
+                .stream()
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/AssertionConsumerServiceValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/AssertionConsumerServiceValidator.java
@@ -1,0 +1,69 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import com.google.common.base.Strings;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+public class AssertionConsumerServiceValidator {
+    private static final Logger LOG = Logger.getLogger(AssertionConsumerServiceValidator.class.getName());
+
+    private final MetadataResolver metadataResolver;
+
+    public AssertionConsumerServiceValidator(MetadataResolver metadataResolver) {
+        this.metadataResolver = metadataResolver;
+    }
+
+    public void validate(AuthnRequest request) {
+        String assertionConsumerServiceURL = request.getAssertionConsumerServiceURL();
+
+        if (Strings.isNullOrEmpty(assertionConsumerServiceURL)) {
+            return;
+        }
+
+        final List<String> locationsFromMetadata = getAssertionConsumerServicesFromMetadata(request.getIssuer().getValue()).stream()
+                .map(AssertionConsumerService::getLocation)
+                .collect(Collectors.toList());
+
+        if (locationsFromMetadata.stream().anyMatch(location -> location.equals(assertionConsumerServiceURL))) {
+            return;
+        }
+
+        throw new InvalidAuthnRequestException("Supplied AssertionConsumerServiceURL has no match in metadata. " +
+                String.format("Supplied: %s. In metadata: %s.", assertionConsumerServiceURL, String.join(", ", locationsFromMetadata)));
+    }
+
+    private Collection<AssertionConsumerService> getAssertionConsumerServicesFromMetadata(String entityId) {
+        try {
+            EntityIdCriterion entityIdCriterion = new EntityIdCriterion(entityId);
+            EntityDescriptor metadata = metadataResolver.resolveSingle(new CriteriaSet(entityIdCriterion));
+
+            if (metadata == null) {
+                return List.of();
+            }
+
+            SPSSODescriptor spssoDescriptor = metadata.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
+
+            if (spssoDescriptor == null) {
+                return List.of();
+            }
+
+            return spssoDescriptor.getAssertionConsumerServices();
+        } catch (ResolverException e) {
+            LOG.warning("Unable to resolve metadata for entity " + entityId);
+            return List.of();
+        }
+    }
+}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/ComparisonValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/ComparisonValidator.java
@@ -1,0 +1,20 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+public class ComparisonValidator {
+    public static final AuthnContextComparisonTypeEnumeration validType = AuthnContextComparisonTypeEnumeration.MINIMUM;
+
+    public void validate(RequestedAuthnContext authnContext) {
+        if (authnContext == null) {
+            throw new InvalidAuthnRequestException("Request has no requested authentication context");
+        }
+
+        AuthnContextComparisonTypeEnumeration comparisonType = authnContext.getComparison();
+        if (comparisonType != null && !validType.equals(comparisonType)) {
+            throw new InvalidAuthnRequestException("Comparison type, if present, must be " + validType.toString());
+        }
+    }
+}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestIssuerValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestIssuerValidator.java
@@ -1,0 +1,12 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import com.google.common.base.Strings;
+import org.opensaml.saml.saml2.core.Issuer;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+public class RequestIssuerValidator {
+    public void validate(Issuer issuer) {
+        if (issuer == null || Strings.isNullOrEmpty(issuer.getValue()))
+            throw new InvalidAuthnRequestException("Missing Issuer");
+    }
+}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
@@ -1,0 +1,68 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.collections.ListUtils;
+import org.opensaml.saml.saml2.core.Attribute;
+import se.litsec.eidas.opensaml.ext.RequestedAttribute;
+import se.litsec.eidas.opensaml.ext.RequestedAttributes;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME;
+
+public class RequestedAttributesValidator {
+
+    private final ImmutableList<String> mandatoryAttributes = ImmutableList.of(
+            EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME,
+            EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME,
+            EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME,
+            EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME
+    );
+
+    public void validate(RequestedAttributes requestedAttributesParent) {
+        if (requestedAttributesParent == null) throw new InvalidAuthnRequestException("Missing RequestedAttributes");
+
+        List<RequestedAttribute> requestedAttributes = requestedAttributesParent.getRequestedAttributes();
+
+        List<String> requestedAttributesNames = requestedAttributes.stream()
+                .map(this::validateRequestedAttribute)
+                .map(Attribute::getName)
+                .collect(Collectors.toList());
+
+        List missingMandatoryAttributes = ListUtils.subtract(mandatoryAttributes, requestedAttributesNames);
+        if (!missingMandatoryAttributes.isEmpty())
+            throw new InvalidAuthnRequestException(MessageFormat.format("Missing mandatory RequestedAttribute(s): {0}", String.join(", ", missingMandatoryAttributes)));
+    }
+
+    private RequestedAttribute validateRequestedAttribute(RequestedAttribute requestedAttribute) {
+        if(!RequestedAttribute.URI_REFERENCE.equals(requestedAttribute.getNameFormat()))
+            throw new InvalidAuthnRequestException(nameFormatError(requestedAttribute));
+
+        if(mandatoryAttributes.contains(requestedAttribute.getName()) && !requestedAttribute.isRequired())
+            throw new InvalidAuthnRequestException(mandatoryAttributeError(requestedAttribute));
+
+        if(!mandatoryAttributes.contains(requestedAttribute.getName()) && requestedAttribute.isRequired())
+            throw new InvalidAuthnRequestException(optionalAttributeError(requestedAttribute));
+
+        return requestedAttribute;
+    }
+
+    private String nameFormatError(RequestedAttribute requestedAttribute) {
+        return MessageFormat.format("Invalid RequestedAttribute NameFormat ''{0}''", requestedAttribute.getNameFormat());
+    }
+
+    private String mandatoryAttributeError(RequestedAttribute requestedAttribute) {
+        return MessageFormat.format("Mandatory RequestedAttribute needs to be required ''{0}''", requestedAttribute.getName());
+    }
+
+    private String optionalAttributeError(RequestedAttribute requestedAttribute) {
+        return MessageFormat.format("Non-mandatory RequestedAttribute should not be required ''{0}''", requestedAttribute.getName());
+    }
+}
+

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/SpTypeValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/SpTypeValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import se.litsec.eidas.opensaml.ext.SPType;
+import se.litsec.eidas.opensaml.ext.SPTypeEnumeration;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+import java.text.MessageFormat;
+
+public class SpTypeValidator {
+    public void validate(SPType spType) {
+        if(spType == null) return;
+
+        SPTypeEnumeration spTypeType = spType.getType();
+        if (!SPTypeEnumeration.PUBLIC.equals(spTypeType)) {
+            String message = MessageFormat.format("Invalid SPType ''{0}''", spTypeType);
+            throw new InvalidAuthnRequestException(message);
+        }
+    }
+}

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasAuthnRequestValidatorTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasAuthnRequestValidatorTest.java
@@ -1,0 +1,263 @@
+package uk.gov.ida.notification.eidassaml;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.RequestedAuthnContext;
+import se.litsec.eidas.opensaml.ext.RequestedAttributes;
+import se.litsec.eidas.opensaml.ext.SPType;
+import se.litsec.eidas.opensaml.ext.SPTypeEnumeration;
+import se.litsec.opensaml.saml2.common.response.MessageReplayChecker;
+import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.AssertionConsumerServiceValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.ComparisonValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestIssuerValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestedAttributesValidator;
+import uk.gov.ida.notification.eidassaml.saml.validation.components.SpTypeValidator;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
+import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
+import uk.gov.ida.notification.saml.validation.components.LoaValidator;
+
+import javax.xml.transform.TransformerException;
+import javax.xml.xpath.XPathExpressionException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class EidasAuthnRequestValidatorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private EidasAuthnRequestValidator eidasAuthnRequestValidator;
+    private EidasAuthnRequestBuilder eidasAuthnRequestBuilder;
+    private RequestIssuerValidator requestIssuerValidator;
+    private SpTypeValidator spTypeValidator;
+    private LoaValidator loaValidator;
+    private RequestedAttributesValidator requestedAttributesValidator;
+    private MessageReplayChecker messageReplayChecker;
+    private ComparisonValidator comparisonValidator;
+    private DestinationValidator destinationValidator;
+    private AssertionConsumerServiceValidator assertionConsumerServiceValidator;
+
+    @BeforeClass
+    public static void classSetup() throws Throwable {
+        InitializationService.initialize();
+    }
+
+    @Before
+    public void setUp() throws Throwable {
+        requestIssuerValidator = mock(RequestIssuerValidator.class);
+        spTypeValidator = mock(SpTypeValidator.class);
+        loaValidator = mock(LoaValidator.class);
+        requestedAttributesValidator = mock(RequestedAttributesValidator.class);
+        messageReplayChecker = mock(MessageReplayChecker.class);
+        comparisonValidator = mock(ComparisonValidator.class);
+        destinationValidator = mock(DestinationValidator.class);
+        assertionConsumerServiceValidator = mock(AssertionConsumerServiceValidator.class);
+
+        eidasAuthnRequestValidator = new EidasAuthnRequestValidator(requestIssuerValidator,
+                spTypeValidator,
+                loaValidator,
+                requestedAttributesValidator,
+                messageReplayChecker,
+                comparisonValidator,
+                destinationValidator,
+                assertionConsumerServiceValidator);
+
+        eidasAuthnRequestBuilder = new EidasAuthnRequestBuilder().withRandomRequestId();
+    }
+
+    @Test
+    public void shouldNotThrowExceptionIfValidAuthnRequest() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfNullAuthnRequest() {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Null request");
+
+        eidasAuthnRequestValidator.validate(null);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAuthnRequestHasNoRequestId() throws Throwable {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Missing Request ID");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutRequestId().build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAuthnRequestHasEmptyRequestId() throws Throwable {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Missing Request ID");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withRequestId("").build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowExceptionIfAuthnRequestHasNoExtensions() throws Throwable {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Missing Extensions");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutExtensions().build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowIfAuthRequestHasIsPassiveFlagMissing() throws TransformerException, XPathExpressionException {
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutIsPassive().build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowIfAuthRequestHasIsPassiveFlagSetToFalse() throws TransformerException, XPathExpressionException {
+        AuthnRequest request = eidasAuthnRequestBuilder.withIsPassive(false).build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowIfAuthRequestHasIsPassiveFlagSetToTrue() throws TransformerException, XPathExpressionException {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Request should not require zero user interaction (isPassive should be missing or false)");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withIsPassive(true).build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowIfAuthRequestHasForceAuthSetToTrue() throws TransformerException, XPathExpressionException {
+        AuthnRequest request = eidasAuthnRequestBuilder.withForceAuthn(true).build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldNotThrowIfAuthRequestHasForceAuthSetToFalse() throws TransformerException, XPathExpressionException {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Request should require fresh authentication (forceAuthn should be true)");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withForceAuthn(false).build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowIfAuthRequestHasForceAuthMissing() throws TransformerException, XPathExpressionException {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Request should require fresh authentication (forceAuthn should be true)");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutForceAuthn().build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowIfAuthnRequestHasProtocolBinding() throws XPathExpressionException, TransformerException {
+        expectedException.expect(InvalidAuthnRequestException.class);
+        expectedException.expectMessage("Bad Authn Request from Connector Node: Request should not specify protocol binding");
+
+        AuthnRequest request = eidasAuthnRequestBuilder.withProtocolBinding("protocol-binding-attribute").build();
+        eidasAuthnRequestValidator.validate(request);
+    }
+
+    @Test
+    public void shouldThrowIfAuthnRequestHasUnsupportedSamlVersion() {
+        final String expectedMessage = "Bad Authn Request from Connector Node: SAML Version should be " + SAMLVersion.VERSION_20.toString();
+
+        assertThrows(InvalidAuthnRequestException.class, () ->
+                eidasAuthnRequestValidator.validate(eidasAuthnRequestBuilder.withSamlVersion(SAMLVersion.VERSION_10).build()), expectedMessage);
+
+        assertThrows(InvalidAuthnRequestException.class, () ->
+                eidasAuthnRequestValidator.validate(eidasAuthnRequestBuilder.withSamlVersion(SAMLVersion.VERSION_11).build()), expectedMessage);
+    }
+
+    @Test
+    public void shouldValidateRequestIssuerValidator() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        eidasAuthnRequestValidator.validate(request);
+        verify(requestIssuerValidator, times(1)).validate(request.getIssuer());
+    }
+
+    @Test
+    public void shouldValidateWithoutSpType() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutSpType().build();
+        eidasAuthnRequestValidator.validate(request);
+        verify(spTypeValidator, times(1)).validate(null);
+    }
+
+    @Test
+    public void shouldValidateWithSpType() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.withSpType(SPTypeEnumeration.PRIVATE.toString()).build();
+        SPType spType = (SPType) request.getExtensions().getOrderedChildren().get(0);
+        eidasAuthnRequestValidator.validate(request);
+        verify(spTypeValidator, times(1)).validate(spType);
+    }
+
+    @Test
+    public void shouldValidateLoA() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        eidasAuthnRequestValidator.validate(request);
+        verify(loaValidator, times(1)).validate(request.getRequestedAuthnContext());
+    }
+
+    @Test
+    public void shouldValidateRequestedAttributes() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        RequestedAttributes requestedAttributes = (RequestedAttributes) request.getExtensions().getOrderedChildren().get(1);
+        eidasAuthnRequestValidator.validate(request);
+        verify(requestedAttributesValidator, times(1)).validate(requestedAttributes);
+    }
+
+    @Test
+    public void shouldValidateWithoutRequestedAttributes() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.withoutRequestedAttributes().build();
+        eidasAuthnRequestValidator.validate(request);
+        verify(requestedAttributesValidator, times(1)).validate(null);
+    }
+
+    @Test
+    public void shouldValidateAssertionConsumerServiceUrl() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        eidasAuthnRequestValidator.validate(request);
+
+        verify(assertionConsumerServiceValidator, times(1)).validate(request);
+    }
+
+    @Test
+    public void shouldValidateComparisonAttribute() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        final RequestedAuthnContext requestedAuthnContext = request.getRequestedAuthnContext();
+
+        eidasAuthnRequestValidator.validate(request);
+        verify(comparisonValidator, times(1)).validate(requestedAuthnContext);
+    }
+
+    @Test
+    public void shouldValidateDuplicateAuthnRequest() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        final String requestID = request.getID();
+
+        eidasAuthnRequestValidator.validate(request);
+        verify(messageReplayChecker, times(1)).checkReplay(requestID);
+    }
+
+    @Test
+    public void shouldValidateDestination() throws Throwable {
+        AuthnRequest request = eidasAuthnRequestBuilder.build();
+        final String destination = request.getDestination();
+
+        eidasAuthnRequestValidator.validate(request);
+        verify(destinationValidator, times(1)).validate(destination);
+    }
+}

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.MediaType;
 import static org.junit.Assert.assertEquals;
 
 public class EidasSamlResourceTest {
+
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
         .addResource(new EidasSamlResource())

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/signing/SoftHSMKeyRetrieverService.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/signing/SoftHSMKeyRetrieverService.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.notification.signing;
 
-
 import org.opensaml.security.credential.Credential;
 import se.swedenconnect.opensaml.pkcs11.PKCS11Provider;
 import se.swedenconnect.opensaml.pkcs11.configuration.PKCS11ProviderConfiguration;


### PR DESCRIPTION
- The ESP will be now be responsible for validating the eIDAS authn request
from the connector code. Set up the ESP with the classes and config needed
to carry out this validation but don't tie it into the resource yet. Will do that in a separate PR. 
- Add tests for the ESP validation
- Put in the bones in the Application class. 
- Place variables in config.yml as a placeholder, these aren't currently being set anywhere. The DefaultNotUsed will be removed once they are. 
- Add connector metadata configuration in the ESP, so the connector metadata bundle can be created to validate the Authn Request 
- Add Redis configuration so that it can validate the Message Replay on the Request 