### PR TITLE
BAU: More secure SAML parsing

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlParser.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlParser.java
@@ -1,23 +1,14 @@
 package uk.gov.ida.notification.saml;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.xml.XMLObject;
-import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
-import org.opensaml.core.xml.io.Unmarshaller;
-import org.opensaml.core.xml.io.UnmarshallerFactory;
 import org.opensaml.core.xml.io.UnmarshallingException;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.xml.sax.SAXException;
+import se.litsec.opensaml.utils.ObjectUtils;
 import uk.gov.ida.notification.exceptions.saml.SamlParsingException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Objects;
-
-import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 /**
  * Due to security requirements, {@link DocumentBuilder} and
@@ -27,29 +18,12 @@ import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
  */
 @SuppressWarnings("unchecked")
 public class SamlParser {
-    private final DocumentBuilder documentBuilder;
-    private final UnmarshallerFactory unmarshallerFactory;
-
-    public SamlParser() throws ParserConfigurationException {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setFeature(FEATURE_SECURE_PROCESSING, true);
-        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        dbf.setNamespaceAware(true);
-        documentBuilder = dbf.newDocumentBuilder();
-        unmarshallerFactory = XMLObjectProviderRegistrySupport.getUnmarshallerFactory();
-    }
-
     public <T extends XMLObject> T parseSamlString(String xmlString) {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(xmlString.getBytes());
 
         try {
-            Document document = documentBuilder.parse(inputStream);
-            Element element = document.getDocumentElement();
-            Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(element);
-            return (T) Objects.requireNonNull(
-                unmarshaller, String.format("No unmarshaller for element <%s>", element.getTagName())
-            ).unmarshall(element);
-        } catch (NullPointerException | SAXException | IOException | UnmarshallingException e) {
+            return (T) ObjectUtils.unmarshall(inputStream, XMLObject.class);
+        } catch (XMLParserException | UnmarshallingException e) {
             throw new SamlParsingException(e);
         }
     }

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlParserTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlParserTest.java
@@ -1,11 +1,12 @@
 package uk.gov.ida.notification.saml;
 
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestImpl;
 import org.opensaml.saml.saml2.core.impl.ResponseImpl;
-import org.xml.sax.SAXParseException;
 import uk.gov.ida.notification.SamlInitializedTest;
 import uk.gov.ida.notification.exceptions.saml.SamlParsingException;
 import uk.gov.ida.notification.helpers.FileHelpers;
@@ -49,8 +50,8 @@ public class SamlParserTest extends SamlInitializedTest {
             parser.parseSamlString(xmlString);
             fail("expected exception not thrown");
         } catch(SamlParsingException e) {
-            assertThat(e.getCause()).isInstanceOf(NullPointerException.class);
-            assertThat(e.getCause().getMessage()).isEqualTo("No unmarshaller for element <lolz>");
+            assertThat(e.getCause()).isInstanceOf(UnmarshallingException.class);
+            assertThat(e.getCause().getMessage()).isEqualTo("No unmarshaller found for lolz");
         }
     }
 
@@ -80,7 +81,7 @@ public class SamlParserTest extends SamlInitializedTest {
             parser.parseSamlString(xmlString);
             fail("expected exception not thrown");
         } catch(SamlParsingException e) {
-            assertThat(e.getCause()).isInstanceOf(SAXParseException.class);
+            assertThat(e.getCause()).isInstanceOf(XMLParserException.class);
         }
     }
 
@@ -99,8 +100,7 @@ public class SamlParserTest extends SamlInitializedTest {
             parser.parseSamlString(xmlString);
             fail("expected exception not thrown");
         } catch(SamlParsingException e) {
-            assertThat(e.getCause()).isInstanceOf(SAXParseException.class);
-            assertThat(e.getCause().getMessage()).contains("DOCTYPE is disallowed");
+            assertThat(e.getCause()).isInstanceOf(XMLParserException.class);
         }
     }
 }


### PR DESCRIPTION
Instead of creating our own SAML parser and having to worry about the
security features that have to be enabled, delegate to litsec's
`ObjectUtils` class which correctly uses the OpenSAML parser pool which
should always be securely configured.

I've left the tests for XML attacks in place for reassurance.