### PR TITLE
BAU: Enable PKCS11 workaround for stub connector

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
@@ -11,7 +11,12 @@ public class ResponseAssertionDecrypter {
     private final SAMLObjectDecrypter decrypter;
 
     public ResponseAssertionDecrypter(Credential credential) {
+        this(credential, false);
+    }
+
+    public ResponseAssertionDecrypter(Credential credential, boolean usingHsm) {
         this.decrypter = new SAMLObjectDecrypter(credential);
+        this.decrypter.setPkcs11Workaround(usingHsm);
     }
 
     public Response decrypt(Response response) throws DecryptionException {

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -124,7 +124,9 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
             configuration,
             proxyNodeMetadata));
 
-        ResponseAssertionDecrypter decrypter = new ResponseAssertionDecrypter(configuration.getCredentialConfiguration().getCredential());
+        ResponseAssertionDecrypter decrypter = new ResponseAssertionDecrypter(
+            configuration.getCredentialConfiguration().getCredential(),
+            true);
 
         environment.jersey().register(
                 new ReceiveResponseResource(


### PR DESCRIPTION
We're using the `SAMLObjectDecrypter` to decrypt the Response assertions
that come back from the proxy node. Since stub connector uses the HSM to
decrypt, the class needs to have a workaround enabled.

The `SAMLObjectDecrypter` source has this to say:

    If using a HSM it is likely that the SunPKCS11 crypto provider is used. This provider does not have support for
    OAEP padding. This is used commonly for XML encryption since
    {@code http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p} is the default algorithm to use for key encryption. This
    class has a workaround for this limitation that is enabled by setting the {@code pkcs11Workaround} flag.