### PR TITLE
BAU: Fix published signing algorithms in metadata

### DIFF
--- a/mdgen/src/main/resources/connector_template.xml.mustache
+++ b/mdgen/src/main/resources/connector_template.xml.mustache
@@ -3,8 +3,8 @@
   <md:Extensions>
     <eidas:SPType>public</eidas:SPType>
     <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-    <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsigmore#ecdsa-sha256"/>
-    <alg:SigningMethod MinKeySize="3072" MaxKeySize="4096" Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+    <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <alg:SigningMethod MinKeySize="2048" MaxKeySize="4096" Algorithm="http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1"/>
   </md:Extensions>
   <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>

--- a/mdgen/src/main/resources/proxy_template.xml.mustache
+++ b/mdgen/src/main/resources/proxy_template.xml.mustache
@@ -7,9 +7,8 @@
       </saml2:Attribute>
     </mdattr:EntityAttributes>
     <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-    <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsasha256"/>
-    <alg:SigningMethod MinKeySize="3072" MaxKeySize="4096" Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-    <alg:SigningMethod MinKeySize="3072" MaxKeySize="4096" Algorithm="http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1"/>
+    <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <alg:SigningMethod MinKeySize="2048" MaxKeySize="4096" Algorithm="http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1"/>
   </md:Extensions>
   <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>


### PR DESCRIPTION
We need to use and accept the algorithms specified in the eIDAS
Cryptographic Requirements document:

https://joinup.ec.europa.eu/sites/default/files/document/2015-11/eidas_-_crypto_requirements_for_the_eidas_interoperability_framework_v1.0.pdf