### PR TITLE
Add Tracibility and Anti-Affinity ADRs

### DIFF
--- a/doc/adr/20190320-additional-tracing.md
+++ b/doc/adr/20190320-additional-tracing.md
@@ -1,0 +1,45 @@
+# Add service mesh for traceability
+
+Date: 2019-03-20
+
+## Status
+
+Accepted
+
+## Context
+
+eIDAS project has been challenged with some security concerns provided by
+National Cyber Security Centre (NCSC). One of these concerns was a possibility
+for a connector application or the connection between given connector and the
+user being compromised and allow for stolen request IDs impersonate or create
+new identities.
+
+Sadly, it's out of our control. We do however, have an obligation to monitor
+actions that are going through the system, in order to prove our innocence.
+
+We have made a presumption, that Hardware Security Module (HSM) logs would be
+able to tell us when it has been used to sign a thing and attach it to some of
+the logs that we're currently holding.
+
+This isn't however true for the version of HSM that is provided to us by AWS.
+We have managed to raise a feature request, which will not be coming for a
+while.
+
+## Decision
+
+Reliability Engineering has proposed to implement tracing through the system
+with the use of Service Mesh. This requires our services to pass around a
+header in the requests. Cyber Security team, will then create some monitoring
+around these logs and alert when a path of the request is not performed in a
+correct order indicating the request is being injected. These logs would then
+be compared with a size of a body sent through to the HSM and back, to
+establish when that exact request has been signed.
+
+This doesn't solve the problem entirely, but is good enough for now before we
+receive an appropriate solution from AWS.
+
+## Consequences
+
+- Complexity around networking
+- Additional burden to maintain
+

--- a/doc/adr/20190320-anti-affinity.md
+++ b/doc/adr/20190320-anti-affinity.md
@@ -1,0 +1,31 @@
+# Defining Anti-Affinity for Gateway and Translator services
+
+Date: 2019-03-20
+
+## Status
+
+Accepted
+
+## Context
+
+eIDAS project has been challenged with some security concerns provided by
+National Cyber Security Centre (NCSC). One of these concerns was a hypothesis
+that an attacker could compromise the public facing service (Gateway) by
+providing insecure SAML, could perform a Kernel Attack against the more fragile
+and sensitive but not exposed service (Translator) which has capability to
+interacting with Hardware Security Module (HSM).
+
+Provided we're running on GDS Supported Platform (GSP), Reliability Engineering
+(RE) team has suggested separating any service capable of interacting with HSM
+into a different physical machine. This should prevent this sort of attack from
+happening.
+
+## Decision
+
+We'll trust that the GSP is be capable of deploying sensitive applications away
+from the ones that are interacting with HSM.
+
+## Consequences
+
+- Additional complicity we need to keep in mind
+


### PR DESCRIPTION
## What

We're adding some extra complexity into the system, in order to mitigate
some of the risks outlined by NCSC. We should be documenting the
decisions and approaches we have taken, in order to reflect on these in
the future and keep the context alive.

## How to review

- Read through, seek sense