### PR TITLE
store RelayState sent by country in order to send back with eiDAS SAML Response

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2.java
@@ -70,7 +70,7 @@ public class EidasAuthnRequestResourceV2 {
     private View handleAuthnRequest(String encodedEidasAuthnRequest, String eidasRelayState, HttpSession session) {
         final EidasSamlParserResponse eidasSamlParserResponse = parseEidasRequest(encodedEidasAuthnRequest);
         VSPAuthnRequestResponse vspResponse = generateHubRequestWithVSP();
-        logAuthnRequestInformation(session, eidasSamlParserResponse, vspResponse);
+        logAuthnRequestInformation(session, eidasSamlParserResponse, vspResponse, eidasRelayState);
         setResponseDataInSession(session, eidasSamlParserResponse, vspResponse, eidasRelayState);
         return buildSamlFormView(vspResponse, eidasRelayState);
     }
@@ -97,7 +97,8 @@ public class EidasAuthnRequestResourceV2 {
         return samlFormViewBuilder.buildRequest(hubUrl.toString(), samlRequest, SUBMIT_BUTTON_TEXT, relayState);
     }
 
-    private void logAuthnRequestInformation(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, VSPAuthnRequestResponse vspResponse) {
+    private void logAuthnRequestInformation(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, VSPAuthnRequestResponse vspResponse, String relayState) {
+        log.info(String.format("[eIDAS AuthnRequest] RelayState: '%s'", relayState));
         log.info(String.format("[eIDAS AuthnRequest] Session ID: '%s'", session.getId()));
         log.info(String.format("[eIDAS AuthnRequest] eIDAS Request ID: '%s'", eidasSamlParserResponse.getRequestId()));
         log.info(String.format("[eIDAS AuthnRequest] eIDAS Issuer: '%s'", eidasSamlParserResponse.getIssuer()));

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2.java
@@ -33,6 +33,7 @@ public class EidasAuthnRequestResourceV2 {
     public static final String SESSION_KEY_EIDAS_DESTINATION = "eidas_destination";
     public static final String SESSION_KEY_HUB_REQUEST_ID = "hub_request_id";
     public static final String SUBMIT_BUTTON_TEXT = "Post Verify Authn Request to Hub";
+    public static final String SESSION_KEY_EIDAS_RELAY_STATE = "eidas_relay_state";
 
     private final EidasSamlParserService eidasSamlParserService;
     private final VSPService vspService;
@@ -70,14 +71,15 @@ public class EidasAuthnRequestResourceV2 {
         final EidasSamlParserResponse eidasSamlParserResponse = parseEidasRequest(encodedEidasAuthnRequest);
         VSPAuthnRequestResponse vspResponse = generateHubRequestWithVSP();
         logAuthnRequestInformation(session, eidasSamlParserResponse, vspResponse);
-        setResponseDataInSession(session, eidasSamlParserResponse, vspResponse);
+        setResponseDataInSession(session, eidasSamlParserResponse, vspResponse, eidasRelayState);
         return buildSamlFormView(vspResponse, eidasRelayState);
     }
 
-    private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, VSPAuthnRequestResponse vspResponse) {
+    private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, VSPAuthnRequestResponse vspResponse, String eidasRelayState) {
         session.setAttribute(SESSION_KEY_EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
         session.setAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_KEY, eidasSamlParserResponse.getConnectorPublicEncryptionKey());
         session.setAttribute(SESSION_KEY_EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
+        session.setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, eidasRelayState);
         session.setAttribute(SESSION_KEY_HUB_REQUEST_ID, vspResponse.getRequestId());
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2Test.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2Test.java
@@ -117,7 +117,7 @@ public class EidasAuthnRequestResourceV2Test {
         verify(session).setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, "eidas relay state");
         verify(session).setAttribute(SESSION_KEY_HUB_REQUEST_ID, "hub request id");
         verify(session).getId();
-        verify(logHandler, times(7)).publish(captorLoggingEvent.capture());
+        verify(logHandler, times(8)).publish(captorLoggingEvent.capture());
         verify(eidasSamlParserService).parse(captorEidasSamlParserRequest.capture());
         verify(vspService).generateAuthnRequest();
         verify(samlFormViewBuilder).buildRequest("http://hub.bub", "hub blob", SUBMIT_BUTTON_TEXT, "eidas relay state");
@@ -127,6 +127,7 @@ public class EidasAuthnRequestResourceV2Test {
         List<LogRecord> allLogRecords = captorLoggingEvent.getAllValues();
 
         List<String> expectedLogOutput = Lists.newArrayList(
+                "eidas relay state",
                 "some session id",
                 "eidas request id",
                 "issuer",

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2Test.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceV2Test.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_KEY;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SESSION_KEY_EIDAS_DESTINATION;
+import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SESSION_KEY_EIDAS_RELAY_STATE;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SESSION_KEY_EIDAS_REQUEST_ID;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SESSION_KEY_HUB_REQUEST_ID;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResourceV2.SUBMIT_BUTTON_TEXT;
@@ -113,6 +114,7 @@ public class EidasAuthnRequestResourceV2Test {
         verify(session).setAttribute(SESSION_KEY_EIDAS_REQUEST_ID, "eidas request id");
         verify(session).setAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_KEY, "abcdefghijk");
         verify(session).setAttribute(SESSION_KEY_EIDAS_DESTINATION, "destination");
+        verify(session).setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, "eidas relay state");
         verify(session).setAttribute(SESSION_KEY_HUB_REQUEST_ID, "hub request id");
         verify(session).getId();
         verify(logHandler, times(7)).publish(captorLoggingEvent.capture());


### PR DESCRIPTION
A small PR to store the RelayState sent by the country as part of its Authn request.
The RelayState is stored in the http session, and logged.