### PR TITLE
Eid 1337 - Apprule tests for gateway hub response endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ subprojects {
         )
 
         proxy_node_test (
+                "net.sourceforge.htmlcleaner:htmlcleaner:2.22",
                 "net.sourceforge.htmlunit:htmlunit:2.28",
         )
 

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/proxy/TranslatorProxy.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/proxy/TranslatorProxy.java
@@ -2,16 +2,18 @@ package uk.gov.ida.notification.proxy;
 
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.shared.Urls;
 
+import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
 public class TranslatorProxy {
     private final JsonClient translatorClient;
     private final URI translateHubResponsePath;
 
-    public TranslatorProxy(JsonClient translatorClient, URI translateHubResponsePath) {
+    public TranslatorProxy(JsonClient translatorClient, URI translatorURI) {
         this.translatorClient = translatorClient;
-        this.translateHubResponsePath = translateHubResponsePath;
+        this.translateHubResponsePath = UriBuilder.fromUri(translatorURI).path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH).build();
     }
 
     public String getTranslatedResponse(HubResponseTranslatorRequest translatorRequest) {

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -31,7 +31,7 @@ import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_REQU
 import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_RELAY_STATE;
 import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_HUB_REQUEST_ID;
 
-@Path(Urls.GatewayUrls.GATEWAY_EIDAS_AUTHN_REQUEST_PATH)
+@Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class EidasAuthnRequestResource {
 
     private final Logger log = Logger.getLogger(getClass().getName());
@@ -51,7 +51,7 @@ public class EidasAuthnRequestResource {
     }
 
     @GET
-    @Path("/Redirect")
+    @Path(Urls.GatewayUrls.GATEWAY_EIDAS_AUTHN_REQUEST_REDIRECT_PATH)
     public View handleRedirectBinding(
             @QueryParam(SamlFormMessageType.SAML_REQUEST) String encodedEidasAuthnRequest,
             @QueryParam("RelayState") String relayState,
@@ -60,7 +60,7 @@ public class EidasAuthnRequestResource {
     }
 
     @POST
-    @Path("/POST")
+    @Path(Urls.GatewayUrls.GATEWAY_EIDAS_AUTHN_REQUEST_POST_PATH)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public View handlePostBinding(
             @FormParam(SamlFormMessageType.SAML_REQUEST) String encodedEidasAuthnRequest,

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -23,7 +23,7 @@ import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_RELA
 import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_REQUEST_ID;
 import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_HUB_REQUEST_ID;
 
-@Path(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_PATH)
+@Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class HubResponseResource {
     private static final Logger LOG = Logger.getLogger(HubResponseResource.class.getName());
     public static final String LEVEL_OF_ASSURANCE = "LEVEL_2";
@@ -40,7 +40,7 @@ public class HubResponseResource {
     }
 
     @POST
-    @Path("/POST")
+    @Path(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_PATH)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     public View hubResponse(
         @FormParam(SamlFormMessageType.SAML_RESPONSE) String hubResponse,

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -1,0 +1,77 @@
+package uk.gov.ida.notification.apprule;
+
+import io.dropwizard.testing.ConfigOverride;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
+import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
+import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
+import uk.gov.ida.notification.apprule.rules.TestEidasSamlResource;
+import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
+import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
+import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
+import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
+import uk.gov.ida.notification.helpers.HtmlHelpers;
+import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.shared.Urls;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Form;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
+
+    @ClassRule
+    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
+
+    @ClassRule
+    public static final EidasSamlParserClientRule<TestEidasSamlResource> espClientRule = new EidasSamlParserClientRule<>(new TestEidasSamlResource());
+
+    @ClassRule
+    public static final VerifyServiceProviderClientRule<TestVerifyServiceProviderResource> vspClientRule = new VerifyServiceProviderClientRule<>(new TestVerifyServiceProviderResource());
+
+    @Rule
+    public GatewayAppRule proxyNodeAppRule = new GatewayAppRule(
+        ConfigOverride.config("eidasSamlParserService.url", espClientRule.baseUri().toString()),
+        ConfigOverride.config("verifyServiceProviderService.url", vspClientRule.baseUri().toString()),
+        ConfigOverride.config("translatorService.url", translatorClientRule.baseUri().toString())
+    );
+
+    @Test
+    public void hubResponseReturnsHtmlFormWithSamlBlob() throws Exception{
+        Form postForm = new Form()
+            .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
+            .param("RelayState", "relay-state");
+
+        Response response = proxyNodeAppRule
+            .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+            .request()
+            .cookie(getSessionCookie())
+            .post(Entity.form(postForm));
+
+        assertEquals(200, response.getStatus());
+
+        String htmlString = response.readEntity(String.class);
+        HtmlHelpers.assertXPath(
+            htmlString,
+            String.format(
+                "//form[@action='http://connector-node.com']/input[@name='SAMLResponse'][@value='%s']",
+                TestTranslatorResource.SAML_BLOB
+            )
+        );
+        HtmlHelpers.assertXPath(
+            htmlString,
+            "//form[@action='http://connector-node.com']/input[@name='RelayState'][@value='relay-state']"
+        );
+    }
+
+    private NewCookie getSessionCookie() throws Exception {
+        return postEidasAuthnRequest(buildAuthnRequest(), proxyNodeAppRule).getCookies().get("gateway-session");
+    }
+
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -5,6 +5,7 @@ import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
+import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 
@@ -30,7 +31,7 @@ public class GatewayAppRuleTestBase {
 
     protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest, GatewayAppRule proxyNodeAppRule) throws URISyntaxException {
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
-        Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest);
+        Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest).param("RelayState", "relay-state");
         return proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
     }
 
@@ -38,7 +39,15 @@ public class GatewayAppRuleTestBase {
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
         return proxyNodeAppRule.target("/SAML2/SSO/Redirect")
                 .queryParam(SamlFormMessageType.SAML_REQUEST, encodedRequest)
+                .queryParam("RelayState", "relay-state")
                 .request()
                 .get();
+    }
+
+    protected AuthnRequest buildAuthnRequest() throws Exception {
+        return new EidasAuthnRequestBuilder()
+            .withIssuer(CONNECTOR_NODE_ENTITY_ID)
+            .withRandomRequestId()
+            .build();
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
@@ -17,6 +17,6 @@ public class TestEidasSamlResource {
     @POST
     @Valid
     public EidasSamlParserResponse post(@Valid EidasSamlParserRequest request) {
-        return new EidasSamlParserResponse("eidas request id", "issuer", "cert", "destination");
+        return new EidasSamlParserResponse("eidas request id", "issuer", "cert", "http://connector-node.com");
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorResource.java
@@ -11,14 +11,11 @@ import uk.gov.ida.saml.core.test.builders.*;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_ENCRYPTION_KEY;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
-
-@Path("/translator")
+@Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
 public class TestTranslatorResource {
 
     @POST
-    @Path("/SAML2/SSO/Response")
+    @Path("Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_XML)
     public String hubResponse(@FormParam(SamlFormMessageType.SAML_RESPONSE) String encryptedHubResponse) throws Throwable {

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorResource.java
@@ -1,61 +1,23 @@
 package uk.gov.ida.notification.apprule.rules;
 
-import org.opensaml.saml.saml2.core.*;
-import org.opensaml.security.credential.Credential;
-import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
-import uk.gov.ida.notification.saml.SamlFormMessageType;
-import uk.gov.ida.notification.saml.SamlObjectMarshaller;
-import uk.gov.ida.saml.core.test.TestCredentialFactory;
-import uk.gov.ida.saml.core.test.builders.*;
+import org.glassfish.jersey.internal.util.Base64;
+import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.shared.Urls;
 
-import javax.ws.rs.*;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 @Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
+@Produces(MediaType.APPLICATION_JSON)
 public class TestTranslatorResource {
 
+    public static final String SAML_BLOB = Base64.encodeAsString("I'm also going to be a SAML blob!");
+
     @POST
-    @Path("Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH")
-    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @Produces(MediaType.APPLICATION_XML)
-    public String hubResponse(@FormParam(SamlFormMessageType.SAML_RESPONSE) String encryptedHubResponse) throws Throwable {
-        Credential encryptingCredential = new TestCredentialFactory(
-                TEST_RP_PUBLIC_ENCRYPTION_CERT,
-                TEST_RP_PRIVATE_ENCRYPTION_KEY
-        ).getDecryptingCredential();
-
-        AttributeValue firstnameValue = PersonNameAttributeValueBuilder
-                .aPersonNameValue()
-                .withValue("Jazzy Harold")
-                .withVerified(true)
-                .build();
-
-        Attribute firstname = PersonNameAttributeBuilder_1_1.aPersonName_1_1()
-                .addValue(firstnameValue)
-                .buildAsFirstname();
-
-        AttributeStatement attributeStatement = AttributeStatementBuilder
-                .anAttributeStatement()
-                .addAttribute(firstname)
-                .build();
-
-        AuthnStatement authnStatement = AuthnStatementBuilder.anAuthnStatement().build();
-
-        EncryptedAssertion encryptedAssertion = AssertionBuilder
-                .anAssertion()
-                .withId("encryptedAssertion")
-                .addAttributeStatement(attributeStatement)
-                .addAuthnStatement(authnStatement)
-                .buildWithEncrypterCredential(encryptingCredential);
-
-        Response response = ResponseBuilder
-                .aResponse()
-                .withInResponseTo(new EidasAuthnRequestBuilder().build().getID())
-                .addEncryptedAssertion(encryptedAssertion)
-                .build();
-
-        SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
-        String samlMessage = marshaller.transformToString(response);
-        return samlMessage;
+    @Path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH)
+    public String hubResponse(HubResponseTranslatorRequest hubResponseTranslatorRequest) {
+        return SAML_BLOB;
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestVerifyServiceProviderResource.java
@@ -1,11 +1,8 @@
 package uk.gov.ida.notification.apprule.rules;
 
 import org.glassfish.jersey.internal.util.Base64;
-import org.opensaml.saml.saml2.core.AuthnRequest;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestGenerationBody;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
-import uk.gov.ida.notification.saml.SamlBuilder;
-import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 import uk.gov.ida.notification.shared.Urls;
 
 import javax.validation.Valid;
@@ -21,13 +18,11 @@ import java.net.URISyntaxException;
 public class TestVerifyServiceProviderResource {
 
     public static final String REQUEST_ID_HUB = "a hub request id";
+    public static final String ENCODED_SAML_BLOB = Base64.encodeAsString("Encoded SAML blob!");
 
     @POST
     @Valid
     public AuthnRequestResponse post(@Valid AuthnRequestGenerationBody request) throws URISyntaxException {
-        AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
-        authnRequest.setID(REQUEST_ID_HUB);
-        String encodedAuthnRequest = Base64.encodeAsString(new SamlObjectMarshaller().transformToString(authnRequest));
-        return new AuthnRequestResponse(encodedAuthnRequest, REQUEST_ID_HUB, new URI("http://www.hub.com"));
+        return new AuthnRequestResponse(ENCODED_SAML_BLOB, REQUEST_ID_HUB, new URI("http://www.hub.com"));
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
@@ -57,7 +57,8 @@ public class TranslatorProxyTest {
         );
         TranslatorProxy translatorProxy = new TranslatorProxy(
             jsonClient,
-            UriBuilder.fromUri(clientRule.baseUri()).path("/translate-hub-response").build());
+            clientRule.baseUri()
+        );
 
         String samlResponse = translatorProxy.getTranslatedResponse(request);
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/Urls.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/Urls.java
@@ -7,8 +7,11 @@ public interface Urls {
     }
 
     interface GatewayUrls {
-        String GATEWAY_EIDAS_AUTHN_REQUEST_PATH = "/SAML2/SSO";
-        String GATEWAY_HUB_RESPONSE_PATH = "/SAML2/SSO/Response";
+        String GATEWAY_ROOT = "/SAML2/SSO";
+        String GATEWAY_EIDAS_AUTHN_REQUEST_POST_PATH = "/POST";
+        String GATEWAY_EIDAS_AUTHN_REQUEST_REDIRECT_PATH = "/Redirect";
+        String GATEWAY_HUB_RESPONSE_PATH = "/Response/POST";
+        String GATEWAY_HUB_RESPONSE_RESOURCE = GATEWAY_ROOT + GATEWAY_HUB_RESPONSE_PATH;
     }
 
     interface TranslatorUrls {

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/HtmlHelpers.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/HtmlHelpers.java
@@ -6,9 +6,21 @@ import com.gargoylesoftware.htmlunit.html.HTMLParser;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import org.glassfish.jersey.internal.util.Base64;
+import org.htmlcleaner.CleanerProperties;
+import org.htmlcleaner.DomSerializer;
+import org.htmlcleaner.HtmlCleaner;
+import org.htmlcleaner.TagNode;
+import org.w3c.dom.Document;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.io.IOException;
 import java.net.URL;
+
+import static org.junit.Assert.assertTrue;
 
 public class HtmlHelpers {
     public static String getValueFromForm(String html, String inputName) throws IOException {
@@ -20,5 +32,13 @@ public class HtmlHelpers {
             String encodedEidasResponse = samlForm.getInputByName(inputName).getValueAttribute();
             return Base64.decodeAsString(encodedEidasResponse);
         }
+    }
+
+    public static void assertXPath(String htmlString, String xPathExpression) throws XPathExpressionException, ParserConfigurationException {
+        TagNode tagNode = new HtmlCleaner().clean(htmlString);
+        Document doc = new DomSerializer(new CleanerProperties()).createDOM(tagNode);
+        XPath xpath = XPathFactory.newInstance().newXPath();
+
+        assertTrue((Boolean) xpath.evaluate(xPathExpression, doc, XPathConstants.BOOLEAN));
     }
 }


### PR DESCRIPTION
### EID-1337 Refactor shared URLS  …
Some of the shared URLS were incomplete and hard to work with.

### EID-1337 Add helper for asserting html with XPath  …
When returning html to users we can use xpath to assert we're returning
them the correct thing.

### EID-1337 Refactor gateway authn request app rule tests  …
Previously the tests were dealing with parsing saml, which we don't need
to do - gateway doesn't need to know anything about saml. Instead, we
can test the expected content of the response via xpath.

This also pushes the method for building an authn response up to the
base apprule class as it will be useful for the hub response apprule
tests.

### EID-1337 Refactor test service resources for clientrules  …
The test resources for the VSP and the Translator were both creating
saml objects to be serialized and sent as responses. This is unnecessary
for the gateway as it is unaware of saml. We can instead just provide
strings and make sure they are passed correctly by the gateway.

### EID-1337 Add apprule tests for gateway hub response resource  …
This tests the happy path for the hub response endpoint by firing a
request at it and ensuring the correct values in the html response.

To set this up, we first create a session by hitting the authn endpoint
and capturing the session cookie. This is sent in the request to the hub
response endpoint.