### PR TITLE
EID-1333 - Add Connector Metadata healthcheck to ESP

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/MetadataAppRuleTests.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/MetadataAppRuleTests.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.notification.eidassaml.apprule;
+
+import org.junit.Test;
+import uk.gov.ida.notification.eidassaml.apprule.base.EidasSamlParserAppRuleTestBase;
+
+import javax.ws.rs.core.Response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetadataAppRuleTests extends EidasSamlParserAppRuleTestBase {
+    @Test
+    public void shouldConsumeMetadata() throws Exception {
+        Response response = eidasSamlParserAppRule.target("healthcheck", eidasSamlParserAppRule.getAdminPort())
+            .request()
+            .get();
+
+        String healthcheck = response.readEntity(String.class);
+
+        assertThat(healthcheck).contains("\"connector-metadata\":{\"healthy\":true}");
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -118,12 +118,6 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
                 environment,
                 "hub-metadata");
 
-        registerMetadataHealthCheck(
-                connectorMetadataResolverBundle.getMetadataResolver(),
-                configuration.getConnectorMetadataConfiguration(),
-                environment,
-                "connector-metadata");
-
         registerProviders(environment);
         registerExceptionMappers(environment);
         registerResources(configuration, environment);

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/MetadataAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/MetadataAppRuleTests.java
@@ -16,7 +16,6 @@ public class MetadataAppRuleTests extends GatewayAppRuleTestBase {
 
         String healthcheck = response.readEntity(String.class);
 
-        assertThat(healthcheck).contains("\"connector-metadata\":{\"healthy\":true}");
         assertThat(healthcheck).contains("\"hub-metadata\":{\"healthy\":true}");
     }
 }


### PR DESCRIPTION
- The ESP will be the only component using the connector metadata, so
it makes sense for it to be running the healthcheck.
- Remove Connector Metadata healtcheck from Gateway
- Add Connector Metadata healthcheck test to ESP