### PR TITLE
EID-1312 - Extract encryption cert out of connector metadata

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -22,10 +22,14 @@ public class EidasSamlResource {
 
     private EidasAuthnRequestValidator eidasAuthnRequestValidator;
     private SamlRequestSignatureValidator samlRequestSignatureValidator;
+    private String x509EncryptionCert;
 
-    public EidasSamlResource(EidasAuthnRequestValidator eidasAuthnRequestValidator, SamlRequestSignatureValidator samlRequestSignatureValidator) {
+    public EidasSamlResource(EidasAuthnRequestValidator eidasAuthnRequestValidator,
+                             SamlRequestSignatureValidator samlRequestSignatureValidator,
+                             String x509EncryptionCert) {
         this.eidasAuthnRequestValidator = eidasAuthnRequestValidator;
         this.samlRequestSignatureValidator = samlRequestSignatureValidator;
+        this.x509EncryptionCert = x509EncryptionCert;
     }
 
     @POST
@@ -41,6 +45,7 @@ public class EidasSamlResource {
 
         return new ResponseDto(
                 authnRequest.getID(),
-                authnRequest.getIssuer().getValue());
+                authnRequest.getIssuer().getValue(),
+                x509EncryptionCert);
     }
 }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/ResponseDto.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/ResponseDto.java
@@ -10,10 +10,26 @@ public class ResponseDto {
     @JsonProperty
     public String issuer;
 
+    @JsonProperty
+    public String connectorPublicEncryptionKey;
+
     public ResponseDto() {}
 
-    public ResponseDto(String requestId, String issuer) {
+    public ResponseDto(String requestId, String issuer, String connectorPublicEncryptionKey) {
         this.requestId = requestId;
         this.issuer = issuer;
+        this.connectorPublicEncryptionKey = connectorPublicEncryptionKey;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public String getConnectorPublicEncryptionKey() {
+        return connectorPublicEncryptionKey;
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -46,10 +46,10 @@ public class EidasSamlResourceTest {
         authnRequest.setIssuer(issuer);
 
         EidasSamlParserRequest request = new EidasSamlParserRequest(Base64.encodeAsString(ObjectUtils.toString(authnRequest)));
-        EidasSamlParserResponse response = resources.target("/eidasAuthnRequest")
+        ResponseDto response = resources.target("/eidasAuthnRequest")
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON_TYPE))
-                .readEntity(EidasSamlParserResponse.class);
+                .readEntity(ResponseDto.class);
 
         assertEquals(response.getRequestId(), "request_id");
         assertEquals(response.getIssuer(), "issuer");

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -11,7 +11,6 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.Issuer;
 import se.litsec.opensaml.utils.ObjectUtils;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
-import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
 import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
 
@@ -19,7 +18,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doNothing;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 
 public class EidasSamlResourceTest {
 
@@ -29,7 +28,7 @@ public class EidasSamlResourceTest {
 
     @ClassRule
     public static final ResourceTestRule resources = ResourceTestRule.builder()
-            .addResource(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator))
+            .addResource(new EidasSamlResource(eidasAuthnRequestValidator, samlRequestSignatureValidator, TEST_RP_PUBLIC_ENCRYPTION_CERT))
             .build();
 
     @Before
@@ -53,5 +52,6 @@ public class EidasSamlResourceTest {
 
         assertEquals(response.getRequestId(), "request_id");
         assertEquals(response.getIssuer(), "issuer");
+        assertEquals(response.getConnectorPublicEncryptionKey(), TEST_RP_PUBLIC_ENCRYPTION_CERT);
     }
 }


### PR DESCRIPTION
- Pull public encryption cert out of the connector metadata and store in the DTO. Will swap to the shared DTO with the Gateway once I have the destination. 