### PR TITLE
EID-1305 - Validate signature of eidas authn request

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -15,10 +15,14 @@ import uk.gov.ida.notification.eidassaml.saml.validation.components.ComparisonVa
 import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestIssuerValidator;
 import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestedAttributesValidator;
 import uk.gov.ida.notification.eidassaml.saml.validation.components.SpTypeValidator;
+import uk.gov.ida.notification.saml.converters.AuthnRequestParameterProvider;
 import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
 import uk.gov.ida.notification.saml.validation.components.LoaValidator;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
+import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
+
+import static uk.gov.ida.notification.saml.SamlSignatureValidatorFactory.createSamlRequestSignatureValidator;
 
 public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
 
@@ -63,7 +67,9 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
     @Override
     public void run(EidasSamlConfiguration configuration, Environment environment) throws Exception {
         EidasAuthnRequestValidator eidasAuthnRequestValidator = createEidasAuthnRequestValidator(configuration, connectorMetadataResolverBundle);
-        environment.jersey().register(new EidasSamlResource(eidasAuthnRequestValidator));
+        SamlRequestSignatureValidator samlRequestSignatureValidator = createSamlRequestSignatureValidator(connectorMetadataResolverBundle);
+
+        environment.jersey().register(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator));
     }
 
     private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlConfiguration configuration, MetadataResolverBundle hubMetadataResolverBundle) throws Exception {

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.notification.eidassaml;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Issuer;
+import se.litsec.opensaml.utils.ObjectUtils;
+import uk.gov.ida.notification.dto.EidasSamlParserRequest;
+import uk.gov.ida.notification.dto.EidasSamlParserResponse;
+import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
+import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doNothing;
+
+public class EidasSamlResourceTest {
+
+    private static EidasAuthnRequestValidator eidasAuthnRequestValidator = Mockito.mock(EidasAuthnRequestValidator.class);
+
+    private static SamlRequestSignatureValidator samlRequestSignatureValidator = Mockito.mock(SamlRequestSignatureValidator.class);
+
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator))
+            .build();
+
+    @Before
+    public void setup() throws Exception {
+        InitializationService.initialize();
+    }
+
+    @Test
+    public void shouldReturnRequestIdAndIssuer() throws Exception {
+        AuthnRequest authnRequest = ObjectUtils.createSamlObject(AuthnRequest.class);
+        Issuer issuer = ObjectUtils.createSamlObject(Issuer.class);
+        issuer.setValue("issuer");
+        authnRequest.setID("request_id");
+        authnRequest.setIssuer(issuer);
+
+        EidasSamlParserRequest request = new EidasSamlParserRequest(Base64.encodeAsString(ObjectUtils.toString(authnRequest)));
+        EidasSamlParserResponse response = resources.target("/eidasAuthnRequest")
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))
+                .readEntity(EidasSamlParserResponse.class);
+
+        assertEquals(response.getRequestId(), "request_id");
+        assertEquals(response.getIssuer(), "issuer");
+    }
+}

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -1,12 +1,9 @@
 package uk.gov.ida.notification.eidassaml.apprule;
 
-import org.apache.http.HttpStatus;
-import org.junit.Before;
-import org.junit.Test;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import uk.gov.ida.notification.eidassaml.ResponseDto;
-import uk.gov.ida.notification.eidassaml.apprule.EidasSamlParserAppRuleTestBase;
+import uk.gov.ida.notification.eidassaml.apprule.base.EidasSamlParserAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 
 import javax.ws.rs.core.Response;
@@ -14,28 +11,30 @@ import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathExpressionException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
 
     private EidasAuthnRequestBuilder request;
 
-    @Before
     public void setup() throws Throwable {
         request = new EidasAuthnRequestBuilder().withIssuer(CONNECTOR_NODE_ENTITY_ID);
     }
 
-    @Test
     public void shouldReturnRequestIdAndIssuer() throws XPathExpressionException, MarshallingException, TransformerException{
         AuthnRequest postedRequest = request
-                .withRequestId("request_id")
-                .withIssuer("issuer")
+                .withRandomRequestId()
                 .build();
+        samlObjectSigner.sign(postedRequest);
+
         Response response = postEidasAuthnRequest(postedRequest);
+
+        if (response.getStatus() != 200) {
+            fail("Unsuccessful Response");
+        }
         ResponseDto responseDto = response.readEntity(ResponseDto.class);
 
         assertEquals(responseDto.requestId, "request_id");
-        assertEquals(responseDto.issuer, "issuer");
+        assertEquals(responseDto.issuer, CONNECTOR_NODE_ENTITY_ID);
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/rules/EidasSamlParserAppRule.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/rules/EidasSamlParserAppRule.java
@@ -1,4 +1,4 @@
-package uk.gov.ida.notification.eidassaml.apprule;
+package uk.gov.ida.notification.eidassaml.apprule.rules;
 
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/EidasAuthnRequestValidatorTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/EidasAuthnRequestValidatorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.ida.notification.eidassaml;
+package uk.gov.ida.notification.eidassaml.saml;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
@@ -14,16 +14,16 @@ import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidat
 public class SamlSignatureValidatorFactory {
 
 
-    public static SamlMessageSignatureValidator createSamlMessageSignatureValidator(MetadataResolverBundle hubMetadataResolverBundle) throws ComponentInitializationException {
-        MetadataCredentialResolver hubMetadataCredentialResolver = hubMetadataResolverBundle.getMetadataCredentialResolver();
+    public static SamlMessageSignatureValidator createSamlMessageSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
+        MetadataCredentialResolver metadataCredentialResolver = metadataResolverBundle.getMetadataCredentialResolver();
         KeyInfoCredentialResolver keyInfoCredentialResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
-        ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine = new ExplicitKeySignatureTrustEngine(hubMetadataCredentialResolver, keyInfoCredentialResolver);
+        ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine = new ExplicitKeySignatureTrustEngine(metadataCredentialResolver, keyInfoCredentialResolver);
         MetadataBackedSignatureValidator metadataBackedSignatureValidator = MetadataBackedSignatureValidator.withoutCertificateChainValidation(explicitKeySignatureTrustEngine);
         return new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
     }
 
-    public static SamlRequestSignatureValidator createSamlRequestSignatureValidator(MetadataResolverBundle hubMetadataResolverBundle) throws ComponentInitializationException {
-        SamlMessageSignatureValidator samlMessageSignatureValidator = createSamlMessageSignatureValidator(hubMetadataResolverBundle);
+    public static SamlRequestSignatureValidator createSamlRequestSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
+        SamlMessageSignatureValidator samlMessageSignatureValidator = createSamlMessageSignatureValidator(metadataResolverBundle);
         return new SamlRequestSignatureValidator(samlMessageSignatureValidator);
     }
 }


### PR DESCRIPTION
- Stop using app rule test for now
- Add unit test to test the resource of the ESP in isolation
- Validate the signature of the eidas authn request, using the connector metadata
- Rename variable variable in the SamlSignatureValidatorFactory to make them more generic 