### PR TITLE
EID-1312 - Extract encryption key from connector metadata

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -74,7 +74,9 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
         espMetadata = new Metadata(connectorMetadataResolverBundle.getMetadataCredentialResolver());
         EidasAuthnRequestValidator eidasAuthnRequestValidator = createEidasAuthnRequestValidator(configuration, connectorMetadataResolverBundle);
         SamlRequestSignatureValidator samlRequestSignatureValidator = createSamlRequestSignatureValidator(connectorMetadataResolverBundle);
-        environment.jersey().register(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator));
+        String x509EncryptionCert = getX509EncryptionCert(configuration);
+
+        environment.jersey().register(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator, x509EncryptionCert));
     }
 
     private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlConfiguration configuration, MetadataResolverBundle hubMetadataResolverBundle) throws Exception {
@@ -94,10 +96,10 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
         );
     }
 
-    public String getX509EncryptionCert(EidasSamlConfiguration eidasSamlConfiguration) {
+    public String getX509EncryptionCert(EidasSamlConfiguration configuration) {
 
         Credential credential = espMetadata.getCredential(UsageType.ENCRYPTION,
-                eidasSamlConfiguration.getConnectorMetadataConfiguration().getExpectedEntityId(),
+                configuration.getConnectorMetadataConfiguration().getExpectedEntityId(),
                 SPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         return credential.getPublicKey().toString();

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -22,10 +22,14 @@ public class EidasSamlResource {
 
     private EidasAuthnRequestValidator eidasAuthnRequestValidator;
     private SamlRequestSignatureValidator samlRequestSignatureValidator;
+    private String x509EncryptionCert;
 
-    public EidasSamlResource(EidasAuthnRequestValidator eidasAuthnRequestValidator, SamlRequestSignatureValidator samlRequestSignatureValidator) {
+    public EidasSamlResource(EidasAuthnRequestValidator eidasAuthnRequestValidator,
+                             SamlRequestSignatureValidator samlRequestSignatureValidator,
+                             String x509EncryptionCert) {
         this.eidasAuthnRequestValidator = eidasAuthnRequestValidator;
         this.samlRequestSignatureValidator = samlRequestSignatureValidator;
+        this.x509EncryptionCert = x509EncryptionCert;
     }
 
     @POST
@@ -41,6 +45,7 @@ public class EidasSamlResource {
 
         return new ResponseDto(
                 authnRequest.getID(),
-                authnRequest.getIssuer().getValue());
+                authnRequest.getIssuer().getValue(),
+                x509EncryptionCert);
     }
 }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/ResponseDto.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/ResponseDto.java
@@ -10,10 +10,26 @@ public class ResponseDto {
     @JsonProperty
     public String issuer;
 
+    @JsonProperty
+    public String connectorPublicEncryptionKey;
+
     public ResponseDto() {}
 
-    public ResponseDto(String requestId, String issuer) {
+    public ResponseDto(String requestId, String issuer, String connectorPublicEncryptionKey) {
         this.requestId = requestId;
         this.issuer = issuer;
+        this.connectorPublicEncryptionKey = connectorPublicEncryptionKey;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public String getConnectorPublicEncryptionKey() {
+        return connectorPublicEncryptionKey;
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -11,7 +11,6 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Issuer;
 import se.litsec.opensaml.utils.ObjectUtils;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
-import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
 import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
 
@@ -19,7 +18,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doNothing;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 
 public class EidasSamlResourceTest {
 
@@ -29,7 +28,7 @@ public class EidasSamlResourceTest {
 
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
-            .addResource(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator))
+            .addResource(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator, TEST_RP_PUBLIC_ENCRYPTION_CERT))
             .build();
 
     @Before

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -46,10 +46,10 @@ public class EidasSamlResourceTest {
         authnRequest.setIssuer(issuer);
 
         EidasSamlParserRequest request = new EidasSamlParserRequest(Base64.encodeAsString(ObjectUtils.toString(authnRequest)));
-        EidasSamlParserResponse response = resources.target("/eidasAuthnRequest")
+        ResponseDto response = resources.target("/eidasAuthnRequest")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))
-                .readEntity(EidasSamlParserResponse.class);
+                .readEntity(ResponseDto.class);
 
         assertEquals(response.getRequestId(), "request_id");
         assertEquals(response.getIssuer(), "issuer");


### PR DESCRIPTION
- We need to send the encryption key from the connector metadata to the gateway, so extract it. Use the DTO in the VSP for now until the destination and been retrieved from the connector metadata 
- See MetadataTest.java for tests that check the functionally which extracts the public encryption key. I would like to add IntegrationTests for this at some point in the future. 