### PR TITLE
EID-1350: Fix ESP Integration Tests

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -23,17 +23,18 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
 
     @Before
     public void setup() throws Throwable {
-        request = new EidasAuthnRequestBuilder().withIssuer(CONNECTOR_NODE_ENTITY_ID);
+        request = new EidasAuthnRequestBuilder()
+                .withIssuer(CONNECTOR_NODE_ENTITY_ID)
+                .withDestination("http://proxy-node/eidasAuthnRequest");
     }
 
     @Test
-    @Ignore
     public void shouldReturnRequestIdAndIssuer() throws Exception {
         AuthnRequest postedRequest = request
-                .withRandomRequestId()
+                .withRequestId("request_id")
                 .build();
         SamlObjectSigner samlObjectSigner = new SamlObjectSigner(
-            X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY)
+                X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY)
         );
         samlObjectSigner.sign(postedRequest);
 

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
@@ -2,7 +2,6 @@ package uk.gov.ida.notification.eidassaml.apprule.base;
 
 import io.dropwizard.testing.ConfigOverride;
 import keystore.KeyStoreResource;
-import org.glassfish.jersey.internal.util.Base64;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.opensaml.core.config.InitializationService;
@@ -19,6 +18,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URISyntaxException;
+import java.util.Base64;
 
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -60,9 +60,12 @@ public class EidasSamlParserAppRuleTestBase {
     );
 
     protected Response postEidasAuthnRequest(AuthnRequest authnRequest) throws MarshallingException {
-        System.out.println(marshaller.transformToString(authnRequest));
 
-        String eidasAuthnRequest = Base64.encodeAsString(ObjectUtils.toString(authnRequest));
+        String eidasAuthnRequest =
+                Base64.getEncoder().encodeToString(
+                        new SamlObjectMarshaller().transformToString(authnRequest).getBytes()
+                );
+
         EidasSamlParserRequest request = new EidasSamlParserRequest(eidasAuthnRequest);
 
         Response response = null;


### PR DESCRIPTION
Initial fix to make the first integration test work.

- Use SamlObjectMarshaller instead of ObjectUtils to convert the AuthnRequest to a string.  Fixes marshalling/encoding issues with the Signature and Digest.
- Use java.util.Base64 library to encode and decode on both sides of the wire for safety, rather than different libraries on each side.