### PR TITLE
Ignore unknown properties when reading an attribute in the VSP response

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
@@ -1,11 +1,13 @@
 package uk.gov.ida.notification.contracts.verifyserviceprovider;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 
 import org.joda.time.DateTime;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Attribute<T> {
 
     @NotNull

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -23,7 +23,7 @@ public class Attributes {
 
     @NotNull
     @JsonProperty
-    private List<Attribute<DateTime>> dateOfBirths;
+    private List<Attribute<DateTime>> datesOfBirth;
 
     @JsonProperty
     private Attribute<String> gender;
@@ -39,13 +39,13 @@ public class Attributes {
             List<Attribute<String>> firstNames,
             List<Attribute<String>> middleNames,
             List<Attribute<String>> surnames,
-            List<Attribute<DateTime>> dateOfBirths,
+            List<Attribute<DateTime>> datesOfBirth,
             Attribute<String> gender,
             List<Attribute<Address>> addresses) {
         this.firstNames = firstNames;
         this.middleNames = middleNames;
         this.surnames = surnames;
-        this.dateOfBirths = dateOfBirths;
+        this.datesOfBirth = datesOfBirth;
         this.gender = gender;
         this.addresses = addresses;
     }
@@ -62,8 +62,8 @@ public class Attributes {
         return surnames;
     }
 
-    public List<Attribute<DateTime>> getDateOfBirths() {
-        return dateOfBirths;
+    public List<Attribute<DateTime>> getDatesOfBirth() {
+        return datesOfBirth;
     }
 
     public Attribute<String> getGender() {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -62,7 +62,7 @@ public class HubResponseTranslatorResource {
 
         final org.opensaml.saml.saml2.core.Response eidasResponse = eidasResponseGenerator.generate(hubResponseContainer, encryptionCertificate);
 
-        DateTime dateOfBirth = translatedHubResponse.getAttributes().getDateOfBirths().iterator().next().getValue();
+        DateTime dateOfBirth = translatedHubResponse.getAttributes().getDatesOfBirth().iterator().next().getValue();
 
         String hashedEidasDetails = hashResponseDetails(
                 translatedHubResponse.getPid(),

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -63,7 +63,7 @@ public class HubResponseTranslator {
                     combineAttributeValues(hubResponseContainer.getAttributes().getSurnames())
             ));
 
-            List<Attribute<DateTime>> dateOfBirths = hubResponseContainer.getAttributes().getDateOfBirths();
+            List<Attribute<DateTime>> dateOfBirths = hubResponseContainer.getAttributes().getDatesOfBirth();
             Attribute<DateTime> dateTimeAttribute = dateOfBirths.stream().findFirst().get();
             eidasAttributeBuilders.add(new EidasAttributeBuilder(
                     AttributeConstants.EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME, AttributeConstants.EIDAS_DATE_OF_BIRTH_ATTRIBUTE_FRIENDLY_NAME, DateOfBirthType.TYPE_NAME,
@@ -109,7 +109,7 @@ public class HubResponseTranslator {
             if (hubResponseContainer.getAttributes().getSurnames() == null) {
                 throw new HubResponseTranslationException("HubResponseContainer Attribute Surnames null.");
             }
-            if (hubResponseContainer.getAttributes().getDateOfBirths() == null) {
+            if (hubResponseContainer.getAttributes().getDatesOfBirth() == null) {
                 throw new HubResponseTranslationException("HubResponseContainer Attribute DateOfBirth null or missing value.");
             }
             if (hubResponseContainer.getPid() == null) {


### PR DESCRIPTION
* ignore unknown properties when reading an attribute in the VSP response
* and rename `dateOfBirths` to `datesOfBirth`