### PR TITLE
Store eIDAS RelayState in session

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -34,6 +34,7 @@ public class EidasAuthnRequestResource {
     public static final String SESSION_KEY_EIDAS_DESTINATION = "eidas_destination";
     public static final String SESSION_KEY_HUB_REQUEST_ID = "hub_request_id";
     public static final String SUBMIT_BUTTON_TEXT = "Post Verify Authn Request to Hub";
+    public static final String SESSION_KEY_EIDAS_RELAY_STATE = "eidas_relay_state";
 
     private final EidasSamlParserProxy eidasSamlParserService;
     private final VerifyServiceProviderProxy vspProxy;
@@ -71,14 +72,15 @@ public class EidasAuthnRequestResource {
         final EidasSamlParserResponse eidasSamlParserResponse = parseEidasRequest(encodedEidasAuthnRequest);
         AuthnRequestResponse vspResponse = generateHubRequestWithVSP();
         logAuthnRequestInformation(session, eidasSamlParserResponse, vspResponse);
-        setResponseDataInSession(session, eidasSamlParserResponse, vspResponse);
+        setResponseDataInSession(session, eidasSamlParserResponse, vspResponse, eidasRelayState);
         return buildSamlFormView(vspResponse, eidasRelayState);
     }
 
-    private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, AuthnRequestResponse vspResponse) {
+    private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, AuthnRequestResponse vspResponse, String eidasRelayState) {
         session.setAttribute(SESSION_KEY_EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
         session.setAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT, eidasSamlParserResponse.getConnectorEncryptionPublicCertificate());
         session.setAttribute(SESSION_KEY_EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
+        session.setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, eidasRelayState);
         session.setAttribute(SESSION_KEY_HUB_REQUEST_ID, vspResponse.getRequestId());
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SESSION_KEY_EIDAS_DESTINATION;
+import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SESSION_KEY_EIDAS_RELAY_STATE;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SESSION_KEY_EIDAS_REQUEST_ID;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SESSION_KEY_HUB_REQUEST_ID;
 import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SUBMIT_BUTTON_TEXT;
@@ -115,6 +116,7 @@ public class EidasAuthnRequestResourceTest {
         verify(session).setAttribute(SESSION_KEY_EIDAS_REQUEST_ID, "eidas request id");
         verify(session).setAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT, UNCHAINED_PUBLIC_CERT);
         verify(session).setAttribute(SESSION_KEY_EIDAS_DESTINATION, "destination");
+        verify(session).setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, "eidas relay state");
         verify(session).setAttribute(SESSION_KEY_HUB_REQUEST_ID, "hub request id");
         verify(session).getId();
         verify(logHandler, times(7)).publish(captorLoggingEvent.capture());


### PR DESCRIPTION
Store the `RelayState` sent by the country in the gateway http session.
We can then send this `RelayState` within the eiDAS SAML Response.