### PR TITLE
EID-1380 - Log when the Translator signs and what with

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
@@ -18,7 +18,10 @@ public class EidasAuthnRequestAttributesLogger {
         } catch (Exception e) {
             throw e;
         } finally {
-            MDC.clear();
+            MDC.remove("eidasRequestId");
+            MDC.remove("eidasDestination");
+            MDC.remove("eidasIssueInstant");
+            MDC.remove("eidasIssuer");
         }
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -56,7 +56,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         SamlObjectSigner samlObjectSignerIncorrectSigningKey = new SamlObjectSigner(
                 X509CredentialFactory.build(STUB_COUNTRY_PUBLIC_PRIMARY_CERT, STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY)
         );
-        samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey);
+        samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey, "request-id");
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(requestWithIncorrectSigningKey),
                 "Error during AuthnRequest Signature Validation: SAML Validation Specification: Signature was not valid."
@@ -83,7 +83,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     @Test
     public void shouldReturnHTTP400WhenAuthnRequestMissingRequestId() throws Exception {
         AuthnRequest requestWithoutId = request.withoutRequestId().build();
-        samlObjectSigner.sign(requestWithoutId);
+        samlObjectSigner.sign(requestWithoutId, "request-id");
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(requestWithoutId),
                 "Bad Authn Request from Connector Node: Missing Request ID."
@@ -183,7 +183,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     @Test
     public void authnRequestShouldNotBeNotDuplicated() throws Exception {
         AuthnRequest duplicatedRequest = request.build();
-        samlObjectSigner.sign(duplicatedRequest);
+        samlObjectSigner.sign(duplicatedRequest, "request-id");
         assertGoodResponse(duplicatedRequest, postEidasAuthnRequest(duplicatedRequest));
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(duplicatedRequest),
@@ -193,19 +193,19 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
 
     private void assertGoodRequest(EidasAuthnRequestBuilder builder) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest,"request-id");
         assertGoodResponse(postedRequest, postEidasAuthnRequest(postedRequest));
     }
 
     private void assertBadRequest(EidasAuthnRequestBuilder builder) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest, "request-id");
         assertErrorResponse(postEidasAuthnRequest(postedRequest));
     }
 
     private void assertBadRequestWithMessage(EidasAuthnRequestBuilder builder, String errorMessageContains) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest, "request-id");
         assertErrorResponseWithMessage(postEidasAuthnRequest(postedRequest), errorMessageContains);
     }
 
@@ -231,7 +231,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         Logger logger = (Logger) LoggerFactory.getLogger(EidasAuthnRequestAttributesLogger.class);
         logger.addAppender(appender);
         AuthnRequest authnRequest = request.withRequestId("request_id").build();
