### PR TITLE
Revert "BAU: Enable PKCS11 workaround for stub connector"

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
@@ -11,12 +11,7 @@ public class ResponseAssertionDecrypter {
     private final SAMLObjectDecrypter decrypter;
 
     public ResponseAssertionDecrypter(Credential credential) {
-        this(credential, false);
-    }
-
-    public ResponseAssertionDecrypter(Credential credential, boolean usingHsm) {
         this.decrypter = new SAMLObjectDecrypter(credential);
-        this.decrypter.setPkcs11Workaround(usingHsm);
     }
 
     public Response decrypt(Response response) throws DecryptionException {

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -124,9 +124,7 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
             configuration,
             proxyNodeMetadata));
 
-        ResponseAssertionDecrypter decrypter = new ResponseAssertionDecrypter(
-            configuration.getCredentialConfiguration().getCredential(),
-            true);
+        ResponseAssertionDecrypter decrypter = new ResponseAssertionDecrypter(configuration.getCredentialConfiguration().getCredential());
 
         environment.jersey().register(
                 new ReceiveResponseResource(


### PR DESCRIPTION
This reverts commit 8ca20e3ba2d6580e99c5936d6c8199538e25d249.