### PR TITLE
EID-1363: Change hash and response logging order

### DIFF
--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -53,14 +53,6 @@ public class HubResponseTranslatorResource {
                         )
                 );
 
-        final org.opensaml.saml.saml2.core.Response eidasResponse =
-                eidasResponseGenerator.generate(
-                        new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse),
-                        X_509_CERTIFICATE_FACTORY.createCertificate(hubResponseTranslatorRequest.getConnectorEncryptionCertificate())
-                );
-
-        logResponse(eidasResponse);
-
         final EidasResponseAttributesHashLoggerHelper eidasResponseAttributesHashLoggerHelper =
                 new EidasResponseAttributesHashLoggerHelper(EidasResponseAttributesHashLogger.instance());
 
@@ -71,6 +63,14 @@ public class HubResponseTranslatorResource {
                 hubResponseTranslatorRequest.getRequestId(),
                 hubResponseTranslatorRequest.getDestinationUrl().toString()
         );
+
+        final org.opensaml.saml.saml2.core.Response eidasResponse =
+                eidasResponseGenerator.generate(
+                        new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse),
+                        X_509_CERTIFICATE_FACTORY.createCertificate(hubResponseTranslatorRequest.getConnectorEncryptionCertificate())
+                );
+
+        logResponse(eidasResponse);
 
         final String samlMessage = Base64.encodeAsString(MARSHALLER.transformToString(eidasResponse));
 


### PR DESCRIPTION
- Log the hash as soon as the information is available after the call to the VSP.
- Do this before response generation.
- Then log the response.