### PR TITLE
BAU: Add Zipkin support to stub-connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,8 @@ subprojects {
                 "io.dropwizard:dropwizard-client:${dropwizard_version}",
                 "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
                 "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
-                "uk.gov.ida:dropwizard-logstash:1.3.5-68"
+                "uk.gov.ida:dropwizard-logstash:1.3.5-68",
+                "com.smoketurner.dropwizard:zipkin-core:${dropwizard_version}-1"
         )
 
         opensaml(

--- a/stub-connector/src/dist/config.yml
+++ b/stub-connector/src/dist/config.yml
@@ -32,3 +32,8 @@ credentialConfiguration:
   privateKey:
     type: ${KEY_TYPES:-encoded}
     key: ${SIGNING_KEY}
+
+zipkin:
+  enabled: ${ZIPKIN_ENABLED:-false}
+  serviceHost: ${ZIPKIN_HOST:-127.0.0.1}
+  servicePort: ${ZIPKIN_PORT:-8080}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.notification.stubconnector;
 
+import com.smoketurner.dropwizard.zipkin.ZipkinBundle;
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
@@ -77,6 +79,13 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
         bootstrap.addBundle(new ViewBundle<>());
         bootstrap.addBundle(new LogstashBundle());
 
+        // Zipkin
+        bootstrap.addBundle(new ZipkinBundle<StubConnectorConfiguration>(getName()) {
+            @Override
+            public ZipkinFactory getZipkinFactory(StubConnectorConfiguration configuration) {
+                return configuration.getZipkin();
+            }
+        });
 
         // Metadata
         proxyNodeMetadataResolverBundle = new MetadataResolverBundle<>(configuration -> Optional.of(configuration.getProxyNodeMetadataConfiguration()));
@@ -85,7 +94,7 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
 
     @Override
     public void run(final StubConnectorConfiguration configuration,
-                    final Environment environment) throws Exception {
+                    final Environment environment) {
 
         proxyNodeMetadata = new Metadata(proxyNodeMetadataResolverBundle.getMetadataCredentialResolver());
 

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.notification.stubconnector;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.smoketurner.dropwizard.zipkin.ZipkinFactory;
 import io.dropwizard.Configuration;
 import uk.gov.ida.notification.configuration.CredentialConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
@@ -25,6 +26,10 @@ public class StubConnectorConfiguration extends Configuration {
     @NotNull
     private TrustStoreBackedMetadataConfiguration proxyNodeMetadataConfiguration;
 
+    @JsonProperty
+    @Valid
+    private ZipkinFactory zipkin;
+
     public URI getConnectorNodeBaseUrl() {
         return connectorNodeBaseUrl;
     }
@@ -39,5 +44,9 @@ public class StubConnectorConfiguration extends Configuration {
 
     public CredentialConfiguration getCredentialConfiguration() {
         return credentialConfiguration;
+    }
+
+    public ZipkinFactory getZipkin() {
+        return zipkin;
     }
 }


### PR DESCRIPTION
This uses the [dropwizard-zipkin][dz] library. Configuration is via the
`zipkin` section of the stub-connector `config.yml` file, exposed via
the following environment variables:

- `ZIPKIN_ENABLED`: enable Zipkin (defaults to false)
- `ZIPKIN_HOST`: host for Zipkin
- `ZIPKIN_PORT`: port for Zipkin