### PR TITLE
EID-1322: Return an eIDAS SAML response with correct values

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponse.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponse.java
@@ -8,7 +8,7 @@ public class TranslatedHubResponse {
 
     @NotNull
     @JsonProperty
-    private String scenario;
+    private VspScenario scenario;
 
     @NotNull
     @JsonProperty
@@ -16,7 +16,7 @@ public class TranslatedHubResponse {
 
     @NotNull
     @JsonProperty
-    private String levelOfAssurance;
+    private VspLevelOfAssurance levelOfAssurance;
 
     @NotNull
     @JsonProperty
@@ -27,9 +27,9 @@ public class TranslatedHubResponse {
     }
 
     public TranslatedHubResponse(
-            String scenario,
+            VspScenario scenario,
             String pid,
-            String levelOfAssurance,
+            VspLevelOfAssurance levelOfAssurance,
             Attributes attributes) {
         this.scenario = scenario;
         this.pid = pid;
@@ -37,7 +37,7 @@ public class TranslatedHubResponse {
         this.attributes = attributes;
     }
 
-    public String getScenario() {
+    public VspScenario getScenario() {
         return scenario;
     }
 
@@ -45,7 +45,7 @@ public class TranslatedHubResponse {
         return pid;
     }
 
-    public String getLevelOfAssurance() {
+    public VspLevelOfAssurance getLevelOfAssurance() {
         return levelOfAssurance;
     }
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/VspLevelOfAssurance.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/VspLevelOfAssurance.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.notification.contracts.verifyserviceprovider;
+
+public enum VspLevelOfAssurance {
+    LEVEL_1,
+    LEVEL_2
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/VspScenario.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/VspScenario.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.notification.contracts.verifyserviceprovider;
+
+public enum VspScenario {
+    IDENTITY_VERIFIED,
+    CANCELLATION,
+    AUTHENTICATION_FAILED,
+    REQUEST_ERROR
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/ApplicationExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/ApplicationExceptionMapper.java
@@ -9,7 +9,10 @@ import static java.text.MessageFormat.format;
 public class ApplicationExceptionMapper extends BaseExceptionMapper<ApplicationException> {
 
     @Override
-    protected Response handleException(ApplicationException exception) {
+    protected void handleException(ApplicationException exception) { }
+
+    @Override
+    protected Response getResponse(ApplicationException exception) {
         final String message = format("Exception with id {0} of type {1} whilst contacting uri [{2}]: {3}",
                 exception.getErrorId(), exception.getExceptionType(), exception.getUri(), exception.getMessage());
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message).build();

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/AuthnRequestExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/AuthnRequestExceptionMapper.java
@@ -5,30 +5,23 @@ import uk.gov.ida.notification.exceptions.authnrequest.AuthnRequestException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-public class AuthnRequestExceptionMapper implements ExceptionMapper<AuthnRequestException> {
-    private final Logger log = Logger.getLogger(getClass().getName());
+public class AuthnRequestExceptionMapper extends BaseExceptionMapper<AuthnRequestException> {
 
     @Override
-    public Response toResponse(AuthnRequestException exception) {
-        String message = exception.getCause().getMessage();
-        String logId = String.format("%016x", ThreadLocalRandom.current().nextLong());
-
-        log.log(Level.WARNING, String.format("Error for logId: %s; requestId: %s; issuer: %s; issueInstant: %s; cause: %s",
-                logId,
+    protected void handleException(AuthnRequestException exception) {
+        setAuthnRequestValues(
                 exception.getAuthnRequest().getID(),
                 exception.getAuthnRequest().getIssuer().getValue(),
-                exception.getAuthnRequest().getIssueInstant(),
-                message)
+                exception.getAuthnRequest().getIssueInstant()
         );
+    }
 
+    @Override
+    protected Response getResponse(AuthnRequestException exception) {
         return Response.status(Response.Status.BAD_REQUEST)
                 .type(MediaType.APPLICATION_JSON_TYPE)
-                .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(), "Error handling authn request. logId: " + logId))
+                .entity(new ErrorMessage(Response.Status.BAD_REQUEST.getStatusCode(), "Error handling authn request. logId: " + getLogId()))
                 .build();
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/HubResponseExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/HubResponseExceptionMapper.java
@@ -5,34 +5,28 @@ import uk.gov.ida.notification.exceptions.hubresponse.HubResponseException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
 import java.text.MessageFormat;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-public class HubResponseExceptionMapper implements ExceptionMapper<HubResponseException> {
-    private final Logger log = Logger.getLogger(getClass().getName());
+public class HubResponseExceptionMapper extends BaseExceptionMapper<HubResponseException> {
 
     @Override
-    public Response toResponse(HubResponseException exception) {
-        String logId = String.format("%016x", ThreadLocalRandom.current().nextLong());
-
-        log.log(Level.WARNING, String.format("logId=%s, requestId=%s, issuer=%s, issueInstant=%s, cause=%s",
-                logId,
+    protected void handleException(HubResponseException exception) {
+        setAuthnRequestValues(
                 exception.getSamlResponse().getID(),
                 exception.getSamlResponse().getIssuer().getValue(),
-                exception.getSamlResponse().getIssueInstant(),
-                exception.getCause())
-        );
+                exception.getSamlResponse().getIssueInstant());
+    }
 
-        String message = MessageFormat.format("Error handling hub response. logId: {0}", logId);
+    @Override
+    protected Response getResponse(HubResponseException exception) {
+        String message = MessageFormat.format("Error handling hub response. logId: {0}", getLogId());
+
         return Response.status(Response.Status.BAD_REQUEST)
                 .type(MediaType.APPLICATION_JSON_TYPE)
                 .entity(
-                    new ErrorMessage(
-                        Response.Status.BAD_REQUEST.getStatusCode(),
-                        message
+                        new ErrorMessage(
+                                Response.Status.BAD_REQUEST.getStatusCode(),
+                                message
                         ))
                 .build();
     }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/HubResponseTranslationExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/HubResponseTranslationExceptionMapper.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.notification.exceptions.mappers;
+
+import uk.gov.ida.notification.exceptions.hubresponse.HubResponseTranslationException;
+
+import javax.ws.rs.core.Response;
+
+import static java.text.MessageFormat.format;
+
+public class HubResponseTranslationExceptionMapper extends BaseExceptionMapper<HubResponseTranslationException> {
+
+    @Override
+    protected void handleException(HubResponseTranslationException exception) { }
+
+    @Override
+    protected Response getResponse(HubResponseTranslationException exception) {
+        final String message = format("Error whilst handling hub response: {0}; {1}", exception.getMessage(), exception.getCause().getMessage());
+        return Response.status(Response.Status.BAD_REQUEST).entity(message).build();
+    }
+}

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -16,7 +16,6 @@ proxyNodeResponseUrl: ${PROXY_NODE_RESPONSE_ENDPOINT}
 proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
 
 hubUrl: ${HUB_URL}
-connectorNodeUrl: ${CONNECTOR_NODE_URL}
 connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
 
 replayChecker:

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -141,9 +141,9 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     private EidasResponseGenerator createEidasResponseGenerator(TranslatorConfiguration configuration) {
         HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
                 configuration.getConnectorNodeIssuerId(),
-                configuration.getConnectorNodeUrl().toString(),
                 configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
         );
+
         KeyRetrieverService keyRetrieverService = KeyRetrieverServiceFactory.createKeyRetrieverService(configuration);
         return new EidasResponseGenerator(hubResponseTranslator, keyRetrieverService.createSamlObjectSigner());
     }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -16,7 +16,7 @@ import se.litsec.opensaml.saml2.common.response.MessageReplayChecker;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.exceptions.mappers.ApplicationExceptionMapper;
-import uk.gov.ida.notification.exceptions.mappers.HubResponseExceptionMapper;
+import uk.gov.ida.notification.exceptions.mappers.HubResponseTranslationExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.pki.KeyPairConfiguration;
 import uk.gov.ida.notification.saml.ResponseAssertionFactory;
@@ -127,8 +127,8 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     }
 
     private void registerExceptionMappers(Environment environment) {
-        environment.jersey().register(new HubResponseExceptionMapper());
         environment.jersey().register(new ApplicationExceptionMapper());
+        environment.jersey().register(new HubResponseTranslationExceptionMapper());
     }
 
     private void registerResources(TranslatorConfiguration configuration, Environment environment) {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
@@ -21,11 +21,6 @@ public class TranslatorConfiguration extends Configuration {
     @JsonProperty
     @Valid
     @NotNull
-    private URI connectorNodeUrl;
-
-    @JsonProperty
-    @Valid
-    @NotNull
     private String proxyNodeEntityId;
 
     @JsonProperty
@@ -95,10 +90,6 @@ public class TranslatorConfiguration extends Configuration {
 
     public URI getHubUrl() {
         return hubUrl;
-    }
-
-    public URI getConnectorNodeUrl() {
-        return connectorNodeUrl;
     }
 
     public String getProxyNodeEntityId() {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
@@ -2,42 +2,51 @@ package uk.gov.ida.notification.translator.saml;
 
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.VspLevelOfAssurance;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.VspScenario;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
 
 import java.net.URI;
 
 public class HubResponseContainer {
-    private String eidasRequestId;
-    private String levelOfAssurance;
-    private URI destinationURL;
+
     private String pid;
+    private String eidasRequestId;
+    private URI destinationURL;
     private Attributes attributes;
+    private VspScenario vspScenario;
+    private VspLevelOfAssurance levelOfAssurance;
 
     public HubResponseContainer(HubResponseTranslatorRequest hubResponseTranslatorRequest, TranslatedHubResponse translatedHubResponse) {
-        this.eidasRequestId = hubResponseTranslatorRequest.getEidasRequestId();
-        this.levelOfAssurance = hubResponseTranslatorRequest.getLevelOfAssurance();
-        this.destinationURL = hubResponseTranslatorRequest.getDestinationUrl();
         this.pid = translatedHubResponse.getPid();
+        this.eidasRequestId = hubResponseTranslatorRequest.getEidasRequestId();
+        this.destinationURL = hubResponseTranslatorRequest.getDestinationUrl();
         this.attributes = translatedHubResponse.getAttributes();
-    }
-
-    public String getEidasRequestId() {
-        return eidasRequestId;
-    }
-
-    public String getLevelOfAssurance() {
-        return levelOfAssurance;
-    }
-
-    public URI getDestinationURL() {
-        return destinationURL;
+        this.vspScenario = translatedHubResponse.getScenario();
+        this.levelOfAssurance = translatedHubResponse.getLevelOfAssurance();
     }
 
     public String getPid() {
         return pid;
     }
 
+    public String getEidasRequestId() {
+        return eidasRequestId;
+    }
+
+    public String getDestinationURL() {
+        return destinationURL.toString();
+    }
+
     public Attributes getAttributes() {
         return attributes;
+    }
+
+    public VspScenario getVspScenario() {
+        return vspScenario;
+    }
+
+    public VspLevelOfAssurance getLevelOfAssurance() {
+        return levelOfAssurance;
     }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
@@ -47,7 +47,6 @@ public class TranslatorAppRuleTestBase {
             ConfigOverride.config("proxyNodeResponseUrl", "http://proxy-node/SAML2/SSO/Response"),
             ConfigOverride.config("proxyNodeMetadataForConnectorNodeUrl", "http://proxy-node.uk"),
             ConfigOverride.config("hubUrl", "http://hub"),
-            ConfigOverride.config("connectorNodeUrl", "http://connector-node:8080"),
             ConfigOverride.config("connectorNodeIssuerId", "http://connector-node:8080/ConnectorMetadata"),
             ConfigOverride.config("connectorMetadataConfiguration.url", metadataClientRule.baseUri() + "/connector-node/metadata"),
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri() + "/vsp"),

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/rules/VspClientRule.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/rules/VspClientRule.java
@@ -17,6 +17,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
+import static uk.gov.ida.notification.contracts.verifyserviceprovider.VspLevelOfAssurance.LEVEL_2;
+import static uk.gov.ida.notification.contracts.verifyserviceprovider.VspScenario.IDENTITY_VERIFIED;
+
 public class VspClientRule extends DropwizardClientRule {
     public VspClientRule() {
         super(new StubVspResource());
@@ -30,7 +33,7 @@ public class VspClientRule extends DropwizardClientRule {
         @POST
         @Path(Urls.VerifyServiceProviderUrls.TRANSLATE_HUB_RESPONSE_ENDPOINT)
         public TranslatedHubResponse getTranslatedHubResponse(HubResponseTranslatorRequest hubResponseTranslatorRequest) {
-            return new TranslatedHubResponse("IDENTITY_VERIFIED", "123456", "LEVEL_2", buildAttributes());
+            return new TranslatedHubResponse(IDENTITY_VERIFIED, "123456", LEVEL_2, buildAttributes());
         }
 
         private Attributes buildAttributes() {


### PR DESCRIPTION
Construct a valid SAML response that contains all the required attributes.

  - Add `HubResponseTranslationExceptionMapper`
  - Refactor exception mappers in pn-shared to extend the same base mapper
  - Supply correct values to the hub response translator