### PR TITLE
EID-1358: Log eIDAS Response Attributes using MDC: Do not clear all a…

### DIFF
--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseTranslatorLoggerHelper.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseTranslatorLoggerHelper.java
@@ -25,7 +25,10 @@ public class HubResponseTranslatorLoggerHelper {
             MDC.put(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_ISSUER, eidasResponse.getIssuer() != null ? eidasResponse.getIssuer().getValue() : "");
             log.info(EIDAS_RESPONSE_LOGGER_MESSAGE);
         } finally {
-            MDC.clear();
+            MDC.remove(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_ID);
+            MDC.remove(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_IN_RESPONSE_TO);
+            MDC.remove(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_DESTINATION);
+            MDC.remove(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_ISSUER);
         }
     }
 


### PR DESCRIPTION
…fter logging.

- Use MDC.remove() rather than MDC.clear() in order to preserve state of MDC in case of usage elsewhere on the same thread.