### PR TITLE
EID-1342/1343: Sign generated metadata with CloudHSM

### DIFF
--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -1,0 +1,20 @@
+from amazonlinux:2.0.20190212
+env WORKDIR=/cloudhsm
+workdir $WORKDIR
+
+# Install AWS CloudHSM client and libs
+run yum install -y wget
+
+run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
+ && yum install -y ./cloudhsm-client-latest.*.rpm
+
+run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-pkcs11-latest.el7.x86_64.rpm \
+ && yum install -y ./cloudhsm-client-pkcs11-latest.*.rpm
+
+copy init.sh .
+run chmod +x init.sh
+
+expose 1111
+env HSM_IP=127.0.0.1
+entrypoint ["/cloudhsm/init.sh"]
+cmd ["/opt/cloudhsm/bin/cloudhsm_client", "/opt/cloudhsm/etc/cloudhsm_client.cfg"]

--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -1,15 +1,10 @@
 from amazonlinux:2.0.20190212
-env WORKDIR=/cloudhsm
-workdir $WORKDIR
+workdir /cloudhsm
 
-# Install AWS CloudHSM client and libs
-run yum install -y wget
-
-run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
+# Install AWS CloudHSM client
+run yum install -y wget \
+ && wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-latest.*.rpm
-
-run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-pkcs11-latest.el7.x86_64.rpm \
- && yum install -y ./cloudhsm-client-pkcs11-latest.*.rpm
 
 copy init.sh .
 run chmod +x init.sh

--- a/cloudhsm/init.sh
+++ b/cloudhsm/init.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Start the cloudhsm-client
+/opt/cloudhsm/bin/configure -a $HSM_IP
+
+# Use TCPSOCKET
+sed 's/UNIXSOCKET/TCPSOCKET/g' < /opt/cloudhsm/etc/cloudhsm_client.cfg > tmp
+mv tmp /opt/cloudhsm/etc/cloudhsm_client.cfg
+
+exec $@

--- a/mdgen/.dockerignore
+++ b/mdgen/.dockerignore
@@ -1,0 +1,7 @@
+.gradle
+.idea
+*.iml
+
+build/
+test/
+*.sh

--- a/mdgen/.gitignore
+++ b/mdgen/.gitignore
@@ -3,4 +3,3 @@
 *.iml
 
 build/
-libs/

--- a/mdgen/.gitignore
+++ b/mdgen/.gitignore
@@ -1,0 +1,6 @@
+.gradle
+.idea
+*.iml
+
+build/
+libs/

--- a/mdgen/Dockerfile
+++ b/mdgen/Dockerfile
@@ -1,12 +1,10 @@
 # build
 from gradle:jdk11 AS build
-env WORKDIR=/mdgen
-workdir $WORKDIR
+workdir /mdgen
 user root
 
-env GRADLE_USER_HOME $WORKDIR/.gradle
-copy build.gradle build.gradle
-copy settings.gradle settings.gradle
+env GRADLE_USER_HOME /mdgen/.gradle
+copy build.gradle settings.gradle ./
 copy src/ src/
 copy libs/ libs/
 
@@ -16,29 +14,26 @@ run gradle --no-daemon installDist -x test
 from amazonlinux:2.0.20190212
 
 # Install AWS CloudHSM client and libs
-run yum install -y wget
-
-run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
+run yum install -y wget tar gzip \
+ && wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-latest.*.rpm \
- && rm ./cloudhsm-client-latest.*.rpm
-
-run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-latest.el7.x86_64.rpm \
+ && rm ./cloudhsm-client-latest.*.rpm \
+ && wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-latest.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-jce-latest.*.rpm \
- && rm ./cloudhsm-client-jce-latest.*.rpm
-
-# Install Java 11
-run yum install -y tar gzip \
+ && rm ./cloudhsm-client-jce-latest.*.rpm \
+ && yum install -y tar gzip \
  && wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
  && mkdir -p /usr/lib/jvm \
  && tar -C /usr/lib/jvm -xf ./openjdk-11.0.2*.tar.gz \
- && rm ./openjdk-11.0.2*.tar.gz
+ && rm ./openjdk-11.0.2*.tar.gz \
+ && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
 
 copy --from=build /mdgen/build/install/mdgen /mdgen
-run sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
 
-env LD_LIBRARY_PATH=/opt/cloudhsm/lib
-env HSM_PARTITION=PARTITION_1
-env HSM_USER=user
-env HSM_PASSWORD=password
-env JAVA_HOME=/usr/lib/jvm/jdk-11.0.2
+env LD_LIBRARY_PATH=/opt/cloudhsm/lib \
+    HSM_PARTITION=PARTITION_1 \
+    HSM_USER=user \
+    HSM_PASSWORD=password \
+    JAVA_HOME=/usr/lib/jvm/jdk-11.0.2
+
 entrypoint ["/mdgen/bin/mdgen"]

--- a/mdgen/Dockerfile
+++ b/mdgen/Dockerfile
@@ -1,13 +1,44 @@
-# Base builder image
-
+# build
 from gradle:jdk11 AS build
-workdir /mdgen
+env WORKDIR=/mdgen
+workdir $WORKDIR
 user root
-env GRADLE_user_HOME ~/.gradle
-copy build.gradle build.gradle
-copy src/ src/
-run gradle --no-daemon --quiet --parallel install
 