-        samlObjectSigner.sign(authnRequest);
+        samlObjectSigner.sign(authnRequest, "request_id");
 
         postEidasAuthnRequest(authnRequest);
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/logging/TranslatorSigningLoggerHelper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/logging/TranslatorSigningLoggerHelper.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.notification.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class TranslatorSigningLoggerHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(TranslatorSigningLoggerHelper.class);
+
+    public static void logSigningRequest(String responseId, String signingProvider) {
+        try {
+            MDC.put("eidasResponseID", responseId);
+            MDC.put("signingProvider", signingProvider);
+            log.info("Signing eIDAS response");
+        } finally {
+            MDC.remove("eidasResponseID");
+            MDC.remove("signingProvider");
+        }
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
@@ -12,10 +12,11 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import uk.gov.ida.notification.logging.TranslatorSigningLoggerHelper;
 
 public class SamlObjectSigner {
     private final SignatureSigningParameters signingParams;
-
+    
     public SamlObjectSigner(BasicX509Credential credential) {
         this(credential, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
     }
@@ -30,7 +31,8 @@ public class SamlObjectSigner {
         signingParams.setKeyInfoGenerator(keyInfoGeneratorFactory.newInstance());
     }
 
-    public void sign(SignableSAMLObject signableSAMLObject) throws MarshallingException, SecurityException, SignatureException {
+    public void sign(SignableSAMLObject signableSAMLObject, String responseId) throws MarshallingException, SecurityException, SignatureException {
+        TranslatorSigningLoggerHelper.logSigningRequest(responseId, signingParams.getSigningCredential().getEntityId());
         SignatureSupport.signObject(signableSAMLObject, signingParams);
         SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
         signatureProfileValidator.validate(signableSAMLObject.getSignature());

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
@@ -25,7 +25,7 @@ public class SamlObjectSignerTest extends SamlInitializedTest {
         BasicX509Credential signingCredential = testKeyPair.getX509Credential();
         SamlObjectSigner samlObjectSigner = new SamlObjectSigner(signingCredential);
         AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
-        samlObjectSigner.sign(authnRequest);
+        samlObjectSigner.sign(authnRequest, "request-id");
         Signature signature = authnRequest.getSignature();
 
         String actualCertificate = signature.getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0).getValue();

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/CloudHsmSignerConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/CloudHsmSignerConfiguration.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.xml.security.algorithms.JCEMapper;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Support;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 
 import java.security.KeyStore;
@@ -16,12 +18,17 @@ import java.security.cert.X509Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudHsmSignerConfiguration extends SignerConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CloudHsmSignerConfiguration.class);
+
     @JsonCreator
     public CloudHsmSignerConfiguration(
         @JsonProperty("publicKey") DeserializablePublicKeyConfiguration publicKey,
         @JsonProperty("hsmKeyLabel") String hsmKeyLabel
     ) throws SignerConfigurationException {
         try {
+            LOG.info(String.format("Signing eIDAS Response with Cloud HSM using HSM Key Label %s", hsmKeyLabel));
+            LOG.info(String.format("Signing eIDAS Response with Cloud HSM using Public Key %s",publicKey.getCert()));
             X509Certificate certificate = X509Support.decodeCertificate(publicKey.getCert().getBytes());
             Provider caviumProvider = (Provider) ClassLoader.getSystemClassLoader()
                 .loadClass("com.cavium.provider.CaviumProvider")
@@ -34,6 +41,7 @@ public class CloudHsmSignerConfiguration extends SignerConfiguration {
             BasicX509Credential credential = new BasicX509Credential(
                 certificate,
                 (PrivateKey) cloudHsmStore.getKey(hsmKeyLabel, null));
+            credential.setEntityId("CloudHSM");
             this.signer = buildSigner(credential);
         } catch(Exception e) {
             throw new SignerConfigurationException(e);

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/KeyFileSignerConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/KeyFileSignerConfiguration.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Support;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.PrivateKeyConfiguration;
 
@@ -12,14 +14,19 @@ import java.security.cert.X509Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeyFileSignerConfiguration extends SignerConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeyFileSignerConfiguration.class);
+
     @JsonCreator
     public KeyFileSignerConfiguration(
         @JsonProperty("publicKey") DeserializablePublicKeyConfiguration publicKey,
         @JsonProperty("privateKey") PrivateKeyConfiguration privateKey
     ) throws SignerConfigurationException {
         try {
+            LOG.info(String.format("Signing eIDAS with KeyFile with Public Cert %s", publicKey.getCert()));
             X509Certificate cert = X509Support.decodeCertificate(publicKey.getCert().getBytes());
             BasicX509Credential credential = new BasicX509Credential(cert, privateKey.getPrivateKey());
+            credential.setEntityId("KeyFileSignerConfiguration");
             this.signer = buildSigner(credential);
         } catch(Exception e) {
             throw new SignerConfigurationException(e);

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
@@ -23,9 +23,8 @@ public class EidasResponseGenerator {
         final Response eidasResponse = translator.translate(hubResponseContainer);
         final BasicX509Credential encryptionCredential = new BasicX509Credential(encryptionCertificate);
         final ResponseAssertionEncrypter assertionEncrypter = new ResponseAssertionEncrypter(encryptionCredential);
-
         Response eidasResponseWithEncryptedAssertion = assertionEncrypter.encrypt(eidasResponse);
-        samlObjectSigner.sign(eidasResponseWithEncryptedAssertion);
+        samlObjectSigner.sign(eidasResponseWithEncryptedAssertion, hubResponseContainer.getEidasRequestId());
 
         return eidasResponseWithEncryptedAssertion;
     }

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -109,7 +109,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
             TEST_RP_PRIVATE_SIGNING_KEY
         ));
 
-        signer.sign(response);
+        signer.sign(response, "request-id");
 
         return response;
     }


### PR DESCRIPTION
- Log when each response is signed and specify whether it is being
signed with the CloudHSM or the KeyFile
- Use MDC.remove() rather than MDC.clear() to preserve state of MDC.
- Further work is needed to tidy up our logging helper classes