### PR TITLE
EID-1307 Log authn request attributes in ESP

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -7,6 +7,7 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import se.litsec.opensaml.utils.ObjectUtils;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
+import uk.gov.ida.notification.eidassaml.logging.EidasAuthnRequestAttributesLogger;
 import uk.gov.ida.notification.eidassaml.saml.validation.EidasAuthnRequestValidator;
 import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidator;
@@ -22,7 +23,6 @@ import java.util.Base64;
 @Path(Urls.EidasSamlParserUrls.EIDAS_AUTHN_REQUEST_PATH)
 @Produces(MediaType.APPLICATION_JSON)
 public class EidasSamlResource {
-
     private EidasAuthnRequestValidator eidasAuthnRequestValidator;
     private SamlRequestSignatureValidator samlRequestSignatureValidator;
     private String x509EncryptionCertString;
@@ -48,6 +48,8 @@ public class EidasSamlResource {
 
         samlRequestSignatureValidator.validate(authnRequest, SPSSODescriptor.DEFAULT_ELEMENT_NAME);
         eidasAuthnRequestValidator.validate(authnRequest);
+
+        EidasAuthnRequestAttributesLogger.logAuthnRequestAttributes(authnRequest);
 
         return new EidasSamlParserResponse(
                 authnRequest.getID(),

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
@@ -1,0 +1,24 @@
+package uk.gov.ida.notification.eidassaml.logging;
+
+import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class EidasAuthnRequestAttributesLogger {
+    private static final Logger log = LoggerFactory.getLogger(EidasAuthnRequestAttributesLogger.class);
+
+    public static void logAuthnRequestAttributes(AuthnRequest authnRequest) {
+        try {
+            MDC.put("eidasRequestId", authnRequest.getID());
+            MDC.put("eidasDestination", authnRequest.getDestination());
+            MDC.put("eidasIssueInstant", authnRequest.getIssueInstant().toString());
+            MDC.put("eidasIssuer", authnRequest.getIssuer().getValue());
+            log.info("Authn request validated by ESP");
+        } catch (Exception e) {
+            MDC.clear();
+            throw e;
+        }
+        MDC.clear();
+    }
+}

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
@@ -16,9 +16,9 @@ public class EidasAuthnRequestAttributesLogger {
             MDC.put("eidasIssuer", authnRequest.getIssuer().getValue());
             log.info("Authn request validated by ESP");
         } catch (Exception e) {
-            MDC.clear();
             throw e;
+        } finally {
+            MDC.clear();
         }
-        MDC.clear();
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -2,6 +2,7 @@ package uk.gov.ida.notification.eidassaml;
 
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.glassfish.jersey.internal.util.Base64;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,6 +47,8 @@ public class EidasSamlResourceTest {
         issuer.setValue("issuer");
         authnRequest.setID("request_id");
         authnRequest.setIssuer(issuer);
+        authnRequest.setDestination("destination");
+        authnRequest.setIssueInstant(new DateTime(2019, 02, 28, 9, 54));
 
         EidasSamlParserRequest request = new EidasSamlParserRequest(Base64.encodeAsString(ObjectUtils.toString(authnRequest)));
         EidasSamlParserResponse response = resources.target("/eidasAuthnRequest")

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/logging/CombinedAuthnRequestAttributesLogger.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/logging/CombinedAuthnRequestAttributesLogger.java
@@ -1,0 +1,42 @@
+package uk.gov.ida.notification.logging;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.AuthnRequestResponse;
+
+import javax.servlet.http.HttpSession;
+
+public class CombinedAuthnRequestAttributesLogger {
+    private static final Logger log = LoggerFactory.getLogger(CombinedAuthnRequestAttributesLogger.class);
+
+    public static void logAuthnRequestAttributes(
+        String sessionId,
+        EidasSamlParserResponse eidasSamlParserResponse,
+        AuthnRequestResponse vspResponse
+    ) {
+        try {
+            MDC.put("sessionId", sessionId);
+            MDC.put("eidasRequestId", eidasSamlParserResponse.getRequestId());
+            MDC.put("eidasIssuer", eidasSamlParserResponse.getIssuer());
+            MDC.put("eidasDestination", eidasSamlParserResponse.getDestination());
+            MDC.put(
+                "eidasConnectorPublicKeySuffix",
+                StringUtils.right(
+                    eidasSamlParserResponse.getConnectorEncryptionPublicCertificate(),
+                    10
+                )
+            );
+            MDC.put("hubRequestId", vspResponse.getRequestId());
+            MDC.put("hubUrl", vspResponse.getSsoLocation().toString());
+            log.info("Authn requests received from ESP and VSP");
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            MDC.clear();
+        }
+
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -32,7 +32,6 @@ public class EidasAuthnRequestResource {
 
     private final Logger log = Logger.getLogger(getClass().getName());
     public static final String SUBMIT_BUTTON_TEXT = "Post Verify Authn Request to Hub";
-
     private final EidasSamlParserProxy eidasSamlParserService;
     private final VerifyServiceProviderProxy vspProxy;
     private final SamlFormViewBuilder samlFormViewBuilder;


### PR DESCRIPTION
### EID-1307 Log authn request attributes in ESP
Cyber needs us to log the attributes of the authn request after it's
been validated by the ESP.

They need the attributes to be key/value pairs in a json log event. We're
using the logstash-console appender which is jsonifying the logs for us.

We can add custom key/value pairs to those logs by adding them to
[logbacks MDC](https://logback.qos.ch/manual/mdc.html).

There will be a follow up piece of work to this to log the hub authn request
in the VSP.

### EID-1307 Refactor gateway authn route attribute logging
This refactors the gateway authn logging to log all the attributes in
one log message. Each attribute will appear as a key/value pair in the
json log event.