### PR TITLE
bau - Improve logging when extracting encryption cert from metadata

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -89,7 +89,9 @@ public class EidasAuthnRequestResource {
         return eidasSamlParserService.parse(new EidasSamlParserRequest(encodedEidasAuthnRequest), sessionId);
     }
 
-    private AuthnRequestResponse generateHubRequestWithVsp(String sessionId) { return vspProxy.generateAuthnRequest(sessionId); }
+    private AuthnRequestResponse generateHubRequestWithVsp(String sessionId) {
+        return vspProxy.generateAuthnRequest(sessionId);
+    }
 
     private SamlFormView buildSamlFormView(AuthnRequestResponse vspResponse, String relayState) {
         URI hubUrl = vspResponse.getSsoLocation();

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/metadata/Metadata.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/metadata/Metadata.java
@@ -40,11 +40,11 @@ public class Metadata {
         try {
             Credential credential = metadataCredentialResolver.resolveSingle(criteria);
             if (credential == null) {
-                throw new MissingMetadataException(String.format("Missing %s certificate", usageType));
+                throw new MissingMetadataException(String.format("Missing %s certificate from Connector Metadata with entityID %s", usageType, entityId));
             }
             return credential;
         } catch (ResolverException ex) {
-            throw new InvalidMetadataException("Unable to resolve metadata credentials", ex);
+            throw new InvalidMetadataException(String.format("Unable to resolve metadata credentials from Connector Metadata with entityID %s", entityId), ex);
         }
     }
 


### PR DESCRIPTION
- The logging message was a bit vague when the ESP was unable to extract the encryption certificate from the Connector Metadata. This class is only being used to for the Connector Metadata so specify that in the log message and output the EntityID of the Connector Metadata. 