### PR TITLE
EID-1293 - Log hashed details for eidas response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ apply plugin: 'com.github.ben-manes.versions'
 
 ext {
     opensaml_version = '3.4.0'
-    dropwizard_version = '1.3.8'
+    dropwizard_version = '1.3.9'
     utils_version = '2.0.0-350'
-    saml_libs_version = "${opensaml_version}-163"
+    saml_libs_version = "${opensaml_version}-176"
     soft_hsm_version = '1.1.1'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -31,6 +31,7 @@ import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidat
 
 import java.security.cert.CertificateEncodingException;
 import java.util.Base64;
+import java.util.Optional;
 
 import static uk.gov.ida.notification.saml.SamlSignatureValidatorFactory.createSamlRequestSignatureValidator;
 
@@ -68,7 +69,7 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
 
         VerifySamlInitializer.init();
 
-        connectorMetadataResolverBundle = new MetadataResolverBundle<>(EidasSamlConfiguration::getConnectorMetadataConfiguration);
+        connectorMetadataResolverBundle = new MetadataResolverBundle<>(configuration -> Optional.of(configuration.getConnectorMetadataConfiguration()));
 
         bootstrap.addBundle(connectorMetadataResolverBundle);
         bootstrap.addBundle(new LogstashBundle());

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -1,10 +1,13 @@
 package uk.gov.ida.notification.translator.resources;
 
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.security.SecurityException;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.Attribute;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.VerifyServiceProviderTranslationRequest;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
@@ -20,7 +23,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import static uk.gov.ida.saml.core.transformers.ResponseAttributesHashFactory.hashResponseDetails;
 
 @Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -53,14 +61,42 @@ public class HubResponseTranslatorResource {
         final X509Certificate encryptionCertificate = X_509_CERTIFICATE_FACTORY.createCertificate(hubResponseTranslatorRequest.getConnectorEncryptionCertificate());
 
         final org.opensaml.saml.saml2.core.Response eidasResponse = eidasResponseGenerator.generate(hubResponseContainer, encryptionCertificate);
+
+        DateTime dateOfBirth = translatedHubResponse.getAttributes().getDateOfBirth().getValue();
+
+        String hashedEidasDetails = hashResponseDetails(
+                translatedHubResponse.getPid(),
+                translatedHubResponse.getAttributes().getFirstName().getValue(),
+                combineAttributeValues(translatedHubResponse.getAttributes().getMiddleNames()),
+                combineAttributeValues(translatedHubResponse.getAttributes().getSurnames()),
+                dateOfBirth.toString(DateTimeFormat.forPattern("YYYY-MM-dd"))
+        );
+
+        logHashedResponseDetails(
+                hubResponseTranslatorRequest.getRequestId(),
+                hubResponseTranslatorRequest.getDestinationUrl().toString(),
+                hashedEidasDetails);
         logEidasResponse(eidasResponse);
 
         final String samlMessage = MARSHALLER.transformToString(eidasResponse);
         return Response.ok().entity(samlMessage).build();
     }
 
+    private String combineAttributeValues(List<Attribute<String>> attributes) {
+        return attributes.stream()
+                .filter(Objects::nonNull)
+                .map(Attribute::getValue)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(" "));
+    }
+
     private void logEidasResponse(org.opensaml.saml.saml2.core.Response eidasResponse) {
         LOG.info("[eIDAS Response] ID: " + eidasResponse.getID());
         LOG.info("[eIDAS Response] In response to: " + eidasResponse.getInResponseTo());
+    }
+
+    private void logHashedResponseDetails(String requestId, String destination, String hashedDetails){
+        LOG.info(String.format("[eIDAS Response HASH] received for hub authn request ID '%s', destination '%s', hashedEidasDetails '%s'",
+                requestId, destination, hashedDetails));
     }
 }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 public class StubConnectorApplication extends Application<StubConnectorConfiguration> {
     private Metadata proxyNodeMetadata;
@@ -92,7 +93,7 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
 
 
         // Metadata
-        proxyNodeMetadataResolverBundle = new MetadataResolverBundle<>(StubConnectorConfiguration::getProxyNodeMetadataConfiguration);
+        proxyNodeMetadataResolverBundle = new MetadataResolverBundle<>(configuration -> Optional.of(configuration.getProxyNodeMetadataConfiguration()));
         bootstrap.addBundle(proxyNodeMetadataResolverBundle);
     }
 


### PR DESCRIPTION
- Once the translator has receivied the response from the VSP,
we should log the hashed attributes as well request id and destination.
- Upgrade saml-libs to latest
- Upgrade to dropwizard 1.3.9