### PR TITLE
Read attribute value when supplying VSP first name for eIDAS response

### DIFF
--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -35,7 +35,7 @@ public class HubResponseTranslator {
     }
 
     private String combineFirstAndMiddleNames(List<Attribute<String>> firstNames, List<Attribute<String>> middleNames) {
-        return firstNames.stream().findFirst().get() + " " + combineAttributeValues(middleNames);
+        return firstNames.stream().findFirst().get().getValue() + " " + combineAttributeValues(middleNames);
     }
 
     private String combineAttributeValues(List<Attribute<String>> attributes) {

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -130,7 +130,6 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
         TranslatedHubResponseTestAssertions.checkAssertionStatementsValid(decryptedEidasResponse);
     }
 
-    @Ignore
     @Test
     public void eidasResponseShouldContainCorrectAttributes() throws Exception {
 

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -2,7 +2,6 @@ package uk.gov.ida.notification.translator.apprule;
 
 import org.glassfish.jersey.internal.util.Base64;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -31,7 +31,6 @@ public class HubResponseTranslatorTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Ignore
     @Test
     public void translateShouldReturnValidResponseWhenIdentityVerified() {
 

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.notification.translator.saml;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;


### PR DESCRIPTION
Read the string value of the firstname attribute. Reinstates two `@Ignored` tests.
A future PR is to tidy up the way we combine first and surnames into the eidas response