### PR TITLE
Eid 1338 - Error handling in gateway's hub response resource

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -10,6 +10,7 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.notification.exceptions.mappers.EidasSamlParserResponseExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.GenericExceptionMapper;
+import uk.gov.ida.notification.exceptions.mappers.SessionAttributeExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.VspGenerateAuthnRequestResponseExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.proxy.EidasSamlParserProxy;
@@ -77,6 +78,7 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
     private void registerExceptionMappers(Environment environment) {
         environment.jersey().register(new EidasSamlParserResponseExceptionMapper());
         environment.jersey().register(new VspGenerateAuthnRequestResponseExceptionMapper());
+        environment.jersey().register(new SessionAttributeExceptionMapper());
         environment.jersey().register(new GenericExceptionMapper());
     }
 

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -11,6 +11,7 @@ import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.notification.exceptions.mappers.EidasSamlParserResponseExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.GenericExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.SessionAttributeExceptionMapper;
+import uk.gov.ida.notification.exceptions.mappers.TranslatorResponseExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.VspGenerateAuthnRequestResponseExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.proxy.EidasSamlParserProxy;
@@ -78,6 +79,7 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
     private void registerExceptionMappers(Environment environment) {
         environment.jersey().register(new EidasSamlParserResponseExceptionMapper());
         environment.jersey().register(new VspGenerateAuthnRequestResponseExceptionMapper());
+        environment.jersey().register(new TranslatorResponseExceptionMapper());
         environment.jersey().register(new SessionAttributeExceptionMapper());
         environment.jersey().register(new GenericExceptionMapper());
     }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
