### PR TITLE
Introduce VSP chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,7 @@ proxy-node-translator/src/dist/proxy_node_signing.*
 .helm_values.yml
 pki/test/.test-metadata
 testreport/
+.project
+.classpath
+.settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,6 @@ services:
       context: .
       args:
         component: stub-connector
-  eidas-saml-provider:
-    image: govukverify/eidas-saml-provider:latest
-    build:
-      context: .
-      args:
-        component: eidas-saml-provider
   softhsm:
     image: govukverify/softhsm:latest
     build:

--- a/pki/generate
+++ b/pki/generate
@@ -101,7 +101,7 @@ hub_config_for_proxy_node = {
   'id' => 'VERIFY-HUB',
   'entity_id' => options.idp_entity_id,
   'assertion_consumer_service_uri' => "#{options.proxy_url}/SAML2/SSO/Response/POST",
-  'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'http://dev-hub.local' },
+  'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'https://dev-hub.local' },
   'signing_certificates' => [
     { 'name' => 'hub_signing', 'x509' => strip_pem(idp_signing_keypair.cert.to_pem) }
   ],
@@ -125,7 +125,7 @@ hub_config_for_idp = {
     'id' => 'VERIFY-HUB',
     'entity_id' => options.hub_entity_id,
     'assertion_consumer_service_uri' => "#{options.proxy_url}/SAML2/SSO/Response/POST",
-    'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'http://dev-hub.local' },
+    'organization' => { 'name' => 'Hub', 'display_name' => 'Hub', 'url' => 'https://dev-hub.local' },
     'signing_certificates' => [
         { 'name' => 'hub_signing', 'x509' => strip_pem(hub_signing_keypair.cert.to_pem) }
     ],
@@ -172,7 +172,7 @@ Dir.chdir(output_dir) do
 
   proxy_node_vars = {
     'HUB_ENTITY_ID' => options.hub_entity_id,
-    'HUB_URL' => "#{options.idp_url}/stub-idp-demo/SAML2/SSO",
+    'HUB_URL' => "#{options.idp_url}/SAML2/SSO",
     'SIGNING_CERT' => b64(proxy_signing_keypair.cert.to_pem),
     'SIGNING_KEY' => b64(der2pk8(proxy_signing_keypair.key.to_der)),
     'SIGNING_PRIVATE_KEY_SOFTHSM' => b64(der2p8(proxy_signing_keypair.key.to_der)),
@@ -211,6 +211,24 @@ Dir.chdir(output_dir) do
     'STUB_COUNTRY_SIGNING_CERT' => b64(idp_signing_keypair.cert.to_pem),
     'METADATA_TRUSTSTORE' => b64(metadata_truststore),
     'METADATA_TRUSTSTORE_PASSWORD' => options.truststore_pass,
+  }
+
+  vsp_vars = {
+    'LOG_LEVEL' => 'INFO',
+    'CLOCK_SKEW' => 'PT30s',
+    'SERVICE_ENTITY_IDS' => "[\"#{options.proxy_entity_id}\"]",
+    'VERIFY_ENVIRONMENT' => 'COMPLIANCE_TOOL',
+    'SSO_LOCATION' => "#{options.idp_url}/SAML2/SSO/",
+    'HUB_METADATA_ENTITY_ID' => options.idp_entity_id,
+    'TRUST_STORE' => b64(metadata_truststore),
+    'TRUST_STORE_PASSWORD' => options.truststore_pass,
+    'HUB_TRUST_STORE' => b64(metadata_truststore),
+    'HUB_TRUST_STORE_PASSWORD' => options.truststore_pass,
+    'IDP_TRUST_STORE' => b64(metadata_truststore),
+    'IDP_TRUST_STORE_PASSWORD' => options.truststore_pass,
+    'SAML_SIGNING_KEY' => b64(der2pk8(hub_signing_keypair.key.to_der)),
+    'SAML_PRIMARY_ENCRYPTION_KEY' => b64(der2pk8(hub_encryption_keypair.key.to_der)),
+    'SAML_SECONDARY_ENCRYPTION_KEY' => b64(der2pk8(hub_encryption_keypair.key.to_der)),
   }
 
   if options.do_files
@@ -286,6 +304,12 @@ Dir.chdir(output_dir) do
       cfg['data']['metadata_for_connector_node.xml'] = b64(proxy_node_metadata_xml_signed)
     end
     create_file('metadata-secret.yaml', YAML.dump(secret))
+
+    secret = YAML.load_file(SECRET).tap do |cfg|
+      cfg['metadata']['name'] = 'verify-service-provider'
+      cfg['data'] = vsp_vars.inject({}) { |vars, (key, value)| vars[key] = b64(value); vars }
+    end
+    create_file('verify-service-provider-secret.yaml', YAML.dump(secret))
   end
 
   if options.do_env

--- a/pki/generate
+++ b/pki/generate
@@ -216,7 +216,7 @@ Dir.chdir(output_dir) do
   vsp_vars = {
     'LOG_LEVEL' => 'INFO',
     'CLOCK_SKEW' => 'PT30s',
-    'SERVICE_ENTITY_IDS' => "[\"#{options.proxy_entity_id}\"]",
+    'SERVICE_ENTITY_IDS' => "[\"http://verify-service-provider/\"]",
     'VERIFY_ENVIRONMENT' => 'COMPLIANCE_TOOL',
     'SSO_LOCATION' => "#{options.idp_url}/SAML2/SSO/",
     'HUB_METADATA_ENTITY_ID' => options.idp_entity_id,

--- a/proxy-node-chart/charts/verify-service-provider/.helmignore
+++ b/proxy-node-chart/charts/verify-service-provider/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/proxy-node-chart/charts/verify-service-provider/Chart.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: verify-service-provider
+version: 0.1.0

--- a/proxy-node-chart/charts/verify-service-provider/templates/_helpers.tpl
+++ b/proxy-node-chart/charts/verify-service-provider/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "verify-service-provider.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "verify-service-provider.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "verify-service-provider.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/proxy-node-chart/charts/verify-service-provider/templates/config.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/templates/config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "verify-service-provider.name" . }}
+    chart: {{ template "verify-service-provider.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "verify-service-provider.fullname" . }}
+data:
+  verify-service-provider.yaml: |-
+{{ toYaml .Values.configFile | indent 4 }}

--- a/proxy-node-chart/charts/verify-service-provider/templates/deployment.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/templates/deployment.yaml
@@ -1,0 +1,142 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "verify-service-provider.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "verify-service-provider.name" . }}
+    helm.sh/chart: {{ include "verify-service-provider.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "verify-service-provider.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "verify-service-provider.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - bin/verify-service-provider
+          args:
+            - server
+            - /etc/vsp/verify-service-provider.yaml
+          env:
+            - name: LOG_LEVEL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: LOG_LEVEL
+            - name: CLOCK_SKEW
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: CLOCK_SKEW
+            - name: SERVICE_ENTITY_IDS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: SERVICE_ENTITY_IDS
+            - name: VERIFY_ENVIRONMENT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: VERIFY_ENVIRONMENT
+            - name: SSO_LOCATION
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: SSO_LOCATION
+            - name: HUB_METADATA_URI
+              value: http://{{ .Release.Name }}-stub-metadata/hub_metadata_for_proxy_node.xml
+            - name: HUB_METADATA_ENTITY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: HUB_METADATA_ENTITY_ID
+            - name: TRUST_STORE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: TRUST_STORE
+            - name: TRUST_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: TRUST_STORE_PASSWORD
+            - name: HUB_TRUST_STORE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: HUB_TRUST_STORE
+            - name: HUB_TRUST_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: HUB_TRUST_STORE_PASSWORD
+            - name: IDP_TRUST_STORE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: IDP_TRUST_STORE
+            - name: IDP_TRUST_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: IDP_TRUST_STORE_PASSWORD
+            - name: SAML_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: SAML_SIGNING_KEY
+            - name: SAML_PRIMARY_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: SAML_PRIMARY_ENCRYPTION_KEY
+            - name: SAML_SECONDARY_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keySecretName }}
+                  key: SAML_SECONDARY_ENCRYPTION_KEY
+          ports:
+            - name: http
+              containerPort: 50400
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /admin/healthcheck
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /admin/healthcheck
+              port: http
+          volumeMounts:
+            - name: config
+              mountPath: /etc/vsp/verify-service-provider.yaml
+              subPath: verify-service-provider.yaml
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "verify-service-provider.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/proxy-node-chart/charts/verify-service-provider/templates/service.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "verify-service-provider.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "verify-service-provider.name" . }}
+    helm.sh/chart: {{ include "verify-service-provider.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "verify-service-provider.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/proxy-node-chart/charts/verify-service-provider/values.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/values.yaml
@@ -1,0 +1,75 @@
+# Default values for verify-service-provider.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: govukverify/verify-service-provider
+  tag: "latest"
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+keySecretName: verify-service-provider
+
+configFile:
+  server:
+    type: simple
+    applicationContextPath: /
+    adminContextPath: /admin
+    connector:
+      type: http
+      port: ${PORT:-50400}
+  logging:
+    level: ${LOG_LEVEL:-INFO}
+    appenders:
+      - type: console
+  clockSkew: ${CLOCK_SKEW:-PT30s}
+  serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
+  verifyHubConfiguration:
+    environment: ${VERIFY_ENVIRONMENT:-}
+    ssoLocation: ${SSO_LOCATION:-}
+    metadata:
+      uri: ${HUB_METADATA_URI:-}
+      expectedEntityId: ${HUB_METADATA_ENTITY_ID:-}
+      hubFederationId: VERIFY-FEDERATION
+      trustStore:
+        type: encoded
+        store: ${TRUST_STORE:-}
+        password: ${TRUST_STORE_PASSWORD:-marshmallow}
+      hubTrustStore:
+        type: encoded
+        store: ${HUB_TRUST_STORE:-}
+        password: ${HUB_TRUST_STORE_PASSWORD:-marshmallow}
+      idpTrustStore:
+        type: encoded
+        store: ${IDP_TRUST_STORE:-}
+        password: ${IDP_TRUST_STORE_PASSWORD:-marshmallow}
+  samlSigningKey: ${SAML_SIGNING_KEY:-}
+  samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
+  samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
+
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/proxy-node-chart/charts/verify-service-provider/values.yaml
+++ b/proxy-node-chart/charts/verify-service-provider/values.yaml
@@ -30,23 +30,6 @@ configFile:
   serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
   verifyHubConfiguration:
     environment: ${VERIFY_ENVIRONMENT:-}
-    ssoLocation: ${SSO_LOCATION:-}
-    metadata:
-      uri: ${HUB_METADATA_URI:-}
-      expectedEntityId: ${HUB_METADATA_ENTITY_ID:-}
-      hubFederationId: VERIFY-FEDERATION
-      trustStore:
-        type: encoded
-        store: ${TRUST_STORE:-}
-        password: ${TRUST_STORE_PASSWORD:-marshmallow}
-      hubTrustStore:
-        type: encoded
-        store: ${HUB_TRUST_STORE:-}
-        password: ${HUB_TRUST_STORE_PASSWORD:-marshmallow}
-      idpTrustStore:
-        type: encoded
-        store: ${IDP_TRUST_STORE:-}
-        password: ${IDP_TRUST_STORE_PASSWORD:-marshmallow}
   samlSigningKey: ${SAML_SIGNING_KEY:-}
   samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
   samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}

--- a/startup.sh
+++ b/startup.sh
@@ -65,7 +65,7 @@ function generate_pki {
       --proxy-node-entity-id "http://proxy-node" \
       --connector-url "http://$(minikube ip):31100" \
       --proxy-url "http://$(minikube ip):31200" \
-      --idp-url "http://$(minikube ip):31300" \
+      --idp-url "http://$(minikube ip):31300/stub-idp-demo" \
       --softhsm \
       --secrets \
       "${PKI_OUTPUT_DIR}"


### PR DESCRIPTION
We're refactoring the behaviour and request journey through our system.
This involves adding two additional apps responsible for validating the
SAML. ESP and VSP will be a crucial part of the system and they deserve
a Chart to define what they look like.

The generation script is somewhat extended to cover some additional
secrets. But it may be broken when it comes to running the setup
locally.