### PR TITLE
EID-1363: Log Hash of Eidas Response Attributes in Proxy Node

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,10 @@ ext {
     opensaml_version = '3.4.0'
     dropwizard_version = '1.3.9'
     utils_version = '2.0.0-350'
-    saml_libs_version = "${opensaml_version}-176"
+    saml_libs_version = "${opensaml_version}-180"
     soft_hsm_version = '1.1.1'
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
-
 
 subprojects {
 
@@ -64,13 +63,13 @@ subprojects {
     }
 
     dependencies {
-        common (
+        common(
                 "javax.xml.bind:jaxb-api:2.3.0",
                 "javax.activation:activation:1.1.1",
                 "io.lettuce:lettuce-core:5.1.4.RELEASE",
         )
 
-        dropwizard (
+        dropwizard(
                 "io.dropwizard:dropwizard-core:${dropwizard_version}",
                 "io.dropwizard:dropwizard-client:${dropwizard_version}",
                 "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
@@ -78,22 +77,22 @@ subprojects {
                 "uk.gov.ida:dropwizard-logstash:1.3.5-68"
         )
 
-        opensaml (
+        opensaml(
                 "org.opensaml:opensaml-core:${opensaml_version}",
                 "org.opensaml:opensaml-saml-impl:${opensaml_version}",
                 "org.opensaml:opensaml-storage-impl:${opensaml_version}",
         )
 
-        eidas_saml (
+        eidas_saml(
                 "se.litsec.eidas:eidas-opensaml3:1.3.1",
                 "se.litsec.opensaml:opensaml3-ext:1.2.2",
         )
 
-        ida_utils (
+        ida_utils(
                 "uk.gov.ida:rest-utils:${utils_version}"
         )
 
-        verify_saml (
+        verify_saml(
                 "uk.gov.ida:saml-extensions:${saml_libs_version}",
                 "uk.gov.ida:saml-metadata-bindings:${saml_libs_version}",
                 "uk.gov.ida:saml-security:${saml_libs_version}",
@@ -101,26 +100,26 @@ subprojects {
                 "uk.gov.ida:security-utils:${utils_version}",
         )
 
-        verify_saml_test (
+        verify_saml_test(
                 "uk.gov.ida:common-test-utils:${utils_version}",
                 "uk.gov.ida:saml-metadata-bindings-test:${saml_libs_version}",
         )
 
-        soft_hsm (
+        soft_hsm(
                 "se.swedenconnect.opensaml:opensaml-pkcs11-support:${soft_hsm_version}",
         )
 
-        proxy_node_test (
+        proxy_node_test(
                 "net.sourceforge.htmlcleaner:htmlcleaner:2.22",
                 "net.sourceforge.htmlunit:htmlunit:2.28",
         )
 
-        testCompile (
-                "org.junit.jupiter:junit-jupiter-api:5.3.1",
+        testCompile(
+                "org.junit.jupiter:junit-jupiter-api:5.4.0",
+                'org.junit.jupiter:junit-jupiter-params:5.4.0',
                 "org.assertj:assertj-core:3.11.1",
-                "org.hamcrest:hamcrest-core:1.3",
-                "org.hamcrest:hamcrest-library:1.3",
-                "org.mockito:mockito-core:2.23.0",
+                "org.mockito:mockito-core:2.25.0",
+                "org.mockito:mockito-junit-jupiter:2.17.0",
                 "io.dropwizard:dropwizard-testing:${dropwizard_version}",
                 "net.sourceforge.htmlunit:htmlunit:2.28",
                 "com.github.stefanbirkner:system-rules:1.19.0",

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -54,7 +54,7 @@ public class Attributes {
     }
 
     public List<Attribute<String>> getFirstNames() {
-        return firstNames;
+        return firstNames != null ? firstNames : new ArrayList<>();
     }
 
     public List<Attribute<String>> getMiddleNames() {
@@ -62,11 +62,11 @@ public class Attributes {
     }
 
     public List<Attribute<String>> getSurnames() {
-        return surnames;
+        return surnames != null ? surnames : new ArrayList<>();
     }
 
     public List<Attribute<DateTime>> getDatesOfBirth() {
-        return datesOfBirth;
+        return datesOfBirth != null ? datesOfBirth : new ArrayList<>();
     }
 
     public Attribute<String> getGender() {

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/AttributesBuilder.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/AttributesBuilder.java
@@ -5,7 +5,6 @@ import org.joda.time.DateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 public class AttributesBuilder {
@@ -18,17 +17,17 @@ public class AttributesBuilder {
     public static DateTime DATE_OF_BIRTH = createDateTime(1990, 1, 1, 0, 0);
 
     private List<Attribute<String>> firstNames = new ArrayList<>(singletonList(createAttribute(FIRST_NAME)));
-    private Attribute<String> middleName = createAttribute(MIDDLE_NAME);
-    private Attribute<String> lastName = createAttribute(LAST_NAME);
+    private List<Attribute<String>> middleNames = new ArrayList<>(singletonList(createAttribute(MIDDLE_NAME)));
+    private List<Attribute<String>> lastNames = new ArrayList<>(singletonList(createAttribute(LAST_NAME)));
     private Attribute<String> gender = createAttribute(GENDER);
-    private Attribute<DateTime> dateOfBirth = createAttribute(DATE_OF_BIRTH);
+    private List<Attribute<DateTime>> datesOfBirth = new ArrayList<>(singletonList(createAttribute(DATE_OF_BIRTH)));
 
     public Attributes build() {
         return new Attributes(
                 firstNames,
-                middleName != null ? singletonList(middleName) : emptyList(),
-                lastName != null ? singletonList(lastName) : emptyList(),
-                dateOfBirth != null ? singletonList(dateOfBirth) : emptyList(),
+                middleNames,
+                lastNames,
+                datesOfBirth,
                 gender,
                 singletonList(createAttribute(new Address(singletonList("1 Acacia Avenue"), "SW1A 1AA", null, null))));
     }
@@ -43,23 +42,38 @@ public class AttributesBuilder {
         return this;
     }
 
+    public AttributesBuilder addMiddleName(Attribute<String> middleName) {
+        this.middleNames.add(middleName);
+        return this;
+    }
+
+    public AttributesBuilder addLastName(Attribute<String> lastName) {
+        this.lastNames.add(lastName);
+        return this;
+    }
+
+    public AttributesBuilder addDateOfBirth(Attribute<DateTime> dateOfBirth) {
+        this.datesOfBirth.add(dateOfBirth);
+        return this;
+    }
+
     public AttributesBuilder withoutFirstName() {
-        this.firstNames = emptyList();
+        this.firstNames = new ArrayList<>();
         return this;
     }
 
     public AttributesBuilder withoutMiddleName() {
-        this.middleName = null;
+        this.middleNames = new ArrayList<>();
         return this;
     }
 
     public AttributesBuilder withoutLastName() {
-        this.lastName = null;
+        this.lastNames = new ArrayList<>();
         return this;
     }
 
     public AttributesBuilder withoutDateOfBirth() {
-        this.dateOfBirth = null;
+        this.datesOfBirth = new ArrayList<>();
         return this;
     }
 

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseBuilder.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseBuilder.java
@@ -1,31 +1,13 @@
 package uk.gov.ida.notification.contracts.verifyserviceprovider;
 
+import org.joda.time.DateTime;
+
 public class TranslatedHubResponseBuilder {
 
     private String pid = "123456";
     private VspLevelOfAssurance loa = VspLevelOfAssurance.LEVEL_2;
     private VspScenario vspScenario = VspScenario.IDENTITY_VERIFIED;
     private Attributes attributes = new AttributesBuilder().build();
-
-    public static TranslatedHubResponse buildTranslatedHubResponseIdentityVerified() {
-        return new TranslatedHubResponseBuilder().build();
-    }
-
-    public static TranslatedHubResponse buildTranslatedHubResponseAuthenticationFailed() {
-        return new TranslatedHubResponseBuilder().withScenario(VspScenario.AUTHENTICATION_FAILED).withoutAttributes().build();
-    }
-
-    public static TranslatedHubResponse buildTranslatedHubResponseRequestError() {
-        return new TranslatedHubResponseBuilder().withScenario(VspScenario.REQUEST_ERROR).withoutAttributes().build();
-    }
-
-    public static TranslatedHubResponse buildTranslatedHubResponseCancellation() {
-        return new TranslatedHubResponseBuilder().withScenario(VspScenario.CANCELLATION).withoutAttributes().build();
-    }
-
-    public TranslatedHubResponse build() {
-        return new TranslatedHubResponse(vspScenario, pid, loa, attributes);
-    }
 
     public TranslatedHubResponseBuilder withScenario(VspScenario scenario) {
         this.vspScenario = scenario;
@@ -45,5 +27,115 @@ public class TranslatedHubResponseBuilder {
     public TranslatedHubResponseBuilder withLevelOfAssurance(VspLevelOfAssurance loa) {
         this.loa = loa;
         return this;
+    }
+
+    public TranslatedHubResponseBuilder withoutPid() {
+        this.pid = null;
+        return this;
+    }
+
+    public TranslatedHubResponse build() {
+        return new TranslatedHubResponse(vspScenario, pid, loa, attributes);
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseIdentityVerified() {
+        return new TranslatedHubResponseBuilder().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseAuthenticationFailed() {
+        return new TranslatedHubResponseBuilder().withScenario(VspScenario.AUTHENTICATION_FAILED).withoutAttributes().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseRequestError() {
+        return new TranslatedHubResponseBuilder().withScenario(VspScenario.REQUEST_ERROR).withoutAttributes().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseCancellation() {
+        return new TranslatedHubResponseBuilder().withScenario(VspScenario.CANCELLATION).withoutAttributes().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseIdentityVerifiedLOA1() {
+        return new TranslatedHubResponseBuilder().withScenario(VspScenario.IDENTITY_VERIFIED).withLevelOfAssurance(VspLevelOfAssurance.LEVEL_1).build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseIdentityVerifiedNoAttributes() {
+        return new TranslatedHubResponseBuilder().withScenario(VspScenario.IDENTITY_VERIFIED).withoutAttributes().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseIncompleteAttributes() {
+        return new TranslatedHubResponseBuilder()
+                .withScenario(VspScenario.IDENTITY_VERIFIED)
+                .withAttributes(
+                        new AttributesBuilder()
+                                .withoutMiddleName()
+                                .withoutLastName()
+                                .withoutDateOfBirth()
+                                .withoutGender()
+                                .build()
+                ).build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseAllAttributesMissing() {
+        return new TranslatedHubResponseBuilder()
+                .withScenario(VspScenario.IDENTITY_VERIFIED)
+                .withAttributes(
+                        new AttributesBuilder()
+                                .withoutFirstName()
+                                .withoutMiddleName()
+                                .withoutLastName()
+                                .withoutDateOfBirth()
+                                .withoutGender()
+                                .build()
+                ).build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseAttributesNullPidNull() {
+        return new TranslatedHubResponseBuilder().withoutAttributes().withoutPid().build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseAttributesThreeFirstNamesOnlyLastVerified() {
+        return new TranslatedHubResponseBuilder()
+                .withScenario(VspScenario.IDENTITY_VERIFIED)
+                .withAttributes(
+                        new AttributesBuilder()
+                                .withoutMiddleName()
+                                .withoutLastName()
+                                .withoutDateOfBirth()
+                                .withoutGender()
+                                .withoutFirstName()
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameA", false, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameB", false, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameV", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .build()
+                ).build();
+    }
+
+    public static TranslatedHubResponse buildTranslatedHubResponseAttributesMultipleValues() {
+        return new TranslatedHubResponseBuilder()
+                .withScenario(VspScenario.IDENTITY_VERIFIED)
+                .withAttributes(
+                        new AttributesBuilder()
+                                .withoutMiddleName()
+                                .withoutLastName()
+                                .withoutDateOfBirth()
+                                .withoutGender()
+                                .withoutFirstName()
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameA", false, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameB", false, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addFirstName(AttributesBuilder.createAttribute("FirstNameV", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addMiddleName(AttributesBuilder.createAttribute("MiddleNameA", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addMiddleName(AttributesBuilder.createAttribute("MiddleNameB", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addMiddleName(AttributesBuilder.createAttribute("MiddleNameC", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addLastName(AttributesBuilder.createAttribute("SurnameA", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addLastName(AttributesBuilder.createAttribute("SurnameB", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addLastName(AttributesBuilder.createAttribute("SurnameC", true, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addDateOfBirth(AttributesBuilder.createAttribute(createDateTime(1990, 1, 1, 0, 0), false, createDateTime(2001, 1, 1, 12, 0), null))
+                                .addDateOfBirth(AttributesBuilder.createAttribute(createDateTime(1985, 9, 7, 14, 0), false, createDateTime(2005, 1, 1, 12, 0), null))
+                                .build()
+                ).build();
+    }
+
+    private static DateTime createDateTime(int year, int month, int day, int hour, int minute) {
+        return new DateTime().withYear(year).withMonthOfYear(month).withDayOfMonth(day).withHourOfDay(hour).withMinuteOfHour(minute);
     }
 }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerHelper.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerHelper.java
@@ -1,0 +1,45 @@
+package uk.gov.ida.notification.translator.logging;
+
+import uk.gov.ida.notification.contracts.verifyserviceprovider.Attribute;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
+import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
+
+public final class EidasResponseAttributesHashLoggerHelper {
+
+    EidasResponseAttributesHashLogger eidasResponseAttributesHashLogger;
+
+    private EidasResponseAttributesHashLoggerHelper() {
+    }
+
+    public EidasResponseAttributesHashLoggerHelper(EidasResponseAttributesHashLogger eidasResponseAttributesHashLogger) {
+        this.eidasResponseAttributesHashLogger = eidasResponseAttributesHashLogger;
+    }
+
+    public EidasResponseAttributesHashLogger applyAttributesToHashLogger(Attributes attributes, String pid) {
+
+        eidasResponseAttributesHashLogger.setPid(pid);
+
+        if (attributes != null) {
+
+            attributes.getFirstNames().stream()
+                    .filter(Attribute::isVerified)
+                    .findFirst()
+                    .ifPresent(firstName -> eidasResponseAttributesHashLogger.setFirstName(firstName.getValue()));
+
+            attributes.getMiddleNames().forEach(
+                    middleName -> eidasResponseAttributesHashLogger.addMiddleName(middleName.getValue())
+            );
+
+            attributes.getSurnames().forEach(
+                    surname -> eidasResponseAttributesHashLogger.addSurname(surname.getValue())
+            );
+
+            attributes.getDatesOfBirth().stream()
+                    .filter(Attribute::isVerified)
+                    .findFirst()
+                    .ifPresent(dateOfBirth -> eidasResponseAttributesHashLogger.setDateOfBirth(dateOfBirth.getValue()));
+        }
+
+        return eidasResponseAttributesHashLogger;
+    }
+}

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseTranslatorLoggerHelper.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseTranslatorLoggerHelper.java
@@ -31,9 +31,4 @@ public class HubResponseTranslatorLoggerHelper {
             MDC.remove(HubResponseTranslatorLoggerAttributes.EIDAS_RESPONSE_ISSUER);
         }
     }
-
-    public static void logHashedResponseDetails(String requestId, String destination, String hashedDetails) {
-        log.info(String.format("[eIDAS Response HASH] received for hub authn request ID '%s', destination '%s', hashedEidasDetails '%s'",
-                requestId, destination, hashedDetails));
-    }
 }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -6,17 +6,16 @@ import org.opensaml.security.SecurityException;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
-import uk.gov.ida.notification.contracts.verifyserviceprovider.Attribute;
-import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.VerifyServiceProviderTranslationRequest;
-import uk.gov.ida.notification.exceptions.hubresponse.HubResponseTranslationException;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
+import uk.gov.ida.notification.translator.logging.EidasResponseAttributesHashLoggerHelper;
 import uk.gov.ida.notification.translator.logging.HubResponseTranslatorLoggerHelper;
 import uk.gov.ida.notification.translator.saml.EidasResponseGenerator;
 import uk.gov.ida.notification.translator.saml.HubResponseContainer;
+import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -24,15 +23,12 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.security.cert.X509Certificate;
-
-import static uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes.combineAttributeValues;
-import static uk.gov.ida.saml.core.transformers.ResponseAttributesHashFactory.hashResponseDetails;
 
 @Path(Urls.TranslatorUrls.TRANSLATOR_ROOT)
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class HubResponseTranslatorResource {
+
     private static final SamlObjectMarshaller MARSHALLER = new SamlObjectMarshaller();
     private static final X509CertificateFactory X_509_CERTIFICATE_FACTORY = new X509CertificateFactory();
 
@@ -48,20 +44,33 @@ public class HubResponseTranslatorResource {
     @Path(Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH)
     public Response hubResponse(HubResponseTranslatorRequest hubResponseTranslatorRequest) throws MarshallingException, SecurityException, SignatureException {
 
-        final VerifyServiceProviderTranslationRequest vspRequest = new VerifyServiceProviderTranslationRequest(
-                hubResponseTranslatorRequest.getSamlResponse(),
-                hubResponseTranslatorRequest.getRequestId(),
-                hubResponseTranslatorRequest.getLevelOfAssurance());
+        final TranslatedHubResponse translatedHubResponse =
+                verifyServiceProviderProxy.getTranslatedHubResponse(
+                        new VerifyServiceProviderTranslationRequest(
+                                hubResponseTranslatorRequest.getSamlResponse(),
+                                hubResponseTranslatorRequest.getRequestId(),
+                                hubResponseTranslatorRequest.getLevelOfAssurance()
+                        )
+                );
 
-        final TranslatedHubResponse translatedHubResponse = verifyServiceProviderProxy.getTranslatedHubResponse(vspRequest);
+        final org.opensaml.saml.saml2.core.Response eidasResponse =
+                eidasResponseGenerator.generate(
+                        new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse),
+                        X_509_CERTIFICATE_FACTORY.createCertificate(hubResponseTranslatorRequest.getConnectorEncryptionCertificate())
+                );
 
-        final HubResponseContainer hubResponseContainer = new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse);
-        final X509Certificate encryptionCertificate = X_509_CERTIFICATE_FACTORY.createCertificate(hubResponseTranslatorRequest.getConnectorEncryptionCertificate());
-
-        final org.opensaml.saml.saml2.core.Response eidasResponse = eidasResponseGenerator.generate(hubResponseContainer, encryptionCertificate);
-
-        logResponseDetailsHash(hubResponseTranslatorRequest, translatedHubResponse);
         logResponse(eidasResponse);
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(EidasResponseAttributesHashLogger.instance());
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                translatedHubResponse.getAttributes(),
+                translatedHubResponse.getPid()
+        ).logHashFor(
+                hubResponseTranslatorRequest.getRequestId(),
+                hubResponseTranslatorRequest.getDestinationUrl().toString()
+        );
 
         final String samlMessage = Base64.encodeAsString(MARSHALLER.transformToString(eidasResponse));
 
@@ -70,27 +79,5 @@ public class HubResponseTranslatorResource {
 
     private void logResponse(final org.opensaml.saml.saml2.core.Response eidasResponse) {
         HubResponseTranslatorLoggerHelper.logEidasResponse(eidasResponse);
-    }
-
-    private void logResponseDetailsHash(final HubResponseTranslatorRequest hubResponseTranslatorRequest, final TranslatedHubResponse translatedHubResponse) {
-        final String firstDateOfBirth = translatedHubResponse.getAttributes().getDatesOfBirth()
-                .stream()
-                .findFirst()
-                .map(Attribute::getValue)
-                .map(Attributes::getFormattedDate)
-                .orElseThrow(() -> new HubResponseTranslationException("No date of birth present"));
-
-        final String hashedEidasDetails = hashResponseDetails(
-                translatedHubResponse.getPid(),
-                combineAttributeValues(translatedHubResponse.getAttributes().getFirstNames()),
-                combineAttributeValues(translatedHubResponse.getAttributes().getMiddleNames()),
-                combineAttributeValues(translatedHubResponse.getAttributes().getSurnames()),
-                firstDateOfBirth
-        );
-
-        HubResponseTranslatorLoggerHelper.logHashedResponseDetails(
-                hubResponseTranslatorRequest.getRequestId(),
-                hubResponseTranslatorRequest.getDestinationUrl().toString(),
-                hashedEidasDetails);
     }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -69,7 +69,7 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
     private EncryptedAssertion matchingDatasetAssertion;
     private Credential eidasDecryptingCredential;
 
-    private static final String publicBuild = (System.getenv("VERIFY_USE_PUBLIC_BINARIES"));
+    private static final String publicBuild = System.getenv("VERIFY_USE_PUBLIC_BINARIES");
 
     @Before
     public void setup() throws Throwable {
@@ -170,7 +170,7 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
         ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
 
         // Resource method logs twice: once for Response Details and once for the Hash, so expect 2 invocations.
-        verify(appender, Mockito.times(2)).doAppend(loggingEventArgumentCaptor.capture());
+        verify(appender, Mockito.times(1)).doAppend(loggingEventArgumentCaptor.capture());
 
         ILoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
         Map<String, String> mdcPropertyMap = loggingEvent.getMDCPropertyMap();

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerParameterizedTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerParameterizedTest.java
@@ -1,0 +1,119 @@
+package uk.gov.ida.notification.translator.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder;
+import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(Parameterized.class)
+public class EidasResponseAttributesHashLoggerParameterizedTest {
+
+    private final static String REQUEST_ID = "request-id";
+    private final static String DESTINATION_URL = "http://connnector.eu";
+
+    public TranslatedHubResponse translatedHubResponse;
+    public String hashResult;
+
+    public EidasResponseAttributesHashLoggerParameterizedTest(TranslatedHubResponse translatedHubResponse, String hashResult) {
+        this.translatedHubResponse = translatedHubResponse;
+        this.hashResult = hashResult;
+    }
+
+    @Test
+    public void shouldLogHashForTranslatedHubReponses() {
+
+        Logger logger = (Logger) LoggerFactory.getLogger(EidasResponseAttributesHashLogger.class);
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        logger.addAppender(appender);
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(EidasResponseAttributesHashLogger.instance());
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                translatedHubResponse.getAttributes(),
+                translatedHubResponse.getPid()
+        ).logHashFor(
+                REQUEST_ID,
+                DESTINATION_URL
+        );
+
+        ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(appender).doAppend(loggingEventArgumentCaptor.capture());
+
+        ILoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
+        Map<String, String> mdcPropertyMap = loggingEvent.getMDCPropertyMap();
+
+        Assertions.assertThat(
+                mdcPropertyMap.get(EidasResponseAttributesHashLogger.MDC_KEY_EIDAS_USER_HASH))
+                .as("EidasResponse Hash Test Failure.\n" +
+                        "Method used to calculate the hash (or the test data) may have changed.\n" +
+                        "Caution: Hash calculation must be identical in both the Proxy Node and the Hub.")
+                .isEqualTo(hashResult);
+    }
+
+    @Parameterized.Parameters(name = "Run {index}: translatedHubResponse={0}, hashResult={1}")
+    public static Collection<Object[]> getHashTestParameters() throws Throwable {
+        return Arrays.asList(
+                new Object[][]{
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseIdentityVerified(),
+                                "7ea43365b70f9d94c13bcf27733e57a39f45edaa3a143e93faf15cc5f26226f3"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseIdentityVerifiedLOA1(),
+                                "7ea43365b70f9d94c13bcf27733e57a39f45edaa3a143e93faf15cc5f26226f3"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseIdentityVerifiedNoAttributes(),
+                                "bff88ccaf63d6700d8112b3a0409b469b6301e2fc5a1adcf1c158d600e62352f"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseAuthenticationFailed(),
+                                "bff88ccaf63d6700d8112b3a0409b469b6301e2fc5a1adcf1c158d600e62352f"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseIncompleteAttributes(),
+                                "4d11a15b7f8a391b2f5cf4909dde7d68e34b5ac9d11762b848d3f7345bab8b0b"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseCancellation(),
+                                "bff88ccaf63d6700d8112b3a0409b469b6301e2fc5a1adcf1c158d600e62352f"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseRequestError(),
+                                "bff88ccaf63d6700d8112b3a0409b469b6301e2fc5a1adcf1c158d600e62352f"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseAllAttributesMissing(),
+                                "bff88ccaf63d6700d8112b3a0409b469b6301e2fc5a1adcf1c158d600e62352f"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseAttributesNullPidNull(),
+                                "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseAttributesThreeFirstNamesOnlyLastVerified(),
+                                "bc2b8e0f12328de50702ee62c7140044793cb59582bec34e73f580d55cb25e28"
+                        },
+                        {
+                                TranslatedHubResponseBuilder.buildTranslatedHubResponseAttributesMultipleValues(),
+                                "aab9e4c152098e35fb04a9a02783367fb44d0a77359a759b414a6e622ffc0571"
+                        }}
+        );
+    }
+}

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerTest.java
@@ -1,0 +1,163 @@
+package uk.gov.ida.notification.translator.logging;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.Attribute;
+import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
+import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EidasResponseAttributesHashLoggerTest {
+
+    private final static String PID = "pid1234ABCD";
+
+    @Mock
+    Attributes attributesMock;
+
+    @Mock
+    EidasResponseAttributesHashLogger hashLoggerMock;
+
+    @Test
+    public void shouldOnlyIncludeFirstVerifiedFirstNameInHash() {
+
+        when(attributesMock.getFirstNames()).thenReturn(List.of(
+                new Attribute<>("FirstNameA", false, null, null),
+                new Attribute<>("FirstNameV1", true, null, null),
+                new Attribute<>("FirstNameB", false, null, null),
+                new Attribute<>("FirstNameV2", true, null, null)
+        ));
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(hashLoggerMock);
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                attributesMock,
+                PID
+        );
+
+        verify(hashLoggerMock).setPid(PID);
+        verify(hashLoggerMock, times(1)).setFirstName(any());
+        verify(hashLoggerMock, never()).setFirstName("FirstNameA");
+        verify(hashLoggerMock, never()).setFirstName("FirstNameB");
+        verify(hashLoggerMock).setFirstName("FirstNameV1");
+        verify(hashLoggerMock, never()).setFirstName("FirstNameV2");
+
+        verify(hashLoggerMock, never()).addMiddleName(any());
+        verify(hashLoggerMock, never()).addSurname(any());
+        verify(hashLoggerMock, never()).setDateOfBirth(any());
+    }
+
+    @Test
+    public void shouldIncludeAllMiddleNamesInHash() {
+
+        when(attributesMock.getMiddleNames()).thenReturn(List.of(
+                new Attribute<>("MiddleNameA", false, null, null),
+                new Attribute<>("MiddleNameV1", true, null, null),
+                new Attribute<>("MiddleNameC", false, null, null),
+                new Attribute<>("MiddleNameV2", true, null, null)
+        ));
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(hashLoggerMock);
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                attributesMock,
+                PID
+        );
+
+        verify(hashLoggerMock).setPid(PID);
+        verify(hashLoggerMock, times(4)).addMiddleName(any());
+
+        InOrder inOrder = inOrder(hashLoggerMock);
+        inOrder.verify(hashLoggerMock).addMiddleName("MiddleNameA");
+        inOrder.verify(hashLoggerMock).addMiddleName("MiddleNameV1");
+        inOrder.verify(hashLoggerMock).addMiddleName("MiddleNameC");
+        inOrder.verify(hashLoggerMock).addMiddleName("MiddleNameV2");
+
+        verify(hashLoggerMock, never()).setFirstName(any());
+        verify(hashLoggerMock, never()).addSurname(any());
+        verify(hashLoggerMock, never()).setDateOfBirth(any());
+    }
+
+    @Test
+    public void shouldIncludeAllSurnamesInHash() {
+
+        when(attributesMock.getSurnames()).thenReturn(List.of(
+                new Attribute<>("SurnameV1", true, null, null),
+                new Attribute<>("SurnameA", false, null, null),
+                new Attribute<>("SurnameV2", true, null, null),
+                new Attribute<>("SurnameB", false, null, null)
+        ));
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(hashLoggerMock);
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                attributesMock,
+                PID
+        );
+
+        verify(hashLoggerMock).setPid(PID);
+        verify(hashLoggerMock, times(4)).addSurname(any());
+
+        InOrder inOrder = inOrder(hashLoggerMock);
+        inOrder.verify(hashLoggerMock).addSurname("SurnameV1");
+        inOrder.verify(hashLoggerMock).addSurname("SurnameA");
+        inOrder.verify(hashLoggerMock).addSurname("SurnameV2");
+        inOrder.verify(hashLoggerMock).addSurname("SurnameB");
+
+        verify(hashLoggerMock, never()).setFirstName(any());
+        verify(hashLoggerMock, never()).addMiddleName(any());
+        verify(hashLoggerMock, never()).setDateOfBirth(any());
+    }
+
+    @Test
+    public void shouldOnlyIncludeFirstVerifiedDateOfBirthInHash() {
+
+        DateTime[] datesOfBirth = new DateTime[]{
+                new DateTime(1990, 1, 1, 0, 0),
+                new DateTime(1985, 9, 7, 14, 0),
+                new DateTime(1984, 10, 1, 0, 0),
+                new DateTime(1977, 12, 6, 12, 0)
+        };
+
+        when(attributesMock.getDatesOfBirth()).thenReturn(List.of(
+                new Attribute<>(datesOfBirth[0], false, null, null),
+                new Attribute<>(datesOfBirth[1], true, null, null),
+                new Attribute<>(datesOfBirth[2], false, null, null),
+                new Attribute<>(datesOfBirth[3], true, null, null)
+        ));
+
+        final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
+                new EidasResponseAttributesHashLoggerHelper(hashLoggerMock);
+
+        eidasResponseAttributesHashLoggerHelper.applyAttributesToHashLogger(
+                attributesMock,
+                PID
+        );
+
+        verify(hashLoggerMock).setPid(PID);
+        verify(hashLoggerMock, times(1)).setDateOfBirth(any());
+        verify(hashLoggerMock, never()).setDateOfBirth(datesOfBirth[0]);
+        verify(hashLoggerMock).setDateOfBirth(datesOfBirth[1]);
+        verify(hashLoggerMock, never()).setDateOfBirth(datesOfBirth[2]);
+        verify(hashLoggerMock, never()).setDateOfBirth(datesOfBirth[3]);
+
+        verify(hashLoggerMock, never()).addMiddleName(any());
+        verify(hashLoggerMock, never()).addSurname(any());
+        verify(hashLoggerMock, never()).setFirstName(any());
+    }
+}

--- a/proxy-node-translator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/proxy-node-translator/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -12,7 +12,11 @@ import se.litsec.eidas.opensaml.ext.attributes.CurrentGivenNameType;
 import uk.gov.ida.notification.apprule.base.StubConnectorAppRuleTestBase;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
 import uk.gov.ida.notification.helpers.X509CredentialFactory;
-import uk.gov.ida.notification.saml.*;
+import uk.gov.ida.notification.saml.EidasAttributeBuilder;
+import uk.gov.ida.notification.saml.EidasResponseBuilder;
+import uk.gov.ida.notification.saml.SamlObjectMarshaller;
+import uk.gov.ida.notification.saml.SamlObjectSigner;
+import uk.gov.ida.notification.saml.SamlParser;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
@@ -21,7 +25,6 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 


### PR DESCRIPTION
- Create a string for hashing based on the required Response Attributes.
- Log the hash after creation.
- Unit tests to prove that the pre-hash string is correct based on the agreed rules.
- Hash must be identical to the one created in Hub on the same attributes using the same rules.
- Unit tests to identify and alert when the implementation of the rules has changed (in case this no longer matches the hub implementation).
- Removal of redundant references to Hamcrest libraries.
- Tweaks to AttributesBuilder to support many middleNames, lastNames and datesOfBirth to match-up with the payload returned from the VSP.