@@ -17,6 +17,8 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 
+import static uk.gov.ida.notification.shared.Urls.TranslatorUrls.TRANSLATOR_HUB_RESPONSE_RESOURCE;
+
 public class TranslatorServiceConfiguration extends Configuration {
 
     @NotNull
@@ -44,7 +46,7 @@ public class TranslatorServiceConfiguration extends Configuration {
         );
         return new TranslatorProxy(
             jsonClient,
-            UriBuilder.fromUri(url).path(Urls.TranslatorUrls.TRANSLATOR_ROOT).build()
+            UriBuilder.fromUri(url).path(TRANSLATOR_HUB_RESPONSE_RESOURCE).build()
         );
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/SessionAttributeException.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/SessionAttributeException.java
@@ -3,7 +3,12 @@ package uk.gov.ida.notification.exceptions;
 import javax.ws.rs.WebApplicationException;
 
 public class SessionAttributeException extends WebApplicationException {
-    public SessionAttributeException(Throwable cause) {
-        super(cause);
+    private final String sessionId;
+
+    public SessionAttributeException(String message, String sessionId) {
+        super(message);
+        this.sessionId = sessionId;
     }
+
+    public String getSessionId() { return this.sessionId; }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/SessionAttributeException.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/SessionAttributeException.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.notification.exceptions;
+
+import javax.ws.rs.WebApplicationException;
+
+public class SessionAttributeException extends WebApplicationException {
+    public SessionAttributeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/TranslatorResponseException.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/TranslatorResponseException.java
@@ -1,0 +1,14 @@
+package uk.gov.ida.notification.exceptions;
+
+import javax.ws.rs.WebApplicationException;
+
+public class TranslatorResponseException extends WebApplicationException {
+    private final String sessionId;
+
+    public TranslatorResponseException(Throwable cause, String sessionId) {
+        super(cause);
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId() { return this.sessionId; }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionAttributeExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionAttributeExceptionMapper.java
@@ -1,0 +1,27 @@
+package uk.gov.ida.notification.exceptions.mappers;
+
+import uk.gov.ida.notification.exceptions.SessionAttributeException;
+import uk.gov.ida.notification.views.ErrorPageView;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.logging.Logger;
+
+public class SessionAttributeExceptionMapper implements ExceptionMapper<SessionAttributeException> {
+    private final Logger log = Logger.getLogger(getClass().getName());
+
+    @Override
+    public Response toResponse(SessionAttributeException exception) {
+        log.warning(
+            String.format(
+                "Exception reading session attributes: %s",
+                exception.getCause()
+            )
+        );
+
+        return Response
+            .status(Response.Status.BAD_REQUEST)
+            .entity(new ErrorPageView("Something went wrong with the session attributes"))
+            .build();
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionAttributeExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionAttributeExceptionMapper.java
@@ -14,8 +14,9 @@ public class SessionAttributeExceptionMapper implements ExceptionMapper<SessionA
     public Response toResponse(SessionAttributeException exception) {
         log.warning(
             String.format(
-                "Exception reading session attributes: %s",
-                exception.getCause()
+                "Exception reading attributes for session '%s': %s",
+                exception.getSessionId(),
+                exception.getMessage()
             )
         );
 

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/TranslatorResponseExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/TranslatorResponseExceptionMapper.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.notification.exceptions.mappers;
+
+import uk.gov.ida.common.ExceptionType;
+import uk.gov.ida.exceptions.ApplicationException;
+import uk.gov.ida.notification.exceptions.TranslatorResponseException;
+import uk.gov.ida.notification.views.ErrorPageView;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.logging.Logger;
+
+public class TranslatorResponseExceptionMapper implements ExceptionMapper<TranslatorResponseException> {
+    private final Logger log = Logger.getLogger(getClass().getName());
+
+    @Override
+    public Response toResponse(TranslatorResponseException exception) {
+        log.warning(
+            String.format(
+                "Exception calling translator for session '%s': %s",
+                exception.getSessionId(),
+                exception.getCause().getMessage()
+            )
+        );
+
+        ApplicationException cause = (ApplicationException) exception.getCause();
+        Response.Status status = cause.getExceptionType() == ExceptionType.CLIENT_ERROR ?
+            Response.Status.BAD_REQUEST : Response.Status.INTERNAL_SERVER_ERROR;
+
+        return Response
+            .status(status)
+            .entity(new ErrorPageView("Something went wrong with the Translator"))
+            .build();
+    }
+
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/proxy/TranslatorProxy.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/proxy/TranslatorProxy.java
@@ -1,7 +1,9 @@
 package uk.gov.ida.notification.proxy;
 
+import uk.gov.ida.exceptions.ApplicationException;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.exceptions.TranslatorResponseException;
 import uk.gov.ida.notification.shared.Urls;
 
 import javax.ws.rs.core.UriBuilder;
@@ -9,14 +11,18 @@ import java.net.URI;
 
 public class TranslatorProxy {
     private final JsonClient translatorClient;
-    private final URI translateHubResponsePath;
+    private final URI translatorUri;
 
-    public TranslatorProxy(JsonClient translatorClient, URI translatorURI) {
+    public TranslatorProxy(JsonClient translatorClient, URI translatorUri) {
         this.translatorClient = translatorClient;
-        this.translateHubResponsePath = UriBuilder.fromUri(translatorURI).path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH).build();
+        this.translatorUri = translatorUri;
     }
 
-    public String getTranslatedResponse(HubResponseTranslatorRequest translatorRequest) {
-        return translatorClient.post(translatorRequest, translateHubResponsePath, String.class);
+    public String getTranslatedResponse(HubResponseTranslatorRequest translatorRequest, String sessionId) {
+        try {
+            return translatorClient.post(translatorRequest, translatorUri, String.class);
+        } catch (ApplicationException e) {
+            throw new TranslatorResponseException(e, sessionId);
+        }
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -76,11 +76,9 @@ public class EidasAuthnRequestResource {
 
     private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, AuthnRequestResponse vspResponse, String eidasRelayState) {
         GatewaySessionData gatewaySessionData = new GatewaySessionData(
-            vspResponse.getRequestId(),
-            eidasSamlParserResponse.getRequestId(),
-            eidasSamlParserResponse.getDestination(),
-            eidasRelayState,
-            eidasSamlParserResponse.getConnectorEncryptionPublicCertificate()
+            eidasSamlParserResponse,
+            vspResponse,
+            eidasRelayState
         );
         session.setAttribute(SESSION_KEY_SESSION_DATA, gatewaySessionData);
     }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -10,6 +10,7 @@ import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
+import uk.gov.ida.notification.session.GatewaySessionData;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.notification.views.SamlFormView;
@@ -25,11 +26,7 @@ import javax.ws.rs.core.MediaType;
 import java.net.URI;
 import java.util.logging.Logger;
 
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_DESTINATION;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_REQUEST_ID;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_RELAY_STATE;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_HUB_REQUEST_ID;
+import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_SESSION_DATA;
 
 @Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class EidasAuthnRequestResource {
@@ -78,11 +75,14 @@ public class EidasAuthnRequestResource {
     }
 
     private void setResponseDataInSession(HttpSession session, EidasSamlParserResponse eidasSamlParserResponse, AuthnRequestResponse vspResponse, String eidasRelayState) {
-        session.setAttribute(SESSION_KEY_EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
-        session.setAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT, eidasSamlParserResponse.getConnectorEncryptionPublicCertificate());
-        session.setAttribute(SESSION_KEY_EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
-        session.setAttribute(SESSION_KEY_EIDAS_RELAY_STATE, eidasRelayState);
-        session.setAttribute(SESSION_KEY_HUB_REQUEST_ID, vspResponse.getRequestId());
+        GatewaySessionData gatewaySessionData = new GatewaySessionData(
+            vspResponse.getRequestId(),
+            eidasSamlParserResponse.getRequestId(),
+            eidasSamlParserResponse.getDestination(),
+            eidasRelayState,
+            eidasSamlParserResponse.getConnectorEncryptionPublicCertificate()
+        );
+        session.setAttribute(SESSION_KEY_SESSION_DATA, gatewaySessionData);
     }
 
     private EidasSamlParserResponse parseEidasRequest(String encodedEidasAuthnRequest, String sessionId) {

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -3,10 +3,11 @@ package uk.gov.ida.notification.resources;
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
 import uk.gov.ida.notification.SamlFormViewBuilder;
-import uk.gov.ida.notification.exceptions.SessionAttributeException;
 import uk.gov.ida.notification.proxy.TranslatorProxy;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
+import uk.gov.ida.notification.session.GatewaySessionData;
+import uk.gov.ida.notification.session.GatewaySessionDataValidator;
 import uk.gov.ida.notification.shared.Urls;
 
 import javax.servlet.http.HttpSession;
@@ -18,15 +19,11 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 import java.util.logging.Logger;
 
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_DESTINATION;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_RELAY_STATE;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_EIDAS_REQUEST_ID;
-import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_HUB_REQUEST_ID;
 
 @Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class HubResponseResource {
     private static final Logger LOG = Logger.getLogger(HubResponseResource.class.getName());
+
     public static final String LEVEL_OF_ASSURANCE = "LEVEL_2";
     public static final String SUBMIT_TEXT = "Post eIDAS Response SAML to Connector Node";
 
@@ -48,42 +45,42 @@ public class HubResponseResource {
         @FormParam("RelayState") String relayState,
         @Session HttpSession session) {
 
-        String hubRequestId;
-        String eidasRequestId;
-        String connectorEncrpytionCredential;
-        String connectorNodeUrl;
-        String eidasRelayState;
+        GatewaySessionData sessionData = GatewaySessionDataValidator.getValidatedSessionData(session);
 
-        try {
-            hubRequestId = session.getAttribute(SESSION_KEY_HUB_REQUEST_ID).toString();
-            eidasRequestId = session.getAttribute(SESSION_KEY_EIDAS_REQUEST_ID).toString();
-            connectorEncrpytionCredential = session.getAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT).toString();
-            connectorNodeUrl = session.getAttribute(SESSION_KEY_EIDAS_DESTINATION).toString();
-            eidasRelayState = session.getAttribute(SESSION_KEY_EIDAS_RELAY_STATE).toString();
-        } catch (NullPointerException e) {
-            throw new SessionAttributeException(e);
-        }
-
-        LOG.info(String.format("[HUB Response] received for hub authn request ID '%s', eIDAS authn request ID '%s'", hubRequestId, eidasRequestId));
+        LOG.info(
+            String.format(
+                "[HUB Response] received for session '%s', hub authn request ID '%s', eIDAS authn request ID '%s'",
+                session.getId(),
+                sessionData.getHubRequestId(),
+                sessionData.getEidasRequestId()
+            )
+        );
 
         HubResponseTranslatorRequest translatorRequest = new HubResponseTranslatorRequest(
             hubResponse,
-            hubRequestId,
-            eidasRequestId,
+            sessionData.getHubRequestId(),
+            sessionData.getEidasRequestId(),
             LEVEL_OF_ASSURANCE,
-            UriBuilder.fromUri(connectorNodeUrl).build(),
-            connectorEncrpytionCredential
+            UriBuilder.fromUri(sessionData.getEidasDestination()).build(),
+            sessionData.getEidasConnectorPublicKey()
         );
 
         String eidasResponse = translatorProxy.getTranslatedResponse(translatorRequest);
 
-        LOG.info(String.format("[eIDAS Response] received for hub authn request ID '%s', eIDAS authn request ID '%s'", hubRequestId, eidasRequestId));
+        LOG.info(
+            String.format(
+                "[eIDAS Response] received for session '%s', hub authn request ID '%s', eIDAS authn request ID '%s'",
+                session.getId(),
+                sessionData.getHubRequestId(),
+                sessionData.getEidasRequestId()
+            )
+        );
 
         return samlFormViewBuilder.buildResponse(
-            connectorNodeUrl,
+            sessionData.getEidasDestination(),
             eidasResponse,
             SUBMIT_TEXT,
-            eidasRelayState
+            sessionData.getEidasRelayState()
         );
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -3,6 +3,7 @@ package uk.gov.ida.notification.resources;
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
 import uk.gov.ida.notification.SamlFormViewBuilder;
+import uk.gov.ida.notification.exceptions.SessionAttributeException;
 import uk.gov.ida.notification.proxy.TranslatorProxy;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
@@ -47,11 +48,21 @@ public class HubResponseResource {
         @FormParam("RelayState") String relayState,
         @Session HttpSession session) {
 
-        String hubRequestId = session.getAttribute(SESSION_KEY_HUB_REQUEST_ID).toString();
-        String eidasRequestId = session.getAttribute(SESSION_KEY_EIDAS_REQUEST_ID).toString();
-        String connectorEncrpytionCredential = session.getAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT).toString();
-        String connectorNodeUrl = session.getAttribute(SESSION_KEY_EIDAS_DESTINATION).toString();
-        String eidasRelayState = session.getAttribute(SESSION_KEY_EIDAS_RELAY_STATE).toString();
+        String hubRequestId;
+        String eidasRequestId;
+        String connectorEncrpytionCredential;
+        String connectorNodeUrl;
+        String eidasRelayState;
+
+        try {
+            hubRequestId = session.getAttribute(SESSION_KEY_HUB_REQUEST_ID).toString();
+            eidasRequestId = session.getAttribute(SESSION_KEY_EIDAS_REQUEST_ID).toString();
+            connectorEncrpytionCredential = session.getAttribute(SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT).toString();
+            connectorNodeUrl = session.getAttribute(SESSION_KEY_EIDAS_DESTINATION).toString();
+            eidasRelayState = session.getAttribute(SESSION_KEY_EIDAS_RELAY_STATE).toString();
+        } catch (NullPointerException e) {
+            throw new SessionAttributeException(e);
+        }
 
         LOG.info(String.format("[HUB Response] received for hub authn request ID '%s', eIDAS authn request ID '%s'", hubRequestId, eidasRequestId));
 

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -65,7 +65,7 @@ public class HubResponseResource {
             sessionData.getEidasConnectorPublicKey()
         );
 
-        String eidasResponse = translatorProxy.getTranslatedResponse(translatorRequest);
+        String eidasResponse = translatorProxy.getTranslatedResponse(translatorRequest, session.getId());
 
         LOG.info(
             String.format(

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
@@ -2,6 +2,8 @@ package uk.gov.ida.notification.session;
 
 
 import org.hibernate.validator.constraints.NotEmpty;
+import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
 
 public class GatewaySessionData {
     @NotEmpty
@@ -19,17 +21,15 @@ public class GatewaySessionData {
     private final String eidasConnectorPublicKey;
 
     public GatewaySessionData(
-        String hubRequestId,
-        String eidasRequestId,
-        String eidasDestination,
-        String eidasRelayState,
-        String eidasConnectorPublicKey
+        EidasSamlParserResponse eidasSamlParserResponse,
+        AuthnRequestResponse vspResponse,
+        String eidasRelayState
     ) {
-        this.hubRequestId = hubRequestId;
-        this.eidasRequestId = eidasRequestId;
-        this.eidasDestination = eidasDestination;
+        this.hubRequestId = vspResponse.getRequestId();
+        this.eidasRequestId = eidasSamlParserResponse.getRequestId();
+        this.eidasDestination = eidasSamlParserResponse.getDestination();
         this.eidasRelayState = eidasRelayState;
-        this.eidasConnectorPublicKey = eidasConnectorPublicKey;
+        this.eidasConnectorPublicKey = eidasSamlParserResponse.getConnectorEncryptionPublicCertificate();
     }
 
     public String getHubRequestId() { return this.hubRequestId; }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
@@ -1,0 +1,44 @@
+package uk.gov.ida.notification.session;
+
+
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class GatewaySessionData {
+    @NotEmpty
+    private final String hubRequestId;
+
+    @NotEmpty
+    private final String eidasRequestId;
+
+    @NotEmpty
+    private final String eidasDestination;
+
+    private final String eidasRelayState;
+
+    @NotEmpty
+    private final String eidasConnectorPublicKey;
+
+    public GatewaySessionData(
+        String hubRequestId,
+        String eidasRequestId,
+        String eidasDestination,
+        String eidasRelayState,
+        String eidasConnectorPublicKey
+    ) {
+        this.hubRequestId = hubRequestId;
+        this.eidasRequestId = eidasRequestId;
+        this.eidasDestination = eidasDestination;
+        this.eidasRelayState = eidasRelayState;
+        this.eidasConnectorPublicKey = eidasConnectorPublicKey;
+    }
+
+    public String getHubRequestId() { return this.hubRequestId; }
+
+    public String getEidasRequestId() { return this.eidasRequestId; }
+
+    public String getEidasDestination() { return this.eidasDestination; }
+
+    public String getEidasRelayState() { return this.eidasRelayState; }
+
+    public String getEidasConnectorPublicKey() { return this.eidasConnectorPublicKey; }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionDataValidator.java
@@ -1,0 +1,40 @@
+package uk.gov.ida.notification.session;
+
+import uk.gov.ida.notification.exceptions.SessionAttributeException;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_SESSION_DATA;
+
+public class GatewaySessionDataValidator {
+    private static final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    public static final String NOT_NULL_MESSAGE = "Session data can not be null";
+
+    public static GatewaySessionData getValidatedSessionData(HttpSession session) {
+        GatewaySessionData sessionData = (GatewaySessionData) session.getAttribute(SESSION_KEY_SESSION_DATA);
+        if (sessionData == null) throw new SessionAttributeException(NOT_NULL_MESSAGE, session.getId());
+
+        Set<ConstraintViolation<GatewaySessionData>> violations = validator.validate(sessionData);
+        if (violations.size() > 0) {
+            List<String> collect = violations
+                .stream()
+                .map(GatewaySessionDataValidator::combinePropertyAndMessage)
+                .sorted()
+                .collect(Collectors.toList());
+
+            throw new SessionAttributeException(String.join(", ", collect), session.getId());
+        }
+
+        return sessionData;
+    }
+
+    private static String combinePropertyAndMessage(ConstraintViolation violation) {
+        return String.format("%s field %s", violation.getPropertyPath().toString(), violation.getMessage());
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/SessionKeys.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/SessionKeys.java
@@ -1,9 +1,5 @@
 package uk.gov.ida.notification.session;
 
 public interface SessionKeys {
-    String SESSION_KEY_EIDAS_REQUEST_ID = "eidas_request_id";
-    String SESSION_KEY_EIDAS_CONNECTOR_PUBLIC_CERT = "eidas_connector_public_key";
-    String SESSION_KEY_EIDAS_DESTINATION = "eidas_destination";
-    String SESSION_KEY_EIDAS_RELAY_STATE = "eidas_relay_state";
-    String SESSION_KEY_HUB_REQUEST_ID = "hub_request_id";
+    String SESSION_KEY_SESSION_DATA = "session-data";
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -16,6 +16,7 @@ import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
 import uk.gov.ida.notification.apprule.rules.TestEidasSamlClientErrorResource;
 import uk.gov.ida.notification.apprule.rules.TestEidasSamlResource;
 import uk.gov.ida.notification.apprule.rules.TestEidasSamlServerErrorResource;
+import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderServerErrorResource;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.verify;
 public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
 
     @ClassRule
-    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
+    public static final TranslatorClientRule<TestTranslatorResource> translatorClientRule = new TranslatorClientRule(new TestTranslatorResource());
 
     @ClassRule
     public static final EidasSamlParserClientRule<TestEidasSamlResource> espClientRule = new EidasSamlParserClientRule<>(new TestEidasSamlResource());

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HealthCheckAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HealthCheckAppRuleTests.java
@@ -8,6 +8,7 @@ import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
 import uk.gov.ida.notification.apprule.rules.TestEidasSamlResource;
+import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
 import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class HealthCheckAppRuleTests extends GatewayAppRuleTestBase {
     @ClassRule
-    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
+    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule(new TestTranslatorResource());
 
     @ClassRule
     public static final EidasSamlParserClientRule espClientRule = new EidasSamlParserClientRule(new TestEidasSamlResource());

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -5,6 +5,7 @@ import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
@@ -13,6 +14,7 @@ import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
 import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
+import uk.gov.ida.notification.exceptions.mappers.SessionAttributeExceptionMapper;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.shared.Urls;
@@ -22,7 +24,15 @@ import javax.ws.rs.core.Form;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
@@ -71,7 +81,12 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
     }
 
     @Test
-    public void returnsErrorPageAndLogsIfNoSession() throws Exception {
+    public void returnsErrorPageAndLogsIfSessionAttributeException() throws Exception {
+        Handler logHandler = mock(Handler.class);
+        ArgumentCaptor<LogRecord> captorLoggingEvent = ArgumentCaptor.forClass(LogRecord.class);
+        Logger logger = Logger.getLogger(SessionAttributeExceptionMapper.class.getName());
+        logger.addHandler(logHandler);
+
         Form postForm = new Form()
             .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
             .param("RelayState", "relay-state");
@@ -88,6 +103,11 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
             htmlString,
             "//div[@class='issues'][text()='Something went wrong with the session attributes']"
         );
+
+        verify(logHandler).publish(captorLoggingEvent.capture());
+        assertThat(captorLoggingEvent.getValue().getLevel()).isEqualTo(WARNING);
+        assertThat(captorLoggingEvent.getValue().getMessage())
+            .matches("Exception reading attributes for session '.+': Session data can not be null");
     }
 
     private NewCookie getSessionCookie() throws Exception {

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -43,7 +43,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
     );
 
     @Test
-    public void hubResponseReturnsHtmlFormWithSamlBlob() throws Exception{
+    public void hubResponseReturnsHtmlFormWithSamlBlob() throws Exception {
         Form postForm = new Form()
             .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
             .param("RelayState", "relay-state");
@@ -67,6 +67,26 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         HtmlHelpers.assertXPath(
             htmlString,
             "//form[@action='http://connector-node.com']/input[@name='RelayState'][@value='relay-state']"
+        );
+    }
+
+    @Test
+    public void returnsErrorPageAndLogsIfNoSession() throws Exception {
+        Form postForm = new Form()
+            .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
+            .param("RelayState", "relay-state");
+
+        Response response = proxyNodeAppRule
+            .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+            .request()
+            .post(Entity.form(postForm));
+
+        assertEquals(400, response.getStatus());
+
+        String htmlString = response.readEntity(String.class);
+        HtmlHelpers.assertXPath(
+            htmlString,
+            "//div[@class='issues'][text()='Something went wrong with the session attributes']"
         );
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -2,6 +2,7 @@ package uk.gov.ida.notification.apprule;
 
 import io.dropwizard.testing.ConfigOverride;
 import org.glassfish.jersey.internal.util.Base64;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,11 +11,14 @@ import uk.gov.ida.notification.apprule.base.GatewayAppRuleTestBase;
 import uk.gov.ida.notification.apprule.rules.EidasSamlParserClientRule;
 import uk.gov.ida.notification.apprule.rules.GatewayAppRule;
 import uk.gov.ida.notification.apprule.rules.TestEidasSamlResource;
+import uk.gov.ida.notification.apprule.rules.TestTranslatorClientErrorResource;
 import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
+import uk.gov.ida.notification.apprule.rules.TestTranslatorServerErrorResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
 import uk.gov.ida.notification.apprule.rules.TranslatorClientRule;
 import uk.gov.ida.notification.apprule.rules.VerifyServiceProviderClientRule;
 import uk.gov.ida.notification.exceptions.mappers.SessionAttributeExceptionMapper;
+import uk.gov.ida.notification.exceptions.mappers.TranslatorResponseExceptionMapper;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.saml.SamlFormMessageType;
 import uk.gov.ida.notification.shared.Urls;
@@ -37,7 +41,13 @@ import static org.mockito.Mockito.verify;
 public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
     @ClassRule
-    public static final TranslatorClientRule translatorClientRule = new TranslatorClientRule();
+    public static final TranslatorClientRule<TestTranslatorResource> translatorClientRule = new TranslatorClientRule<>(new TestTranslatorResource());
+
+    @ClassRule
+    public static final TranslatorClientRule<TestTranslatorServerErrorResource> translatorClientServerErrorRule = new TranslatorClientRule<>(new TestTranslatorServerErrorResource());
+
+    @ClassRule
+    public static final TranslatorClientRule<TestTranslatorClientErrorResource> translatorClientClientErrorRule = new TranslatorClientRule<>(new TestTranslatorClientErrorResource());
 
     @ClassRule
     public static final EidasSamlParserClientRule<TestEidasSamlResource> espClientRule = new EidasSamlParserClientRule<>(new TestEidasSamlResource());
@@ -52,16 +62,39 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         ConfigOverride.config("translatorService.url", translatorClientRule.baseUri().toString())
     );
 
+    @Rule
+    public GatewayAppRule proxyNodeServerErrorAppRule = new GatewayAppRule(
+        ConfigOverride.config("eidasSamlParserService.url", espClientRule.baseUri().toString()),
+        ConfigOverride.config("verifyServiceProviderService.url", vspClientRule.baseUri().toString()),
+        ConfigOverride.config("translatorService.url", translatorClientServerErrorRule.baseUri().toString())
+    );
+
+    @Rule
+    public GatewayAppRule proxyNodeClientErrorAppRule = new GatewayAppRule(
+        ConfigOverride.config("eidasSamlParserService.url", espClientRule.baseUri().toString()),
+        ConfigOverride.config("verifyServiceProviderService.url", vspClientRule.baseUri().toString()),
+        ConfigOverride.config("translatorService.url", translatorClientClientErrorRule.baseUri().toString())
+    );
+
+    private final Form postForm = new Form()
+        .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
+        .param("RelayState", "relay-state");
+
+    private Handler logHandler;
+    private ArgumentCaptor<LogRecord> captorLoggingEvent;
+
+    @Before
+    public void setup() {
+        logHandler = mock(Handler.class);
+        captorLoggingEvent = ArgumentCaptor.forClass(LogRecord.class);
+    }
+
     @Test
     public void hubResponseReturnsHtmlFormWithSamlBlob() throws Exception {
-        Form postForm = new Form()
-            .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
-            .param("RelayState", "relay-state");
-
         Response response = proxyNodeAppRule
             .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
             .request()
-            .cookie(getSessionCookie())
+            .cookie(getSessionCookie(proxyNodeAppRule))
             .post(Entity.form(postForm));
 
         assertEquals(200, response.getStatus());
@@ -82,14 +115,8 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
     @Test
     public void returnsErrorPageAndLogsIfSessionAttributeException() throws Exception {
-        Handler logHandler = mock(Handler.class);
-        ArgumentCaptor<LogRecord> captorLoggingEvent = ArgumentCaptor.forClass(LogRecord.class);
         Logger logger = Logger.getLogger(SessionAttributeExceptionMapper.class.getName());
         logger.addHandler(logHandler);
-
-        Form postForm = new Form()
-            .param(SamlFormMessageType.SAML_RESPONSE, Base64.encodeAsString("I'm going to be a SAML blob"))
-            .param("RelayState", "relay-state");
 
         Response response = proxyNodeAppRule
             .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
@@ -110,8 +137,58 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
             .matches("Exception reading attributes for session '.+': Session data can not be null");
     }
 
-    private NewCookie getSessionCookie() throws Exception {
-        return postEidasAuthnRequest(buildAuthnRequest(), proxyNodeAppRule).getCookies().get("gateway-session");
+    @Test
+    public void serverErrorResponseFromTranslatorLogsAndReturns500() throws Exception {
+        Logger logger = Logger.getLogger(TranslatorResponseExceptionMapper.class.getName());
+        logger.addHandler(logHandler);
+
+        Response response = proxyNodeServerErrorAppRule
+            .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+            .request()
+            .cookie(getSessionCookie(proxyNodeServerErrorAppRule))
+            .post(Entity.form(postForm));
+
+        assertEquals(500, response.getStatus());
+
+        String htmlString = response.readEntity(String.class);
+        HtmlHelpers.assertXPath(
+            htmlString,
+            "//div[@class='issues'][text()='Something went wrong with the Translator']"
+        );
+
+        verify(logHandler).publish(captorLoggingEvent.capture());
+        assertThat(captorLoggingEvent.getValue().getLevel()).isEqualTo(WARNING);
+        assertThat(captorLoggingEvent.getValue().getMessage())
+            .matches("Exception calling translator for session '.*': Exception of type \\[REMOTE_SERVER_ERROR\\] whilst contacting uri:.*\n.*");
+    }
+
+    @Test
+    public void clientErrorResponseFromTranslatorLogsAndReturns400() throws Exception {
+        Logger logger = Logger.getLogger(TranslatorResponseExceptionMapper.class.getName());
+        logger.addHandler(logHandler);
+
+        Response response = proxyNodeClientErrorAppRule
+            .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+            .request()
+            .cookie(getSessionCookie(proxyNodeClientErrorAppRule))
+            .post(Entity.form(postForm));
+
+        assertEquals(400, response.getStatus());
+
+        String htmlString = response.readEntity(String.class);
+        HtmlHelpers.assertXPath(
+            htmlString,
+            "//div[@class='issues'][text()='Something went wrong with the Translator']"
+        );
+
+        verify(logHandler).publish(captorLoggingEvent.capture());
+        assertThat(captorLoggingEvent.getValue().getLevel()).isEqualTo(WARNING);
+        assertThat(captorLoggingEvent.getValue().getMessage())
+            .matches("Exception calling translator for session '.*': Exception of type \\[CLIENT_ERROR\\] whilst contacting uri:.*\n.*");
+    }
+
+    private NewCookie getSessionCookie(GatewayAppRule appRule) throws Exception {
+        return postEidasAuthnRequest(buildAuthnRequest(), appRule).getCookies().get("gateway-session");
     }
 
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorClientErrorResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorClientErrorResource.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.shared.Urls;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
+@Produces(MediaType.APPLICATION_JSON)
+public class TestTranslatorClientErrorResource {
+
+    @POST
+    @Path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH)
+    public Response post(HubResponseTranslatorRequest hubResponseTranslatorRequest) {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorServerErrorResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestTranslatorServerErrorResource.java
@@ -1,0 +1,22 @@
+package uk.gov.ida.notification.apprule.rules;
+
+import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.shared.Urls;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
+@Produces(MediaType.APPLICATION_JSON)
+public class TestTranslatorServerErrorResource {
+
+    @POST
+    @Path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH)
+    public Response post(HubResponseTranslatorRequest hubResponseTranslatorRequest) {
+        return Response.serverError().build();
+    }
+}
+

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TranslatorClientRule.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TranslatorClientRule.java
@@ -2,8 +2,6 @@ package uk.gov.ida.notification.apprule.rules;
 
 import io.dropwizard.testing.junit.DropwizardClientRule;
 
-public class TranslatorClientRule extends DropwizardClientRule {
-    public TranslatorClientRule() {
-        super(new TestTranslatorResource());
-    }
+public class TranslatorClientRule<T> extends DropwizardClientRule {
+    public TranslatorClientRule(T resource) { super(resource); }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
@@ -10,6 +10,7 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.exceptions.EidasSamlParserResponseException;
+import uk.gov.ida.notification.exceptions.saml.SamlParsingException;
 
 import javax.validation.Valid;
 import javax.ws.rs.POST;
@@ -21,8 +22,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.UNCHAINED_PUBLIC_CERT;
 
 public class EidasSamlParserProxyTest {
@@ -73,36 +74,30 @@ public class EidasSamlParserProxyTest {
     public void shouldThrowEidasSamlParserResponseExceptionOnServerError() {
         EidasSamlParserProxy eidasSamlParserService = setUpEidasSamlParserService("/parse/server-error");
 
-        try {
-            EidasSamlParserResponse response = eidasSamlParserService.parse(eidasSamlParserRequest, "session_id");
-            fail("Expected exception not thrown");
-        } catch (EidasSamlParserResponseException e) {
-            assertThat(e.getCause().getMessage())
-                .startsWith(
-                    String.format(
-                        "Exception of type [REMOTE_SERVER_ERROR] whilst contacting uri: %s/parse/server-error",
-                        clientRule.baseUri().toString()
-                    )
-                );
-        }
+        Throwable thrown = catchThrowable(() -> { eidasSamlParserService.parse(eidasSamlParserRequest, "session_id"); });
+        assertThat(thrown).isInstanceOf(EidasSamlParserResponseException.class);
+        assertThat(thrown.getCause().getMessage())
+            .startsWith(
+                String.format(
+                    "Exception of type [REMOTE_SERVER_ERROR] whilst contacting uri: %s/parse/server-error",
+                    clientRule.baseUri().toString()
+                )
+            );
     }
 
     @Test
     public void shouldThrowEidasSamlParserResponseExceptionOnClientError() {
         EidasSamlParserProxy eidasSamlParserService = setUpEidasSamlParserService("/parse/client-error");
 
-        try {
-            EidasSamlParserResponse response = eidasSamlParserService.parse(eidasSamlParserRequest, "session_id");
-            fail("Expected exception not thrown");
-        } catch (EidasSamlParserResponseException e) {
-            assertThat(e.getCause().getMessage())
-                .startsWith(
-                    String.format(
-                        "Exception of type [CLIENT_ERROR] whilst contacting uri: %s/parse/client-error",
-                        clientRule.baseUri().toString()
-                    )
-                );
-        }
+        Throwable thrown = catchThrowable(() -> { eidasSamlParserService.parse(eidasSamlParserRequest, "session_id"); });
+        assertThat(thrown).isInstanceOf(EidasSamlParserResponseException.class);
+        assertThat(thrown.getCause().getMessage())
+            .startsWith(
+                String.format(
+                    "Exception of type [CLIENT_ERROR] whilst contacting uri: %s/parse/client-error",
+                    clientRule.baseUri().toString()
+                )
+            );
     }
 
     private EidasSamlParserProxy setUpEidasSamlParserService(String url) {

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit.DropwizardClientRule;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.ida.exceptions.ApplicationException;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
@@ -12,6 +12,7 @@ import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.exceptions.TranslatorResponseException;
 
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -21,7 +22,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TranslatorProxyTest {
@@ -29,10 +32,16 @@ public class TranslatorProxyTest {
     @Produces(MediaType.APPLICATION_JSON)
     public static class TestTranslatorResource {
 
+        @Path("/happy")
         @POST
         public Response testTranslate(HubResponseTranslatorRequest request) {
-            System.out.println("What?");
             return Response.ok().entity("translated_saml_response_blob").build();
+        }
+
+        @Path("/server-error")
+        @POST
+        public Response testServerErrorTranslate(HubResponseTranslatorRequest request) {
+            return Response.serverError().build();
         }
     }
 
@@ -57,16 +66,46 @@ public class TranslatorProxyTest {
         );
         TranslatorProxy translatorProxy = new TranslatorProxy(
             jsonClient,
-            clientRule.baseUri()
+            UriBuilder.fromUri(clientRule.baseUri()).path("/translate-hub-response/happy").build()
         );
 
-        String samlResponse = translatorProxy.getTranslatedResponse(request);
+        String samlResponse = translatorProxy.getTranslatedResponse(request, "session-id");
 
         assertEquals("translated_saml_response_blob", samlResponse);
         Mockito.verify(jsonClient).post(
             request,
-            UriBuilder.fromUri(String.format("%s/translate-hub-response", clientRule.baseUri())).build(),
+            UriBuilder.fromUri(String.format("%s/translate-hub-response/happy", clientRule.baseUri())).build(),
             String.class
         );
+    }
+
+    @Test
+    public void shouldThrowTranslatorResponseExceptionWhenErrorPostingToTranslator() {
+        HubResponseTranslatorRequest request = new HubResponseTranslatorRequest(
+            "hub_response",
+            "requestid",
+            "eidas_request_id",
+            "level_of_assurance",
+            UriBuilder.fromUri("http://connector.node").build(),
+            "connector_encryption_certificate"
+        );
+
+        TranslatorProxy translatorProxy = new TranslatorProxy(
+            jsonClient,
+            UriBuilder.fromUri(clientRule.baseUri()).path("/translate-hub-response/server-error").build()
+        );
+
+        try {
+            translatorProxy.getTranslatedResponse(request, "session-id");
+            fail("Expected exception not thrown");
+        } catch (TranslatorResponseException e) {
+            assertThat(
+                e.getCause().getMessage()).startsWith(
+                    String.format(
+                        "Exception of type [REMOTE_SERVER_ERROR] whilst contacting uri: %s/translate-hub-response/server-error",
+                        clientRule.baseUri().toString()
+                    )
+            );
+        }
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
@@ -23,8 +23,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TranslatorProxyTest {
@@ -95,17 +95,14 @@ public class TranslatorProxyTest {
             UriBuilder.fromUri(clientRule.baseUri()).path("/translate-hub-response/server-error").build()
         );
 
-        try {
-            translatorProxy.getTranslatedResponse(request, "session-id");
-            fail("Expected exception not thrown");
-        } catch (TranslatorResponseException e) {
-            assertThat(
-                e.getCause().getMessage()).startsWith(
-                    String.format(
-                        "Exception of type [REMOTE_SERVER_ERROR] whilst contacting uri: %s/translate-hub-response/server-error",
-                        clientRule.baseUri().toString()
-                    )
+        Throwable thrown = catchThrowable(() -> { translatorProxy.getTranslatedResponse(request, "session-id"); });
+        assertThat(thrown).isInstanceOf(TranslatorResponseException.class);
+        assertThat(thrown.getCause().getMessage())
+            .startsWith(
+                String.format(
+                    "Exception of type [REMOTE_SERVER_ERROR] whilst contacting uri: %s/translate-hub-response/server-error",
+                    clientRule.baseUri().toString()
+                )
             );
-        }
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
@@ -117,12 +117,11 @@ public class EidasAuthnRequestResourceTest {
 
     private void verifyHappyPath() {
         GatewaySessionData expectedSessionData = new GatewaySessionData(
-            "hub request id",
-            "eidas request id",
-            "destination",
-            "eidas relay state",
-            UNCHAINED_PUBLIC_CERT
+            eidasSamlParserResponse,
+            vspResponse,
+            "eidas relay state"
         );
+
         verify(session).setAttribute(eq(SESSION_KEY_SESSION_DATA), captorGatewaySessionData.capture());
         verify(session, times(3)).getId();
         verify(logHandler, times(7)).publish(captorLoggingEvent.capture());

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -27,8 +27,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -140,12 +139,9 @@ public class HubResponseResourceTest {
             translatorProxy
         );
 
-        try {
-            SamlFormView response = (SamlFormView) resource.hubResponse("hub_saml_response", "relay_state", session);
-            fail("Expected exception not thrown");
-        } catch (SessionAttributeException e) {
-            assertThat(e).hasMessage("Session data can not be null");
-        }
+        assertThatThrownBy(() -> { resource.hubResponse("hub_saml_response", "relay_state", session); })
+            .isInstanceOf(SessionAttributeException.class)
+            .hasMessage("Session data can not be null");
     }
 
     @Test
@@ -176,11 +172,8 @@ public class HubResponseResourceTest {
             translatorProxy
         );
 
-        try {
-            SamlFormView response = (SamlFormView) resource.hubResponse("hub_saml_response", "relay_state", session);
-            fail("Expected exception not thrown");
-        } catch (SessionAttributeException e) {
-            assertThat(e).hasMessage("eidasConnectorPublicKey field may not be empty, eidasDestination field may not be empty");
-        }
+        assertThatThrownBy(() -> { resource.hubResponse("hub_saml_response", "relay_state", session); })
+            .isInstanceOf(SessionAttributeException.class)
+            .hasMessage("eidasConnectorPublicKey field may not be empty, eidasDestination field may not be empty");
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -74,7 +75,7 @@ public class HubResponseResourceTest {
         );
         when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(sessionData);
         when(session.getId()).thenReturn("session-id");
-        when(translatorProxy.getTranslatedResponse(any(HubResponseTranslatorRequest.class))).thenReturn("translated_eidas_response");
+        when(translatorProxy.getTranslatedResponse(any(HubResponseTranslatorRequest.class), eq("session-id"))).thenReturn("translated_eidas_response");
 
         HubResponseResource resource =  new HubResponseResource(
             new SamlFormViewBuilder(),
@@ -83,7 +84,7 @@ public class HubResponseResourceTest {
 
         SamlFormView response = (SamlFormView) resource.hubResponse("hub_saml_response", "relay_state", session);
 
-        verify(translatorProxy).getTranslatedResponse(requestCaptor.capture());
+        verify(translatorProxy).getTranslatedResponse(requestCaptor.capture(), eq("session-id"));
         HubResponseTranslatorRequest request = requestCaptor.getValue();
 
         verifyNoMoreInteractions(translatorProxy);

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
@@ -1,9 +1,12 @@
 package uk.gov.ida.notification.session;
 
 import org.junit.Test;
+import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
 import uk.gov.ida.notification.exceptions.SessionAttributeException;
 
 import javax.servlet.http.HttpSession;
+import javax.ws.rs.core.UriBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -14,15 +17,27 @@ import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_SESSION_DA
 
 public class TestGatewaySessionDataValidator {
 
+    private final AuthnRequestResponse vspResponse = new AuthnRequestResponse(
+        "saml-request",
+        "hub-request-id",
+        UriBuilder.fromUri("https://example.com").build()
+    );
+
     @Test
     public void getValidatedSessionDataShouldReturnSessionData() {
-        GatewaySessionData expectedSessionData = new GatewaySessionData(
+        EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
             "hub-request-id",
-            "eidas-request-id",
-            "eidas-destination",
-            "eidas-relay-state",
-            "eidas-connector-public-key"
+            "issuer",
+            "eidas-connector-public-key",
+            "eidas-destination"
         );
+
+        GatewaySessionData expectedSessionData = new GatewaySessionData(
+            eidasSamlParserResponse,
+            vspResponse,
+            "eidas-relay-state"
+        );
+
         HttpSession session = mock(HttpSession.class);
 
         when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(expectedSessionData);
@@ -46,12 +61,17 @@ public class TestGatewaySessionDataValidator {
 
     @Test
     public void getValidatedSessionDataShouldThrowSessionAttributeExceptionIfSAttributeIsNullOrEmpty() {
-        GatewaySessionData expectedSessionData = new GatewaySessionData(
-            "hub-request-id",
-            "",
+        EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
             null,
-            "eidas-relay-state",
-            "eidas-connector-public-key"
+            "issuer",
+            "eidas-connector-public-key",
+            ""
+        );
+
+        GatewaySessionData expectedSessionData = new GatewaySessionData(
+            eidasSamlParserResponse,
+            vspResponse,
+            "eidas-relay-state"
         );
 
         HttpSession session = mock(HttpSession.class);

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
@@ -1,0 +1,67 @@
+package uk.gov.ida.notification.session;
+
+import org.junit.Test;
+import uk.gov.ida.notification.exceptions.SessionAttributeException;
+
+import javax.servlet.http.HttpSession;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.ida.notification.session.GatewaySessionDataValidator.NOT_NULL_MESSAGE;
+import static uk.gov.ida.notification.session.SessionKeys.SESSION_KEY_SESSION_DATA;
+
+public class TestGatewaySessionDataValidator {
+
+    @Test
+    public void getValidatedSessionDataShouldReturnSessionData() {
+        GatewaySessionData expectedSessionData = new GatewaySessionData(
+            "hub-request-id",
+            "eidas-request-id",
+            "eidas-destination",
+            "eidas-relay-state",
+            "eidas-connector-public-key"
+        );
+        HttpSession session = mock(HttpSession.class);
+
+        when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(expectedSessionData);
+        GatewaySessionData sessionData = GatewaySessionDataValidator.getValidatedSessionData(session);
+
+        assertThat(sessionData).isEqualTo(expectedSessionData);
+    }
+
+    @Test
+    public void getValidatedSessionDataShouldThrowSessionAttributeExceptionIfSessionDataIsNull() {
+        HttpSession session = mock(HttpSession.class);
+        when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(null);
+
+        try {
+            GatewaySessionDataValidator.getValidatedSessionData(session);
+            fail("Expected exception not thrown");
+        } catch (SessionAttributeException e) {
+            assertThat(e).hasMessage(NOT_NULL_MESSAGE);
+        }
+    }
+
+    @Test
+    public void getValidatedSessionDataShouldThrowSessionAttributeExceptionIfSAttributeIsNullOrEmpty() {
+        GatewaySessionData expectedSessionData = new GatewaySessionData(
+            "hub-request-id",
+            "",
+            null,
+            "eidas-relay-state",
+            "eidas-connector-public-key"
+        );
+
+        HttpSession session = mock(HttpSession.class);
+        when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(expectedSessionData);
+
+        try {
+            GatewaySessionDataValidator.getValidatedSessionData(session);
+            fail("Expected exception not thrown");
+        } catch (SessionAttributeException e) {
+            assertThat(e).hasMessage("eidasDestination field may not be empty, eidasRequestId field may not be empty");
+        }
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
@@ -9,7 +9,7 @@ import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.UriBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.ida.notification.session.GatewaySessionDataValidator.NOT_NULL_MESSAGE;
@@ -51,12 +51,9 @@ public class TestGatewaySessionDataValidator {
         HttpSession session = mock(HttpSession.class);
         when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(null);
 
-        try {
-            GatewaySessionDataValidator.getValidatedSessionData(session);
-            fail("Expected exception not thrown");
-        } catch (SessionAttributeException e) {
-            assertThat(e).hasMessage(NOT_NULL_MESSAGE);
-        }
+        assertThatThrownBy(() -> { GatewaySessionDataValidator.getValidatedSessionData(session); })
+            .isInstanceOf(SessionAttributeException.class)
+            .hasMessage(NOT_NULL_MESSAGE);
     }
 
     @Test
@@ -77,11 +74,8 @@ public class TestGatewaySessionDataValidator {
         HttpSession session = mock(HttpSession.class);
         when(session.getAttribute(SESSION_KEY_SESSION_DATA)).thenReturn(expectedSessionData);
 
-        try {
-            GatewaySessionDataValidator.getValidatedSessionData(session);
-            fail("Expected exception not thrown");
-        } catch (SessionAttributeException e) {
-            assertThat(e).hasMessage("eidasDestination field may not be empty, eidasRequestId field may not be empty");
-        }
+        assertThatThrownBy(() -> { GatewaySessionDataValidator.getValidatedSessionData(session); })
+            .isInstanceOf(SessionAttributeException.class)
+            .hasMessage("eidasDestination field may not be empty, eidasRequestId field may not be empty");
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/hubresponse/TranslatorResponseException.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/hubresponse/TranslatorResponseException.java
@@ -1,7 +1,0 @@
-package uk.gov.ida.notification.exceptions.hubresponse;
-
-public class TranslatorResponseException extends RuntimeException {
-    public TranslatorResponseException(Throwable cause) {
-        super(cause);
-    }
-}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/Urls.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/Urls.java
@@ -17,6 +17,7 @@ public interface Urls {
     interface TranslatorUrls {
         String TRANSLATOR_ROOT = "/translator";
         String TRANSLATE_HUB_RESPONSE_PATH = "/translate-hub-response";
+        String TRANSLATOR_HUB_RESPONSE_RESOURCE = TRANSLATOR_ROOT + TRANSLATE_HUB_RESPONSE_PATH;
     }
 
     interface VerifyServiceProviderUrls {


### PR DESCRIPTION
### EID-1338 Throw SessionAttributeException if missing session attributes
It's possible that a user won't have a session when posting a hub
response to the gateway. This could be because they've deleted their
cookies, the app has been deployed and all sessions have been
invalidated or their session has timed out.

We should handle that case.

### EID-1388 Map SessionAttributeException to error page

### EID-1338 Refactor session to an object
We were storing all the values we needed in the session as separate
attribute which led to a lot of duplication, especially when trying to
extract them. This moves them to an object.

### EID-1338 Handle http response errors from translator
Adds a custom exception and handler to handle 400 or 500 responses from
the translator. The status code is passed back to the user, and they're
shown an error page (a stand in for the moment).