### PR TITLE
EID-1327 Gateway integration tests

### DIFF
--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -1,0 +1,51 @@
+package uk.gov.ida.notification.apprule;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
+import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
+import uk.gov.ida.notification.helpers.HtmlHelpers;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.saml.SamlParser;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
+
+    private SamlParser parser;
+
+    @Before
+    public void setup() throws Throwable {
+        parser = new SamlParser();
+    }
+
+    @Test
+    public void bindingsReturnHubAuthnRequestForm() throws Throwable {
+        assertGoodRequest(new EidasAuthnRequestBuilder().withIssuer(CONNECTOR_NODE_ENTITY_ID));
+    }
+
+    private AuthnRequest getHubAuthnRequestFromHtml(String html) throws IOException {
+        String decodedHubAuthnRequest = HtmlHelpers.getValueFromForm(html, SamlFormMessageType.SAML_REQUEST);
+        return parser.parseSamlString(decodedHubAuthnRequest);
+    }
+
+    private void assertGoodRequest(EidasAuthnRequestBuilder builder) throws Throwable {
+        AuthnRequest postedRequest = builder.withRandomRequestId().build();
+        samlObjectSigner.sign(postedRequest);
+        assertGoodResponse(postEidasAuthnRequest(postedRequest));
+
+        AuthnRequest redirectedRequest = builder.withRandomRequestId().build();
+        samlObjectSigner.sign(redirectedRequest);
+        assertGoodResponse(redirectEidasAuthnRequest(redirectedRequest));
+    }
+
+    private void assertGoodResponse(Response response) throws IOException {
+        String html = response.readEntity(String.class);
+        AuthnRequest hubAuthnRequest = getHubAuthnRequestFromHtml(html);
+        assertEquals("a hub request id", hubAuthnRequest.getID());
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -35,11 +35,8 @@ public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
 
     private void assertGoodRequest(EidasAuthnRequestBuilder builder) throws Throwable {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
         assertGoodResponse(postEidasAuthnRequest(postedRequest));
-
         AuthnRequest redirectedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(redirectedRequest);
         assertGoodResponse(redirectEidasAuthnRequest(redirectedRequest));
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -1,22 +1,103 @@
 package uk.gov.ida.notification.apprule.base;
 
 import io.dropwizard.testing.ConfigOverride;
-
+import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Rule;
-
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.security.credential.Credential;
+import uk.gov.ida.notification.VerifySamlInitializer;
+import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
+import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.saml.SamlObjectMarshaller;
+import uk.gov.ida.notification.saml.SamlObjectSigner;
+import uk.gov.ida.saml.core.test.TestCredentialFactory;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 
 public class GatewayAppRuleTestBase {
 
+    private Map<String, NewCookie> cookies;
+
+    protected static final String CONNECTOR_NODE_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
+
     @ClassRule
-    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
+    public static final TranslatorClientRule translatorClientRule;
+
+    @ClassRule
+    public static final EidasSamlParserClientRule espClientRule = new EidasSamlParserClientRule();
+
+    @ClassRule
+    public static final VerifyServiceProviderClientRule vspClientRule = new VerifyServiceProviderClientRule();
+
+    static {
+        try {
+            InitializationService.initialize();
+            VerifySamlInitializer.init();
+            translatorClientRule = new TranslatorClientRule();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
+    protected final Credential countrySigningCredential = new TestCredentialFactory(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY).getSigningCredential();
+    protected final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(
+            countrySigningCredential.getPublicKey(),
+            countrySigningCredential.getPrivateKey(),
+            TEST_RP_PUBLIC_SIGNING_CERT);
 
     @Rule
     public GatewayAppRule proxyNodeAppRule = new GatewayAppRule(
-            ConfigOverride.config("eidasSamlParserService.url", "http://eidas-saml-parser/eidasAuthnRequest"),
-            ConfigOverride.config("verifyServiceProviderService.url", "http://verify-service-provider/"),
+            ConfigOverride.config("eidasSamlParserService.url", espClientRule.baseUri().toString()),
+            ConfigOverride.config("verifyServiceProviderService.url", vspClientRule.baseUri().toString()),
             ConfigOverride.config("translatorService.url", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response")
     );
+
+    protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
+        System.out.println(marshaller.transformToString(eidasAuthnRequest));
+        String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
+        Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest);
+
+        Response response = null;
+
+        try {
+            response = proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
+        } catch (URISyntaxException e) {
+            fail(e);
+        }
+
+        if (response != null) {
+            cookies = response.getCookies();
+        }
+
+        return response;
+    }
+
+    protected Response redirectEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
+        String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
+
+        try {
+            return proxyNodeAppRule.target("/SAML2/SSO/Redirect")
+                    .queryParam(SamlFormMessageType.SAML_REQUEST, encodedRequest)
+                    .request()
+                    .get();
+        } catch (URISyntaxException e) {
+            fail(e);
+            return null;
+        }
+    }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -6,7 +6,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.AuthnRequest;
-import org.opensaml.security.credential.Credential;
 import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
@@ -14,28 +13,18 @@ import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
 import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
-import uk.gov.ida.notification.saml.SamlObjectSigner;
-import uk.gov.ida.saml.core.test.TestCredentialFactory;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Form;
-import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import java.net.URISyntaxException;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.fail;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 
 public class GatewayAppRuleTestBase {
-
-    private Map<String, NewCookie> cookies;
 
     protected static final String CONNECTOR_NODE_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
 
     @ClassRule
-    public static final TranslatorClientRule translatorClientRule;
+    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
 
     @ClassRule
     public static final EidasSamlParserClientRule espClientRule = new EidasSamlParserClientRule();
@@ -47,18 +36,12 @@ public class GatewayAppRuleTestBase {
         try {
             InitializationService.initialize();
             VerifySamlInitializer.init();
-            translatorClientRule = new TranslatorClientRule();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    protected final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
-    protected final Credential countrySigningCredential = new TestCredentialFactory(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY).getSigningCredential();
-    protected final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(
-            countrySigningCredential.getPublicKey(),
-            countrySigningCredential.getPrivateKey(),
-            TEST_RP_PUBLIC_SIGNING_CERT);
+    private final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
 
     @Rule
     public GatewayAppRule proxyNodeAppRule = new GatewayAppRule(
@@ -67,37 +50,17 @@ public class GatewayAppRuleTestBase {
             ConfigOverride.config("translatorService.url", translatorClientRule.baseUri() + "/translator/SAML2/SSO/Response")
     );
 
-    protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
-        System.out.println(marshaller.transformToString(eidasAuthnRequest));
+    protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest) throws URISyntaxException {
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
         Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest);
-
-        Response response = null;
-
-        try {
-            response = proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
-        } catch (URISyntaxException e) {
-            fail(e);
-        }
-
-        if (response != null) {
-            cookies = response.getCookies();
-        }
-
-        return response;
+        return proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
     }
 
-    protected Response redirectEidasAuthnRequest(AuthnRequest eidasAuthnRequest) {
+    protected Response redirectEidasAuthnRequest(AuthnRequest eidasAuthnRequest) throws URISyntaxException {
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
-
-        try {
-            return proxyNodeAppRule.target("/SAML2/SSO/Redirect")
-                    .queryParam(SamlFormMessageType.SAML_REQUEST, encodedRequest)
-                    .request()
-                    .get();
-        } catch (URISyntaxException e) {
-            fail(e);
-            return null;
-        }
+        return proxyNodeAppRule.target("/SAML2/SSO/Redirect")
+                .queryParam(SamlFormMessageType.SAML_REQUEST, encodedRequest)
+                .request()
+                .get();
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/EidasSamlParserClientRule.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/EidasSamlParserClientRule.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import io.dropwizard.testing.junit.DropwizardClientRule;
+
+public class EidasSamlParserClientRule extends DropwizardClientRule {
+    public EidasSamlParserClientRule() {
+        super(new TestEidasSamlResource());
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
+import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
+import uk.gov.ida.notification.shared.Urls;
+
+import javax.validation.Valid;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path(Urls.EidasSamlParserUrls.EIDAS_AUTHN_REQUEST_PATH)
+@Produces(MediaType.APPLICATION_JSON)
+public class TestEidasSamlResource {
+
+    @POST
+    @Valid
+    public EidasSamlParserResponse post(@Valid EidasSamlParserRequest request) {
+        return new EidasSamlParserResponse("eidas request id", "issuer", "cert", "destination");
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
@@ -1,0 +1,32 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import org.glassfish.jersey.internal.util.Base64;
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestGenerationBody;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
+import uk.gov.ida.notification.saml.SamlBuilder;
+import uk.gov.ida.notification.saml.SamlObjectMarshaller;
+import uk.gov.ida.notification.shared.Urls;
+
+import javax.validation.Valid;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Path(Urls.VerifyServiceProviderUrls.GENERATE_HUB_AUTHN_REQUEST_ENDPOINT)
+@Produces(MediaType.APPLICATION_JSON)
+public class TestVerifyServiceProviderResource {
+
+    @POST
+    @Valid
+    public AuthnRequestResponse post(@Valid AuthnRequestGenerationBody request) throws URISyntaxException {
+        AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
+        String hubRequestId = "a hub request id";
+        authnRequest.setID(hubRequestId);
+        String encodedAuthnRequest = Base64.encodeAsString(new SamlObjectMarshaller().transformToString(authnRequest));
+        return new AuthnRequestResponse(encodedAuthnRequest, hubRequestId, new URI("http://www.hub.com"));
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
@@ -20,13 +20,14 @@ import java.net.URISyntaxException;
 @Produces(MediaType.APPLICATION_JSON)
 public class TestVerifyServiceProviderResource {
 
+    public static final String REQUEST_ID_HUB = "a hub request id";
+
     @POST
     @Valid
     public AuthnRequestResponse post(@Valid AuthnRequestGenerationBody request) throws URISyntaxException {
         AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
-        String hubRequestId = "a hub request id";
-        authnRequest.setID(hubRequestId);
+        authnRequest.setID(REQUEST_ID_HUB);
         String encodedAuthnRequest = Base64.encodeAsString(new SamlObjectMarshaller().transformToString(authnRequest));
-        return new AuthnRequestResponse(encodedAuthnRequest, hubRequestId, new URI("http://www.hub.com"));
+        return new AuthnRequestResponse(encodedAuthnRequest, REQUEST_ID_HUB, new URI("http://www.hub.com"));
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/VerifyServiceProviderClientRule.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/VerifyServiceProviderClientRule.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import io.dropwizard.testing.junit.DropwizardClientRule;
+
+public class VerifyServiceProviderClientRule extends DropwizardClientRule {
+    public VerifyServiceProviderClientRule() {
+        super(new TestVerifyServiceProviderResource());
+    }
+}


### PR DESCRIPTION
This PR reinstates the gateway integration tests, and includes:
* one happy path test that processes a connector eIDAS AuthnRequest, and creates a Verify SAML payload
* integration with eidas-saml-parser and verify-service-provider

Further PRs will increase integration test coverage.