### PR TITLE
EID-1381 Integrate with Snyk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,19 @@ language: java
 jdk:
   - openjdk11
 
-script: ./gradlew --no-daemon --quiet test
+install:
+  - npm install -g snyk
+
+script:
+  - ./gradlew --no-daemon --quiet test
+  - snyk/test.sh
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+after_success:
+  - snyk/monitor.sh
 
 cache:
   directories:

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.github.ben-manes.versions'
 ext {
     opensaml_version = '3.4.0'
     dropwizard_version = '1.3.9'
-    utils_version = '2.0.0-350'
+    utils_version = '2.0.0-351'
     saml_libs_version = "${opensaml_version}-180"
     soft_hsm_version = '1.1.1'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
@@ -61,7 +61,8 @@ subprojects {
         proxy_node_test
         soft_hsm
     }
-
+//    If any configurations are added/changed please ensure their dependencies are still being tested and monitored by
+//    Snyk. See the Snyk directory in the root of the project.
     dependencies {
         common(
                 "javax.xml.bind:jaxb-api:2.3.0",
@@ -83,6 +84,18 @@ subprojects {
                 "org.opensaml:opensaml-storage-impl:${opensaml_version}",
         )
 
+        constraints {
+            opensaml("commons-collections:commons-collections:3.2.2") {
+                because "opensaml:3.4.0 has a dep on commons-collections:3.2.1 which is vulnerable to CVE-2015-7501"
+            }
+            opensaml("org.bouncycastle:bcprov-jdk15on:1.60") {
+                because "opensaml:3.4.0 has a dep on bcprov-jdk15on:1.59 which is vulnerable to CVE-2018-1000180"
+            }
+            opensaml("com.google.guava:guava:24.1.1") {
+                because "opensaml:3.4.0 has a dep on guava:20.0.0 which is vulnerable to CVE-2018-10237"
+            }
+        }
+
         eidas_saml(
                 "se.litsec.eidas:eidas-opensaml3:1.3.1",
                 "se.litsec.opensaml:opensaml3-ext:1.2.2",
@@ -99,6 +112,15 @@ subprojects {
                 "uk.gov.ida:saml-utils:${saml_libs_version}",
                 "uk.gov.ida:security-utils:${utils_version}",
         )
+
+        constraints {
+            verify_saml("commons-collections:commons-collections:3.2.2") {
+                because "saml_libs_version-176 has a dep on commons-collections:3.2.1 which is vulnerable to CVE-2015-7501"
+            }
+            verify_saml("org.bouncycastle:bcprov-jdk15on:1.60") {
+                because "saml_libs_version-176 has a dep on bcprov-jdk15on:1.59 which is vulnerable to CVE-2018-1000180"
+            }
+        }
 
         verify_saml_test(
                 "uk.gov.ida:common-test-utils:${utils_version}",

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# This is to allow the snyk_test and snyk_monitor scripts to both use the same list of configurations and stay in sync.
+# Any new gradle configurations to be tested should be added here.
+
+# shellcheck disable=SC2034
+CONFIGURATIONS="common dropwizard eidas_saml ida_utils opensaml soft_hsm verify_saml"

--- a/snyk/monitor.sh
+++ b/snyk/monitor.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# If a new configuration is added it will need adding to `snyk_configurations.sh`.
+# This script is intended to be used by a CI server.
+
+function print_banner() {
+    echo "######################################################################"
+    echo "### Monitoring dependencies for $1 gradle configuration"
+    echo "######################################################################"
+}
+
+function monitor_configuration() {
+    local config=$1;
+    print_banner "$config"
+    # The sub-project specified here is irrelevant. The configuration will still be tested regardless of if the
+    # sub-project actually uses it.
+    snyk monitor --gradle-sub-project=proxy-node-translator --project-name="$config"-config -- --configuration="$config"
+}
+
+source snyk/configurations.sh
+
+for configuration in $CONFIGURATIONS; do
+    monitor_configuration $configuration
+done;

--- a/snyk/test.sh
+++ b/snyk/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# If a new configuration is added it will need adding to `snyk_configurations.sh`.
+# This script is intended to be used by a CI server.
+
+exit_code=0
+
+function print_banner() {
+    echo "######################################################################"
+    echo "### Testing dependencies for $1 gradle configuration"
+    echo "######################################################################"
+}
+
+function test_configuration() {
+    local config=$1;
+    print_banner "$config"
+    # The sub-project specified here is irrelevant. The configuration will still be tested regardless of if the
+    # sub-project actually uses it.
+    snyk test --gradle-sub-project=proxy-node-translator -- --configuration="$config"
+    if [[ $? -gt 0 ]]; then
+        exit_code=1
+    fi
+}
+
+source snyk/configurations.sh
+
+for configuration in $CONFIGURATIONS; do
+   test_configuration $configuration
+done
+
+exit $exit_code


### PR DESCRIPTION
~~This PR is not ready to be merged. There's a technical issue on Snyk's end. Despite this repo being open source they're still imposing a limit of 200 tests per month on us (opensource projects should be unlimited). I have an ongoing support request with them. The approach and the code can still be reviewed however.~~
Snyk have kindly given us unlimited tests until they've resolved the issue, so this looks like it's ready for review.

### EID-1381 Integrate Snyk CLI with Travis  …
Snyk doesn't play very nicely with gradle sub-projects that use
configurations like we do. As such we can't use the Github integration.
We _can_ use the CLI however with Travis to get a similar result.

We can't test individual sub projects, only the gradle configurations.
The configurations to be tested are defined in one place, `snyk/configurations.sh`
so they can be sourced by the test and monitor scripts to ensure consistency.

If `snyk/test.sh` returns a non-zero exit code, the build will be marked as a failure. 
If any of the configurations show a security issue, the script will return non-zero. At
this point you can update the offending dependency and push to rerun the travis build. 
If the issue can't be fixed, it can be ignored via the snyk UI.

The monitor script is run as part of the `after_success` phase of the
Travis build. This will only be run if all tests pass, as well as the
snyk test. If the monitor script fails for some reason the build won't
be marked as failure. Monitoring means that Snyk will notify us if a new vulnerability
becomes apparent with one of our existing dependencies.

### EID-1381 Update dependencies to appease Snyk  …
Snyk found a few vulnerabilities with our dependencies. Some of these
could be fixed by pulling in newer versions of our own libraries, others
needed constraints on transitive dependencies.