### PR TITLE
EID-1334 Clean up gateway Application and Config

### DIFF
--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -11,17 +11,6 @@ logging:
   appenders:
     - type: logstash-console
 
-proxyNodeEntityId: ${PROXY_NODE_ENTITY_ID}
-proxyNodeAuthnRequestUrl: ${PROXY_NODE_AUTHN_REQUEST_ENDPOINT}
-proxyNodeResponseUrl: ${PROXY_NODE_RESPONSE_ENDPOINT}
-proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
-
-hubUrl: ${HUB_URL}
-connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
-
-replayChecker:
-  redisUrl: ${REDIS_SERVER_URI}
-
 eidasSamlParserService:
   url: ${EIDAS_SAML_PARSER_URL}
   clientConfig:
@@ -42,50 +31,3 @@ translatorService:
     timeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
     connectionTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
     connectionRequestTimeout: ${TRANSLATOR_CONNECTION_TIMEOUT:-5s}
-
-connectorMetadataConfiguration:
-  url: ${CONNECTOR_NODE_METADATA_URL}
-  expectedEntityId: ${CONNECTOR_NODE_ENTITY_ID}
-  jerseyClientName: connector-metadata-client
-  maxRefreshDelay: ${METADATA_REFRESH_DELAY:-600000}
-  trustStore:
-    type: ${TRUSTSTORE_TYPES:-encoded}
-    store: ${CONNECTOR_NODE_METADATA_TRUSTSTORE}
-    password: ${CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD}
-
-hubMetadataConfiguration:
-  url: ${HUB_METADATA_URL}
-  expectedEntityId: ${HUB_ENTITY_ID}
-  jerseyClientName: hub-metadata-client
-  maxRefreshDelay: ${METADATA_REFRESH_DELAY:-600000}
-  trustStore:
-    type: ${TRUSTSTORE_TYPES:-encoded}
-    store: ${HUB_METADATA_TRUSTSTORE}
-    password: ${HUB_METADATA_TRUSTSTORE_PASSWORD}
-
-connectorFacingSigningKeyPair:
-  publicKey:
-    type: ${CERT_TYPES:-encoded}
-    cert: ${SIGNING_CERT}
-    name: proxy_node_signing
-  privateKey:
-    type: ${KEY_TYPES:-encoded}
-    key: ${SIGNING_KEY}
-
-hubFacingSigningKeyPair:
-  publicKey:
-    type: ${CERT_TYPES:-encoded}
-    cert: ${HUB_FACING_SIGNING_CERT}
-    name: proxy_node_signing
-  privateKey:
-    type: ${KEY_TYPES:-encoded}
-    key: ${HUB_FACING_SIGNING_KEY}
-
-hubFacingEncryptionKeyPair:
-  publicKey:
-    type: ${CERT_TYPES:-encoded}
-    cert: ${HUB_FACING_ENCRYPTION_CERT}
-    name: proxy_node_encryption
-  privateKey:
-    type: ${KEY_TYPES:-encoded}
-    key: ${HUB_FACING_ENCRYPTION_KEY}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
@@ -3,22 +3,13 @@ package uk.gov.ida.notification;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import uk.gov.ida.notification.configuration.EidasSamlParserServiceConfiguration;
-import uk.gov.ida.notification.configuration.ReplayCheckerConfiguration;
 import uk.gov.ida.notification.configuration.TranslatorServiceConfiguration;
 import uk.gov.ida.notification.configuration.VerifyServiceProviderConfiguration;
