### PR TITLE
EID-1350: ESP Integration Test Enhancements

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -20,6 +20,8 @@ import uk.gov.ida.notification.eidassaml.saml.validation.components.ComparisonVa
 import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestIssuerValidator;
 import uk.gov.ida.notification.eidassaml.saml.validation.components.RequestedAttributesValidator;
 import uk.gov.ida.notification.eidassaml.saml.validation.components.SpTypeValidator;
+import uk.gov.ida.notification.exceptions.mappers.InvalidAuthnRequestExceptionMapper;
+import uk.gov.ida.notification.exceptions.mappers.SamlTransformationErrorExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
 import uk.gov.ida.notification.saml.metadata.Metadata;
@@ -103,6 +105,7 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
                 configuration.getConnectorMetadataConfiguration(),
                 environment,
                 "connector-metadata");
+        registerExceptionMappers(environment);
     }
 
     private void registerMetadataHealthCheck(MetadataResolver metadataResolver, MetadataConfiguration connectorMetadataConfiguration, Environment environment, String name) {
@@ -113,6 +116,11 @@ public class EidasSamlApplication extends Application<EidasSamlConfiguration> {
         );
 
         environment.healthChecks().register(metadataHealthCheck.getName(), metadataHealthCheck);
+    }
+
+    private void registerExceptionMappers(Environment environment) {
+        environment.jersey().register(new SamlTransformationErrorExceptionMapper());
+        environment.jersey().register(new InvalidAuthnRequestExceptionMapper());
     }
 
     private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlConfiguration configuration, MetadataResolverBundle hubMetadataResolverBundle) throws Exception {

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -1,9 +1,12 @@
 package uk.gov.ida.notification.eidassaml.apprule;
 
+import org.apache.http.HttpStatus;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import se.litsec.eidas.opensaml.common.EidasConstants;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.eidassaml.apprule.base.EidasSamlParserAppRuleTestBase;
 import uk.gov.ida.notification.helpers.EidasAuthnRequestBuilder;
@@ -12,40 +15,204 @@ import uk.gov.ida.notification.saml.SamlObjectSigner;
 
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
+import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 
 public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
 
     private EidasAuthnRequestBuilder request;
+    private SamlObjectSigner samlObjectSigner;
 
     @Before
-    public void setup() throws Throwable {
+    public void setup() throws Exception {
         request = new EidasAuthnRequestBuilder()
                 .withIssuer(CONNECTOR_NODE_ENTITY_ID)
                 .withDestination("http://proxy-node/eidasAuthnRequest");
+        samlObjectSigner = new SamlObjectSigner(
+                X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY)
+        );
     }
 
     @Test
-    public void shouldReturnRequestIdAndIssuer() throws Exception {
-        AuthnRequest postedRequest = request
-                .withRequestId("request_id")
-                .build();
-        SamlObjectSigner samlObjectSigner = new SamlObjectSigner(
-                X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY)
+    public void shouldReturnOKForValidSignedRequest() throws Exception {
+        assertGoodRequest(request);
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestNotSignedCorrectly() throws Exception {
+        AuthnRequest requestWithIncorrectSigningKey = request.build();
+        SamlObjectSigner samlObjectSignerIncorrectSigningKey = new SamlObjectSigner(
+                X509CredentialFactory.build(STUB_COUNTRY_PUBLIC_PRIMARY_CERT, STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY)
         );
+        samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey);
+        assertErrorResponseWithMessage(
+                postEidasAuthnRequest(requestWithIncorrectSigningKey),
+                "Error during AuthnRequest Signature Validation: SAML Validation Specification: Signature was not valid."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestUnsigned() throws Exception {
+        AuthnRequest unsignedRequest = request.withRandomRequestId().build();
+        assertErrorResponseWithMessage(
+                postEidasAuthnRequest(unsignedRequest),
+                "Error during AuthnRequest Signature Validation: SAML Validation Specification: Message has no signature."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestIssuerMissing() throws Exception {
+        assertBadRequestWithMessage(
+                request.withIssuer(""),
+                "Error during AuthnRequest Signature Validation: SAML Validation Specification: SAML 'Issuer' element has no value."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestMissingRequestId() throws Exception {
+        AuthnRequest requestWithoutId = request.withoutRequestId().build();
+        samlObjectSigner.sign(requestWithoutId);
+        assertErrorResponseWithMessage(
+                postEidasAuthnRequest(requestWithoutId),
+                "Bad Authn Request from Connector Node: Missing Request ID."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestForceAuthnFalse() throws Exception {
+        assertBadRequestWithMessage(
+                request.withForceAuthn(false),
+                "Bad Authn Request from Connector Node: Request should require fresh authentication (forceAuthn should be true)."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestIsPassiveTrue() throws Exception {
+        assertBadRequestWithMessage(
+                request.withIsPassive(true),
+                "Bad Authn Request from Connector Node: Request should not require zero user interaction (isPassive should be missing or false)."
+        );
+    }
+
+    @Test
+    public void shouldReturnOKWhenAuthnRequestIsPassiveMissing() throws Exception {
+        assertGoodRequest(request.withoutIsPassive());
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestHasIncorrectDestination() throws Exception {
+        assertBadRequestWithMessage(
+                request.withDestination("https://bogus.eu/"),
+                "Bad Authn Request from Connector Node: SAML Validation Specification: Destination is incorrect."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestHasIncorrectComparison() throws Exception {
+        assertBadRequestWithMessage(
+                request.withComparison(AuthnContextComparisonTypeEnumeration.MAXIMUM),
+                "Bad Authn Request from Connector Node: Comparison type, if present, must be minimum."
+        );
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestExtensionsMissing() throws Exception {
+        assertBadRequestWithMessage(
+                request.withoutExtensions(),
+                "Bad Authn Request from Connector Node: Missing Extensions.");
+    }
+
+    @Test
+    public void shouldReturnHTTP400WhenAuthnRequestHasProtocolBinding() throws Exception {
+        assertBadRequestWithMessage(
+                request.withProtocolBinding("protocol-binding-attribute"),
+                "Bad Authn Request from Connector Node: Request should not specify protocol binding."
+        );
+    }
+
+    @Test
+    public void authnRequestShouldSupportCorrectSamlVersion() throws Throwable {
+        assertBadRequest(request.withSamlVersion(SAMLVersion.VERSION_10));
+        assertBadRequest(request.withSamlVersion(SAMLVersion.VERSION_11));
+        assertGoodRequest(request.withSamlVersion(SAMLVersion.VERSION_20));
+    }
+
+    @Test
+    public void authnRequestShouldSupportSPTypePublicOrMissing() throws Exception {
+        assertBadRequest(request.withSpType("private"));
+        assertGoodRequest(request.withSpType("public"));
+        assertGoodRequest(request.withoutSpType());
+    }
+
+    @Test
+    public void authnRequestShouldHaveSupportedLOA() throws Exception {
+        assertGoodRequest(request.withLoa(EidasConstants.EIDAS_LOA_SUBSTANTIAL));
+        assertBadRequest(request.withLoa(EidasConstants.EIDAS_LOA_LOW));
+        assertBadRequest(request.withLoa(EidasConstants.EIDAS_LOA_HIGH));
+        assertBadRequest(request.withoutLoa());
+    }
+
+    @Test
+    public void authnRequestShouldHaveRequestedAttributes() throws Exception {
+        assertBadRequestWithMessage(
+                request.withoutRequestedAttributes(),
+                "Bad Authn Request from Connector Node: Missing RequestedAttributes."
+        );
+    }
+
+    @Test
+    public void authnRequestShouldHaveValidAssertionConsumerServiceUrl() throws Exception {
+        assertBadRequestWithMessage(
+                request.withAssertionConsumerServiceURL("invalid-assertion-consumer-service-url"),
+                "Bad Authn Request from Connector Node: Supplied AssertionConsumerServiceURL has no match in metadata."
+        );
+    }
+
+    @Test
+    public void authnRequestShouldNotBeNotDuplicated() throws Exception {
+        AuthnRequest duplicatedRequest = request.build();
+        samlObjectSigner.sign(duplicatedRequest);
+        assertGoodResponse(duplicatedRequest, postEidasAuthnRequest(duplicatedRequest));
+        assertErrorResponseWithMessage(
+                postEidasAuthnRequest(duplicatedRequest),
+                "Bad Authn Request from Connector Node: Replay check of ID"
+        );
+    }
+
+    private void assertGoodRequest(EidasAuthnRequestBuilder builder) throws Exception {
+        AuthnRequest postedRequest = builder.withRandomRequestId().build();
         samlObjectSigner.sign(postedRequest);
+        assertGoodResponse(postedRequest, postEidasAuthnRequest(postedRequest));
+    }
 
-        Response response = postEidasAuthnRequest(postedRequest);
+    private void assertBadRequest(EidasAuthnRequestBuilder builder) throws Exception {
+        AuthnRequest postedRequest = builder.withRandomRequestId().build();
+        samlObjectSigner.sign(postedRequest);
+        assertErrorResponse(postEidasAuthnRequest(postedRequest));
+    }
 
-        if (response.getStatus() != 200) {
-            fail("Unsuccessful Response");
-        }
-        EidasSamlParserResponse responseDto = response.readEntity(EidasSamlParserResponse.class);
+    private void assertBadRequestWithMessage(EidasAuthnRequestBuilder builder, String errorMessageContains) throws Exception {
+        AuthnRequest postedRequest = builder.withRandomRequestId().build();
+        samlObjectSigner.sign(postedRequest);
+        assertErrorResponseWithMessage(postEidasAuthnRequest(postedRequest), errorMessageContains);
+    }
 
-        assertEquals(responseDto.getRequestId(), "request_id");
-        assertEquals(responseDto.getIssuer(), CONNECTOR_NODE_ENTITY_ID);
+    private void assertGoodResponse(AuthnRequest eidasAuthnRequest, Response response) {
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        EidasSamlParserResponse espResponse = response.readEntity(EidasSamlParserResponse.class);
+        assertThat(espResponse.getRequestId()).isEqualTo(eidasAuthnRequest.getID());
+        assertThat(espResponse.getIssuer()).isEqualTo(CONNECTOR_NODE_ENTITY_ID);
+    }
+
+    private void assertErrorResponse(Response response) {
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+    }
+
+    private void assertErrorResponseWithMessage(Response response, String errorMessageContains) {
+        assertErrorResponse(response);
+        assertThat(response.readEntity(String.class)).contains(errorMessageContains);
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/InvalidAuthnRequestExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/InvalidAuthnRequestExceptionMapper.java
@@ -1,0 +1,18 @@
+package uk.gov.ida.notification.exceptions.mappers;
+
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+import javax.ws.rs.core.Response;
+import static java.text.MessageFormat.format;
+
+public class InvalidAuthnRequestExceptionMapper extends BaseExceptionMapper<InvalidAuthnRequestException> {
+
+    @Override
+    protected void handleException(InvalidAuthnRequestException exception) {
+    }
+
+    @Override
+    protected Response getResponse(InvalidAuthnRequestException exception) {
+        final String message = format("ESP InvalidAuthnRequestException: {0}.", exception.getMessage());
+        return Response.status(Response.Status.BAD_REQUEST).entity(message).build();
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/SamlTransformationErrorExceptionMapper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/exceptions/mappers/SamlTransformationErrorExceptionMapper.java
@@ -1,0 +1,17 @@
+package uk.gov.ida.notification.exceptions.mappers;
+
+import uk.gov.ida.saml.core.validation.SamlTransformationErrorException;
+import javax.ws.rs.core.Response;
+import static java.text.MessageFormat.format;
+
+public class SamlTransformationErrorExceptionMapper extends BaseExceptionMapper<SamlTransformationErrorException> {
+
+    @Override
+    protected void handleException(SamlTransformationErrorException exception) { }
+
+    @Override
+    protected Response getResponse(SamlTransformationErrorException exception) {
+        final String message = format("Error during AuthnRequest Signature Validation: {0};", exception.getMessage());
+        return Response.status(Response.Status.BAD_REQUEST).entity(message).build();
+    }
+}


### PR DESCRIPTION
- Restore and update tests checking all validation scenarios for the AuthnRequest and Signature.
- Add ExceptionMappers to the ESP component to handle exceptions thrown when these validations fail.
- Use assertJ assertions.