### PR TITLE
Refactor EidasResponseBuilder to use builder pattern to create and eiDAS SAML response

### DIFF
--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
@@ -1,0 +1,114 @@
+package uk.gov.ida.notification.saml;
+
+import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.AttributeStatement;
+import org.opensaml.saml.saml2.core.AuthnStatement;
+import org.opensaml.saml.saml2.core.Condition;
+import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.impl.AudienceRestrictionImpl;
+import se.litsec.eidas.opensaml.ext.attributes.CurrentGivenNameType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class EidasResponseBuilderTest {
+
+    static {
+        try {
+            InitializationService.initialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testAnEidasResponseHasASeparateIdToItsAssertionId() {
+        Response response = EidasResponseBuilder.instance().build();
+        assertNotEquals(response.getAssertions().iterator().next().getID(), response.getID());
+    }
+
+    @Test
+    public void testAnEidasResponseHasSameIssuerValueAsItsAssertionIssuerValue() {
+        Response response = EidasResponseBuilder.instance().withIssuer("issuer").build();
+        assertEquals(response.getAssertions().iterator().next().getIssuer().getValue(), response.getIssuer().getValue());
+    }
+
+    @Test
+    public void testAnEidasResponseHasSuppliedStatusAsObject() {
+        Response response = EidasResponseBuilder.instance().withStatus("status").build();
+        Status status = response.getStatus();
+        assertThat(status.getStatusCode().getValue()).isEqualTo("status");
+    }
+
+    @Test
+    public void testAnEidasResponseHasSuppliedDestination() {
+        Response response = EidasResponseBuilder.instance().withDestination("a destination").build();
+        String destination = response.getDestination();
+        assertThat(destination).isEqualTo("a destination");
+    }
+
+    @Test
+    public void testAnEidasResponseHasSuppliedInResponseTo() {
+        Response response = EidasResponseBuilder.instance().withInResponseTo("in response to reference").build();
+        assertThat(response.getInResponseTo()).isEqualTo("in response to reference");
+    }
+
+    @Test
+    public void testAnEidasResponseAndAssertionHaveSameSuppliedIssueInstant() {
+        Response response = EidasResponseBuilder.instance().withIssueInstant(DateTime.now()).build();
+        assertThat(response.getIssueInstant()).isEqualByComparingTo(response.getAssertions().iterator().next().getIssueInstant());
+    }
+
+    @Test
+    public void testAllResponseAssertionsAreSet() {
+
+        Attribute attribute = new EidasAttributeBuilder(
+                "a name",
+                "a friendly name",
+                CurrentGivenNameType.TYPE_NAME, "name")
+                .build();
+
+        DateTime now = DateTime.now();
+        Response response = EidasResponseBuilder.instance()
+                .withAssertionSubject("an assertion subject")
+                .withAssertionConditions("some assertion conditions")
+                .addAssertionAttributeStatement(Lists.newArrayList(attribute))
+                .addAssertionAuthnStatement("an authStatement", now)
+                .build();
+
+
+        List<Assertion> assertions = response.getAssertions();
+        assertThat(assertions.size()).isEqualTo(1);
+
+        Assertion assertion = assertions.iterator().next();
+
+        assertThat(assertion.getSubject().getNameID().getValue()).contains("an assertion subject");
+
+        Conditions conditions = assertion.getConditions();
+        assertThat(conditions.getConditions().size()).isEqualTo(1);
+        Condition condition = conditions.getConditions().iterator().next();
+        assertThat(((AudienceRestrictionImpl) condition).getAudiences().iterator().next().getAudienceURI()).isEqualTo("some assertion conditions");
+
+        List<AttributeStatement> attributeStatements = assertion.getAttributeStatements();
+        assertThat(attributeStatements.size()).isEqualTo(1);
+        AttributeStatement attributeStatement = attributeStatements.iterator().next();
+        List<Attribute> attributes = attributeStatement.getAttributes();
+        assertThat(attributes.size()).isEqualTo(1);
+        assertThat(attributeStatement.getAttributes().iterator().next()).isEqualTo(attribute);
+
+        assertThat(assertion.getAuthnStatements().size()).isEqualTo(1);
+        AuthnStatement authnStatement = assertion.getAuthnStatements().iterator().next();
+        assertThat(authnStatement.getAuthnInstant()).isEqualByComparingTo(now);
+        assertThat(authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef()).isEqualTo("an authStatement");
+    }
+}

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.notification.saml;
 import com.google.common.collect.Lists;
 import org.joda.time.DateTime;
 import org.junit.Test;
+import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Attribute;
@@ -26,8 +27,8 @@ public class EidasResponseBuilderTest {
     static {
         try {
             InitializationService.initialize();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        } catch (InitializationException e) {
+            throw new IllegalStateException("Could not initialize opensaml in test", e);
         }
     }
 

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -90,8 +90,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     }
 
     private EidasResponseGenerator createEidasResponseGenerator(TranslatorConfiguration configuration) {
-        HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
-                () -> EidasResponseBuilder.instance(),
+        HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(EidasResponseBuilder::instance,
                 configuration.getConnectorNodeIssuerId(),
                 configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
         );

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -13,6 +13,7 @@ import uk.gov.ida.notification.VerifySamlInitializer;
 import uk.gov.ida.notification.exceptions.mappers.ApplicationExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.HubResponseTranslationExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
+import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 import uk.gov.ida.notification.translator.configuration.TranslatorConfiguration;
 import uk.gov.ida.notification.translator.resources.HubResponseTranslatorResource;
@@ -90,6 +91,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
 
     private EidasResponseGenerator createEidasResponseGenerator(TranslatorConfiguration configuration) {
         HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
+                () -> EidasResponseBuilder.instance(),
                 configuration.getConnectorNodeIssuerId(),
                 configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
         );

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -21,14 +21,20 @@ import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class HubResponseTranslator {
 
     private String connectorNodeIssuerId;
     private String proxyNodeMetadataForConnectorNodeUrl;
+    private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier;
 
-    public HubResponseTranslator(String connectorNodeIssuerId, String proxyNodeMetadataForConnectorNodeUrl) {
+    public HubResponseTranslator(
+            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier,
+            String connectorNodeIssuerId,
+            String proxyNodeMetadataForConnectorNodeUrl) {
+        this.eidasResponseBuilderSupplier = eidasResponseBuilderSupplier;
         this.connectorNodeIssuerId = connectorNodeIssuerId;
         this.proxyNodeMetadataForConnectorNodeUrl = proxyNodeMetadataForConnectorNodeUrl;
     }
@@ -77,19 +83,20 @@ public class HubResponseTranslator {
                 .map(EidasAttributeBuilder::build)
                 .collect(Collectors.toList());
 
-        return EidasResponseBuilder.createEidasResponse(
-                proxyNodeMetadataForConnectorNodeUrl,
-                getMappedStatusCode(hubResponseContainer.getVspScenario()),
-                hubResponseContainer.getPid(),
-                getMappedLoa(hubResponseContainer.getLevelOfAssurance()),
-                eidasAttributes,
-                hubResponseContainer.getEidasRequestId(),
-                DateTime.now(),
-                DateTime.now(),
-                DateTime.now(),
-                hubResponseContainer.getDestinationURL(),
-                connectorNodeIssuerId
-        );
+
+        DateTime now = DateTime.now();
+        return eidasResponseBuilderSupplier.get()
+                .withIssuer(proxyNodeMetadataForConnectorNodeUrl)
+                .withStatus(getMappedStatusCode(hubResponseContainer.getVspScenario()))
+                .withInResponseTo(hubResponseContainer.getEidasRequestId())
+                .withIssueInstant(now)
+                .withDestination(hubResponseContainer.getDestinationURL())
+                .withAssertionSubject(hubResponseContainer.getPid())
+                .addAssertionAuthnStatement(getMappedLoa(hubResponseContainer.getLevelOfAssurance()), now)
+                .addAssertionAttributeStatement(eidasAttributes)
+                .withAssertionConditions(connectorNodeIssuerId)
+                .build();
+
     }
 
     private void validateHubResponseContainerAttributes(HubResponseContainer hubResponseContainer) {

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -14,7 +14,6 @@ import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
 
 import java.net.URI;
-import java.util.function.Supplier;
 
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 
@@ -29,8 +28,6 @@ public class HubResponseTranslatorTest {
         }
     }
 
-    private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier = () -> EidasResponseBuilder.instance();
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -38,7 +35,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnValidResponseWhenIdentityVerified() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         Response response =
             translator.translate(buildHubResponseContainer());
@@ -52,7 +49,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnResponseForCancelledStatus() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         Response response =
             translator.translate(buildTranslatedHubResponseForCancelledStatus());
@@ -65,7 +62,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnResponseForAuthenticationFailedStatus() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         Response response =
                 translator.translate(buildTranslatedHubResponseForAuthenticationFailedStatus());
@@ -81,7 +78,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("HubResponseContainer Attributes null.");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildHubResponseContainerWithNoAttributes());
     }
@@ -93,7 +90,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("HubResponseContainer Attribute Surnames null.");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildHubResponseContainerWithOnlyOneAttribute());
     }
@@ -105,7 +102,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("Received error status from VSP: ");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildTranslatedHubResponseRequestError());
     }
