### PR TITLE
EID-1380 - Log when the Translator signs and specify what it is using

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/logging/EidasAuthnRequestAttributesLogger.java
@@ -15,10 +15,11 @@ public class EidasAuthnRequestAttributesLogger {
             MDC.put("eidasIssueInstant", authnRequest.getIssueInstant().toString());
             MDC.put("eidasIssuer", authnRequest.getIssuer().getValue());
             log.info("Authn request validated by ESP");
-        } catch (Exception e) {
-            throw e;
         } finally {
-            MDC.clear();
+            MDC.remove("eidasRequestId");
+            MDC.remove("eidasDestination");
+            MDC.remove("eidasIssueInstant");
+            MDC.remove("eidasIssuer");
         }
     }
 }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -54,7 +54,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     public void shouldReturnHTTP400WhenAuthnRequestNotSignedCorrectly() throws Exception {
         AuthnRequest requestWithIncorrectSigningKey = request.build();
         SamlObjectSigner samlObjectSignerIncorrectSigningKey = new SamlObjectSigner(X509CredentialFactory.build(STUB_COUNTRY_PUBLIC_PRIMARY_CERT, STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
-        samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey);
+        samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey, "response-id");
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(requestWithIncorrectSigningKey),
                 "Error during AuthnRequest Signature Validation: SAML Validation Specification: Signature was not valid."
@@ -81,7 +81,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     @Test
     public void shouldReturnHTTP400WhenAuthnRequestMissingRequestId() throws Exception {
         AuthnRequest requestWithoutId = request.withoutRequestId().build();
-        samlObjectSigner.sign(requestWithoutId);
+        samlObjectSigner.sign(requestWithoutId, null);
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(requestWithoutId),
                 "Bad Authn Request from Connector Node: Missing Request ID."
@@ -181,7 +181,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     @Test
     public void authnRequestShouldNotBeNotDuplicated() throws Exception {
         AuthnRequest duplicatedRequest = request.build();
-        samlObjectSigner.sign(duplicatedRequest);
+        samlObjectSigner.sign(duplicatedRequest, "response-id");
         assertGoodResponse(duplicatedRequest, postEidasAuthnRequest(duplicatedRequest));
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(duplicatedRequest),
@@ -191,19 +191,19 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
 
     private void assertGoodRequest(EidasAuthnRequestBuilder builder) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest, "response-id");
         assertGoodResponse(postedRequest, postEidasAuthnRequest(postedRequest));
     }
 
     private void assertBadRequest(EidasAuthnRequestBuilder builder) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest, "response-id");
         assertErrorResponse(postEidasAuthnRequest(postedRequest));
     }
 
     private void assertBadRequestWithMessage(EidasAuthnRequestBuilder builder, String errorMessageContains) throws Exception {
         AuthnRequest postedRequest = builder.withRandomRequestId().build();
-        samlObjectSigner.sign(postedRequest);
+        samlObjectSigner.sign(postedRequest, "response-id");
         assertErrorResponseWithMessage(postEidasAuthnRequest(postedRequest), errorMessageContains);
     }
 
@@ -229,7 +229,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         Logger logger = (Logger) LoggerFactory.getLogger(EidasAuthnRequestAttributesLogger.class);
         logger.addAppender(appender);
         AuthnRequest authnRequest = request.withRequestId("request_id").build();
-        samlObjectSigner.sign(authnRequest);
+        samlObjectSigner.sign(authnRequest, "response-id");
 
         postEidasAuthnRequest(authnRequest);
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/KeyFileCredentialConfiguration.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/KeyFileCredentialConfiguration.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Support;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.PrivateKeyConfiguration;
 