-import uk.gov.ida.notification.pki.KeyPairConfiguration;
-import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import java.net.URI;
 
 public class GatewayConfiguration extends Configuration {
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private URI hubUrl;
 
     @JsonProperty
     @Valid
@@ -35,111 +26,9 @@ public class GatewayConfiguration extends Configuration {
     @NotNull
     private VerifyServiceProviderConfiguration verifyServiceProviderService;
 
-    @JsonProperty
-    @Valid
-    @NotNull
-    private String proxyNodeEntityId;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private URI proxyNodeAuthnRequestUrl;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private URI proxyNodeResponseUrl;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private URI proxyNodeMetadataForConnectorNodeUrl;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private KeyPairConfiguration connectorFacingSigningKeyPair;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private KeyPairConfiguration hubFacingSigningKeyPair;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private KeyPairConfiguration hubFacingEncryptionKeyPair;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private String connectorNodeIssuerId;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private TrustStoreBackedMetadataConfiguration connectorMetadataConfiguration;
-
-    @JsonProperty
-    @Valid
-    @NotNull
-    private TrustStoreBackedMetadataConfiguration hubMetadataConfiguration;
-
-    @JsonProperty
-    @Valid
-    private ReplayCheckerConfiguration replayChecker = new ReplayCheckerConfiguration();
-
-    public URI getHubUrl() {
-        return hubUrl;
-    }
-
     public TranslatorServiceConfiguration getTranslatorServiceConfiguration() { return translatorService; }
 
     public EidasSamlParserServiceConfiguration getEidasSamlParserServiceConfiguration() { return eidasSamlParserService; }
 
     public VerifyServiceProviderConfiguration getVerifyServiceProviderConfiguration() { return verifyServiceProviderService; }
-
-    public String getProxyNodeEntityId() {
-        return proxyNodeEntityId;
-    }
-
-    public KeyPairConfiguration getConnectorFacingSigningKeyPair() {
-        return connectorFacingSigningKeyPair;
-    }
-
-    public KeyPairConfiguration getHubFacingEncryptionKeyPair() {
-        return hubFacingEncryptionKeyPair;
-    }
-
-    public URI getProxyNodeMetadataForConnectorNodeUrl() {
-        return proxyNodeMetadataForConnectorNodeUrl;
-    }
-
-    public String getConnectorNodeIssuerId() {
-        return connectorNodeIssuerId;
-    }
-
-    public TrustStoreBackedMetadataConfiguration getConnectorMetadataConfiguration() {
-        return connectorMetadataConfiguration;
-    }
-
-    public TrustStoreBackedMetadataConfiguration getHubMetadataConfiguration() {
-        return hubMetadataConfiguration;
-    }
-
-    public KeyPairConfiguration getHubFacingSigningKeyPair() {
-        return hubFacingSigningKeyPair;
-    }
-
-    public URI getProxyNodeResponseUrl() {
-        return proxyNodeResponseUrl;
-    }
-
-    public URI getProxyNodeAuthnRequestUrl() {
-        return proxyNodeAuthnRequestUrl;
-    }
-
-    public ReplayCheckerConfiguration getReplayChecker() {
-        return replayChecker;
-    }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
@@ -36,7 +36,7 @@ public class TranslatorServiceConfiguration extends Configuration {
         return clientConfig;
     }
 
-    public TranslatorProxy buildTranslatorService(Environment environment, SamlParser samlParser) {
+    public TranslatorProxy buildTranslatorProxy(Environment environment) {
         Client client = new JerseyClientBuilder(environment).using(clientConfig).build("translator");
         JsonClient jsonClient = new JsonClient(
             new ErrorHandlingClient(client),

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HealthCheckAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HealthCheckAppRuleTests.java
@@ -7,15 +7,15 @@ import javax.ws.rs.core.Response;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MetadataAppRuleTests extends GatewayAppRuleTestBase {
+public class HealthCheckAppRuleTests extends GatewayAppRuleTestBase {
     @Test
-    public void shouldConsumeMetadata() throws Exception {
+    public void shouldExposeHealthCheck() throws Exception {
         Response response = proxyNodeAppRule.target("healthcheck", proxyNodeAppRule.getAdminPort())
             .request()
             .get();
 
         String healthcheck = response.readEntity(String.class);
 
-        assertThat(healthcheck).contains("\"hub-metadata\":{\"healthy\":true}");
+        assertThat(healthcheck).contains("\"gateway\":{\"healthy\":true}");
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -1,160 +1,22 @@
 package uk.gov.ida.notification.apprule.base;
 
 import io.dropwizard.testing.ConfigOverride;
-import keystore.KeyStoreResource;
 
-import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Rule;
-import org.opensaml.core.config.InitializationService;
-import org.opensaml.saml.saml2.core.AuthnRequest;
-import org.opensaml.security.credential.Credential;
 
-import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
-import uk.gov.ida.notification.apprule.rules.MetadataClientRule;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
-import uk.gov.ida.notification.saml.SamlFormMessageType;
-import uk.gov.ida.notification.saml.SamlObjectMarshaller;
-import uk.gov.ida.notification.saml.SamlObjectSigner;
-import uk.gov.ida.saml.core.test.TestCredentialFactory;
-import uk.gov.ida.saml.core.test.TestEntityIds;
-
-import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
-import static org.junit.jupiter.api.Assertions.fail;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PRIVATE_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PUBLIC_CERT;
-import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
-
-import java.net.URISyntaxException;
-import java.util.Map;
-
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
 
 public class GatewayAppRuleTestBase {
 
-    private Map<String, NewCookie> cookies;
-
-    protected static final String CONNECTOR_NODE_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
-
     @ClassRule
-    public static final MetadataClientRule metadataClientRule;
-
-    @ClassRule
-    public static final TranslatorClientRule translatorClientRule;
-
-    private static final KeyStoreResource truststore = aKeyStoreResource()
-            .withCertificate("VERIFY-FEDERATION", aCertificate().withCertificate(METADATA_SIGNING_A_PUBLIC_CERT).build().getCertificate())
-            .build();
-
-    static {
-        try {
-            InitializationService.initialize();
-            VerifySamlInitializer.init();
-            metadataClientRule = new MetadataClientRule();
-            translatorClientRule = new TranslatorClientRule();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        truststore.create();
-    }
-
-    protected final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
-    protected final Credential countrySigningCredential = new TestCredentialFactory(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY).getSigningCredential();
-    protected final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(countrySigningCredential.getPublicKey(), countrySigningCredential.getPrivateKey(), TEST_RP_PUBLIC_SIGNING_CERT);
+    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
 
     @Rule
     public GatewayAppRule proxyNodeAppRule = new GatewayAppRule(
-            ConfigOverride.config("proxyNodeEntityId", "http://proxy-node.uk"),
-            ConfigOverride.config("proxyNodeAuthnRequestUrl", "http://proxy-node/SAML2/SSO/POST"),
-            ConfigOverride.config("proxyNodeResponseUrl", "http://proxy-node/SAML2/SSO/Response"),
-            ConfigOverride.config("proxyNodeMetadataForConnectorNodeUrl", "http://proxy-node.uk"),
-            ConfigOverride.config("hubUrl", "http://hub"),
-            ConfigOverride.config("connectorNodeIssuerId", "http://connector-node:8080/ConnectorMetadata"),
             ConfigOverride.config("eidasSamlParserService.url", "http://eidas-saml-parser/eidasAuthnRequest"),
             ConfigOverride.config("verifyServiceProviderService.url", "http://verify-service-provider/"),
-            ConfigOverride.config("translatorService.url", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response"),
-            ConfigOverride.config("connectorMetadataConfiguration.url", metadataClientRule.baseUri() + "/connector-node/metadata"),
-            ConfigOverride.config("connectorMetadataConfiguration.expectedEntityId", "http://connector-node:8080/ConnectorResponderMetadata"),
-            ConfigOverride.config("connectorMetadataConfiguration.trustStore.type", "file"),
-            ConfigOverride.config("connectorMetadataConfiguration.trustStore.store", truststore.getAbsolutePath()),
-            ConfigOverride.config("connectorMetadataConfiguration.trustStore.password", truststore.getPassword()),
-            ConfigOverride.config("hubMetadataConfiguration.url", metadataClientRule.baseUri() + "/hub/metadata"),
-            ConfigOverride.config("hubMetadataConfiguration.expectedEntityId", TestEntityIds.HUB_ENTITY_ID),
-            ConfigOverride.config("hubMetadataConfiguration.trustStore.type", "file"),
-            ConfigOverride.config("hubMetadataConfiguration.trustStore.store", truststore.getAbsolutePath()),
-            ConfigOverride.config("hubMetadataConfiguration.trustStore.password", truststore.getPassword()),
-            ConfigOverride.config("connectorFacingSigningKeyPair.publicKey.type", "x509"),
-            ConfigOverride.config("connectorFacingSigningKeyPair.publicKey.cert", TEST_PUBLIC_CERT),
-            ConfigOverride.config("connectorFacingSigningKeyPair.privateKey.key", TEST_PRIVATE_KEY),
-            ConfigOverride.config("hubFacingSigningKeyPair.publicKey.type", "x509"),
-            ConfigOverride.config("hubFacingSigningKeyPair.publicKey.cert", TEST_PUBLIC_CERT),
-            ConfigOverride.config("hubFacingSigningKeyPair.privateKey.key", TEST_PRIVATE_KEY),
-            ConfigOverride.config("hubFacingEncryptionKeyPair.publicKey.type", "x509"),
-            ConfigOverride.config("hubFacingEncryptionKeyPair.publicKey.cert", TEST_PUBLIC_CERT),
-            ConfigOverride.config("hubFacingEncryptionKeyPair.privateKey.key", TEST_PRIVATE_KEY)
+            ConfigOverride.config("translatorService.url", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response")
     );
-
-    protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
-        System.out.println(marshaller.transformToString(eidasAuthnRequest));
-        String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
-        Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest);
-
-        Response response = null;
-
-        try {
-            response = proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
-        } catch (URISyntaxException e) {
-            fail(e);
-        }
-
-        if (response != null) {
-            cookies = response.getCookies();
-        }
-
-        return response;
-    }
-
-    protected Response redirectEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
-        String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
-
-        try {
-            return proxyNodeAppRule.target("/SAML2/SSO/Redirect")
-                    .queryParam(SamlFormMessageType.SAML_REQUEST, encodedRequest)
-                    .request()
-                    .get();
-        } catch (URISyntaxException e) {
-            fail(e);
-            return null;
-        }
-    }
-
-    protected Response postHubResponse(org.opensaml.saml.saml2.core.Response hubResponse) throws URISyntaxException {
-        String encodedResponse = Base64.encodeAsString(marshaller.transformToString(hubResponse));
-        Form postForm = new Form()
-                .param(SamlFormMessageType.SAML_RESPONSE, encodedResponse)
-                .param("RelayState", "relay");
-
-        Invocation.Builder request;
-
-        try {
-            request = proxyNodeAppRule.target("/SAML2/SSO/Response/POST").request();
-        } catch (URISyntaxException e) {
-            fail(e);
-            return null;
-        }
-
-        if (cookies != null) {
-            request.cookie(cookies.get("gateway-session"));
-        }
-
-        return request.post(Entity.form(postForm));
-    }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/GatewayAppRule.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/GatewayAppRule.java
@@ -33,7 +33,6 @@ public class GatewayAppRule extends DropwizardAppRule<GatewayConfiguration> {
         configOverridesList.add(ConfigOverride.config("server.applicationConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
         configOverridesList.add(ConfigOverride.config("server.adminConnectors[0].port", "0"));
-        configOverridesList.add(ConfigOverride.config("replayChecker.redisUrl", ""));
         return configOverridesList.toArray(new ConfigOverride[0]);
     }
 


### PR DESCRIPTION
Now that the gateway has been stripped back in its functionality there's
a lot of cruft left over in the Application class as well as the config.

It also fixes up the AppRule tests by removing the config overrides for
fields that no longer exist.