-from openjdk:11-jre-slim
-copy --from=build /mdgen/build/install/mdgen /
-entrypoint ["/bin/mdgen"]
+env GRADLE_USER_HOME $WORKDIR/.gradle
+copy build.gradle build.gradle
+copy settings.gradle settings.gradle
+copy src/ src/
+copy libs/ libs/
+
+run gradle --no-daemon installDist -x test
+
+# runtime
+from amazonlinux:2.0.20190212
+
+# Install AWS CloudHSM client and libs
+run yum install -y wget
+
+run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
+ && yum install -y ./cloudhsm-client-latest.*.rpm \
+ && rm ./cloudhsm-client-latest.*.rpm
+
+run wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-latest.el7.x86_64.rpm \
+ && yum install -y ./cloudhsm-client-jce-latest.*.rpm \
+ && rm ./cloudhsm-client-jce-latest.*.rpm
+
+# Install Java 11
+run yum install -y tar gzip \
+ && wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
+ && mkdir -p /usr/lib/jvm \
+ && tar -C /usr/lib/jvm -xf ./openjdk-11.0.2*.tar.gz \
+ && rm ./openjdk-11.0.2*.tar.gz
+
+copy --from=build /mdgen/build/install/mdgen /mdgen
+run sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
+
+env LD_LIBRARY_PATH=/opt/cloudhsm/lib
+env HSM_PARTITION=PARTITION_1
+env HSM_USER=user
+env HSM_PASSWORD=password
+env JAVA_HOME=/usr/lib/jvm/jdk-11.0.2
+entrypoint ["/mdgen/bin/mdgen"]

--- a/mdgen/Dockerfile
+++ b/mdgen/Dockerfile
@@ -1,16 +1,3 @@
-# build
-from gradle:jdk11 AS build
-workdir /mdgen
-user root
-
-env GRADLE_USER_HOME /mdgen/.gradle
-copy build.gradle settings.gradle ./
-copy src/ src/
-copy libs/ libs/
-
-run gradle --no-daemon installDist -x test
-
-# runtime
 from amazonlinux:2.0.20190212
 
 # Install AWS CloudHSM client and libs
@@ -21,19 +8,22 @@ run yum install -y wget tar gzip \
  && wget https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-latest.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-jce-latest.*.rpm \
  && rm ./cloudhsm-client-jce-latest.*.rpm \
- && yum install -y tar gzip \
  && wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
  && mkdir -p /usr/lib/jvm \
  && tar -C /usr/lib/jvm -xf ./openjdk-11.0.2*.tar.gz \
  && rm ./openjdk-11.0.2*.tar.gz \
  && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
 
-copy --from=build /mdgen/build/install/mdgen /mdgen
-
-env LD_LIBRARY_PATH=/opt/cloudhsm/lib \
+workdir /mdgen
+env GRADLE_USER_HOME=/build/.gradle \
+    LD_LIBRARY_PATH=/opt/cloudhsm/lib \
     HSM_PARTITION=PARTITION_1 \
     HSM_USER=user \
     HSM_PASSWORD=password \
     JAVA_HOME=/usr/lib/jvm/jdk-11.0.2
+copy gradlew build.gradle settings.gradle ./
+copy gradle/ gradle/
+copy src/ src/
+run ./gradlew --no-daemon installDist -x test
 
-entrypoint ["/mdgen/bin/mdgen"]
+entrypoint ["/mdgen/build/install/mdgen/bin/mdgen"]

--- a/mdgen/build.gradle
+++ b/mdgen/build.gradle
@@ -8,6 +8,11 @@ repositories {
   mavenCentral()
   maven { url 'http://oss.sonatype.org/content/groups/public/' }
   maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
+
+  // cloudhsm libraries downloaded from AWS
+  flatDir {
+    dirs 'libs'
+  }
 }
 
 dependencies {
@@ -24,4 +29,10 @@ dependencies {
     'com.github.spullara.mustache.java:compiler:0.9.6',
     'org.yaml:snakeyaml:1.24-SNAPSHOT',
     'se.swedenconnect.opensaml:opensaml-pkcs11-support:1.1.1'
+
+  implementation name: 'cloudhsm-2.0.0'
+  implementation name: 'log4j-api-2.8'
+  implementation name: 'log4j-core-2.8'
+
+  testImplementation name: 'cloudhsm-test-2.0.0'
 }

--- a/mdgen/build.gradle
+++ b/mdgen/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
   // cloudhsm libraries downloaded from AWS
   flatDir {
-    dirs 'libs'
+    dirs '/opt/cloudhsm/java'
   }
 }
 

--- a/mdgen/pre-commit.sh
+++ b/mdgen/pre-commit.sh
@@ -35,7 +35,7 @@ function test_with_hsm {
   local key_pass="1234"
   echo -n "test_with_hsm  $node $cert $key $algo: "
   ./init_softhsm.sh "$algo" >"$log" 2>&1 \
-    && ./gradlew run -q --args "$node test/${node}.yml $cert --algorithm $algo --credential hsm --hsm-module $HSM_MODULE --hsm-key-label $algo --hsm-pin 1234 --output $output" >"$log" 2>&1 \
+    && ./gradlew run -q --args "$node test/${node}.yml $cert --algorithm $algo --credential pkcs11 --hsm-module $HSM_MODULE --hsm-key-label $algo --hsm-pin 1234 --output $output" >"$log" 2>&1 \
     && $XMLSECTOOL --verifySignature --inFile "$output" --certificate "$cert" >"$log" 2>&1
   test 0 -eq "$?" && echo OK || {
     echo FAIL


### PR DESCRIPTION
This adds a Docker image from the CloudHSM client and modifies the metadata generator Java code and Docker image to use the CloudHSM.