@@ -12,14 +14,19 @@ import java.security.cert.X509Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeyFileCredentialConfiguration extends CredentialConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeyFileCredentialConfiguration.class);
+
     @JsonCreator
     public KeyFileCredentialConfiguration(
         @JsonProperty("publicKey") DeserializablePublicKeyConfiguration publicKey,
         @JsonProperty("privateKey") PrivateKeyConfiguration privateKey
     ) throws CredentialConfigurationException {
         try {
+            LOG.info("Signing eIDAS with KeyFileCredentialConfiguration");
             X509Certificate cert = X509Support.decodeCertificate(publicKey.getCert().getBytes());
             BasicX509Credential credential = new BasicX509Credential(cert, privateKey.getPrivateKey());
+            credential.setEntityId("KeyFileCredentialConfiguration");
             setCredential(credential);
         } catch(Exception e) {
             throw new CredentialConfigurationException(e);

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/logging/SamlSigningLoggerHelper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/logging/SamlSigningLoggerHelper.java
@@ -1,0 +1,21 @@
+package uk.gov.ida.notification.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class SamlSigningLoggerHelper {
+
+    private static final Logger log = LoggerFactory.getLogger(SamlSigningLoggerHelper.class);
+
+    public static void logSigningRequest(String responseId, String signingProvider) {
+        try {
+            MDC.put("eidasResponseID", responseId);
+            MDC.put("signingProvider", signingProvider);
+            log.info("Signing eIDAS response");
+        } finally {
+            MDC.remove("eidasResponseID");
+            MDC.remove("signingProvider");
+        }
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
@@ -9,6 +9,7 @@ import org.opensaml.xmlsec.SignatureSigningParameters;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import uk.gov.ida.notification.logging.SamlSigningLoggerHelper;
 
 public class SamlObjectSigner {
     private final SignatureSigningParameters signingParams;
@@ -17,7 +18,8 @@ public class SamlObjectSigner {
         signingParams = SignatureSigningParametersHelper.build(signingCredential, signingAlgorithm);
     }
 
-    public void sign(SignableSAMLObject signableSAMLObject) throws MarshallingException, SecurityException, SignatureException {
+    public void sign(SignableSAMLObject signableSAMLObject, String responseId) throws MarshallingException, SecurityException, SignatureException {
+        SamlSigningLoggerHelper.logSigningRequest(responseId, signingParams.getSigningCredential().getEntityId());
         SignatureSupport.signObject(signableSAMLObject, signingParams);
         SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
         signatureProfileValidator.validate(signableSAMLObject.getSignature());

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
@@ -25,7 +25,7 @@ public class SamlObjectSignerTest extends SamlInitializedTest {
         BasicX509Credential signingCredential = testKeyPair.getX509Credential();
         SamlObjectSigner samlObjectSigner = new SamlObjectSigner(signingCredential, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
         AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
-        samlObjectSigner.sign(authnRequest);
+        samlObjectSigner.sign(authnRequest, "response-id");
         Signature signature = authnRequest.getSignature();
 
         String actualCertificate = signature.getKeyInfo().getX509Datas().get(0).getX509Certificates().get(0).getValue();

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
@@ -25,7 +25,7 @@ public class EidasResponseGenerator {
         final ResponseAssertionEncrypter assertionEncrypter = new ResponseAssertionEncrypter(encryptionCredential);
 
         Response eidasResponseWithEncryptedAssertion = assertionEncrypter.encrypt(eidasResponse);
-        samlObjectSigner.sign(eidasResponseWithEncryptedAssertion);
+        samlObjectSigner.sign(eidasResponseWithEncryptedAssertion, hubResponseContainer.getEidasRequestId());
 
         return eidasResponseWithEncryptedAssertion;
     }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -44,7 +44,7 @@ public class HubResponseTranslator {
         this.proxyNodeMetadataForConnectorNodeUrl = proxyNodeMetadataForConnectorNodeUrl;
     }
 
-    Response translate(HubResponseContainer hubResponseContainer) {
+    public Response translate(HubResponseContainer hubResponseContainer) {
         final List<EidasAttributeBuilder> eidasAttributeBuilders = new ArrayList<>();
 
         if (hubResponseContainer.getVspScenario().equals(VspScenario.IDENTITY_VERIFIED)) {

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -113,7 +113,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
                     TEST_RP_PRIVATE_SIGNING_KEY
                 ), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
 
-        signer.sign(response);
+        signer.sign(response, "response-id");
 
         return response;
     }


### PR DESCRIPTION
- Log when each response is signed and specify whether it is being
signed with the CloudHSM or the KeyFile
- Use MDC.remove() rather than MDC.clear() to preserve state of MDC