@@ -117,7 +114,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("Received unsupported LOA from VSP: ");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildHubResponseContainerLOA1());
     }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -10,9 +10,11 @@ import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseTestAssertions;
 import uk.gov.ida.notification.exceptions.hubresponse.HubResponseTranslationException;
+import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
 
 import java.net.URI;
+import java.util.function.Supplier;
 
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 
@@ -27,6 +29,8 @@ public class HubResponseTranslatorTest {
         }
     }
 
+    private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier = () -> EidasResponseBuilder.instance();
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -34,7 +38,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnValidResponseWhenIdentityVerified() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         Response response =
             translator.translate(buildHubResponseContainer());
@@ -48,7 +52,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnResponseForCancelledStatus() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         Response response =
             translator.translate(buildTranslatedHubResponseForCancelledStatus());
@@ -61,7 +65,7 @@ public class HubResponseTranslatorTest {
     public void translateShouldReturnResponseForAuthenticationFailedStatus() {
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         Response response =
                 translator.translate(buildTranslatedHubResponseForAuthenticationFailedStatus());
@@ -77,10 +81,9 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("HubResponseContainer Attributes null.");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
-        Response response =
-                translator.translate(buildHubResponseContainerWithNoAttributes());
+        translator.translate(buildHubResponseContainerWithNoAttributes());
     }
 
     @Test
@@ -90,7 +93,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("HubResponseContainer Attribute Surnames null.");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildHubResponseContainerWithOnlyOneAttribute());
     }
