### PR TITLE
fix mdgen(erated) metadata expiring instantly

### DIFF
--- a/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
+++ b/mdgen/src/main/java/uk/gov/ida/mdgen/MetadataGenerator.java
@@ -182,7 +182,7 @@ public class MetadataGenerator implements Callable<Void> {
         String xml = renderTemplate(nodeType.toString() + "_template.xml.mustache", yamlMap);
         EntityDescriptor entityDescriptor = ObjectUtils.unmarshall(new ByteArrayInputStream(xml.getBytes()), EntityDescriptor.class);
         entityDescriptor.setID(UUID.randomUUID().toString());
-        entityDescriptor.setValidUntil(new DateTime());
+        entityDescriptor.setValidUntil(DateTime.now().plusDays(365));
         updateSsoDescriptor(entityDescriptor);
         sign(entityDescriptor);
         return entityDescriptor;


### PR DESCRIPTION
the mdgen tool was generating metadata that instantly expired, this
updates it to 1y.

long term we should consider accepting the expiry as an arg