@@ -102,7 +105,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("Received error status from VSP: ");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildTranslatedHubResponseRequestError());
     }
@@ -114,7 +117,7 @@ public class HubResponseTranslatorTest {
         expectedException.expectMessage("Received unsupported LOA from VSP: ");
 
         HubResponseTranslator translator =
-                new HubResponseTranslator("Issuer", "connectorMetadataURL");
+                new HubResponseTranslator(eidasResponseBuilderSupplier, "Issuer", "connectorMetadataURL");
 
         translator.translate(buildHubResponseContainerLOA1());
     }

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -90,21 +90,17 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
 
         DateTime now = DateTime.now();
 
-        Response response = EidasResponseBuilder.createEidasResponse(
-                "http://stub-connector/",
-                StatusCode.SUCCESS,
-                UUID.randomUUID().toString(),
-                EidasConstants.EIDAS_LOA_SUBSTANTIAL,
-                eidasAttributes,
-                authid,
-                now,
-                now,
-                now,
-                "http://stub-connector/SAML2/Response/POST",
-                "http://localhost:5000/Metadata"
-        );
-
-        return response;
+        return EidasResponseBuilder.instance()
+                .withIssuer("http://stub-connector/")
+                .withStatus(StatusCode.SUCCESS)
+                .withAssertionSubject(UUID.randomUUID().toString())
+                .addAssertionAuthnStatement(EidasConstants.EIDAS_LOA_SUBSTANTIAL, now)
+                .addAssertionAttributeStatement(eidasAttributes)
+                .withInResponseTo(authid)
+                .withIssueInstant(now)
+                .withDestination("http://stub-connector/SAML2/Response/POST")
+                .withAssertionConditions("http://localhost:5000/Metadata")
+                .build();
     }
 
     private Response signResponse(Response response) throws Exception {


### PR DESCRIPTION
Allow HubResponseTranslator to use a builder pattern to create an eIDAS response, in preference to calling a static method on EidasResponseBuilder with many arguments.

The PR:
* refactors `EidasResponseBuilder` to create a trasnslator `Response` using Builder pattern
* updates `HubResponseTranslator` to use the builder to create a response, the assignment of values to the builder is easier to read
* Adds unit tests for `EidasResponseBuilder`