### PR TITLE
BAU: Force ResponseAssertionDecrypter to use Cavium provider

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/CloudHsmCredentialConfiguration.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/CloudHsmCredentialConfiguration.java
@@ -18,7 +18,7 @@ import java.security.cert.X509Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudHsmCredentialConfiguration extends CredentialConfiguration {
-
+    public static final String ID = "CloudHsmCredentialConfiguration";
     private static final Logger LOG = LoggerFactory.getLogger(CloudHsmCredentialConfiguration.class);
 
     @JsonCreator
@@ -40,7 +40,7 @@ public class CloudHsmCredentialConfiguration extends CredentialConfiguration {
             BasicX509Credential credential = new BasicX509Credential(
                 certificate,
                 (PrivateKey) cloudHsmStore.getKey(hsmKeyLabel, null));
-            credential.setEntityId("CloudHsmCredentialConfiguration");
+            credential.setEntityId(ID);
             setCredential(credential);
         } catch(Exception e) {
             throw new CredentialConfigurationException(e);

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
@@ -3,21 +3,32 @@ package uk.gov.ida.notification.saml;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.encryption.support.DecryptionException;
-import se.litsec.opensaml.xmlsec.SAMLObjectDecrypter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.ida.notification.configuration.CloudHsmCredentialConfiguration;
+import uk.gov.ida.saml.security.DecrypterFactory;
+
+import java.util.Collections;
 
 public class ResponseAssertionDecrypter {
-    private final SAMLObjectDecrypter decrypter;
+    private final Logger log = LoggerFactory.getLogger(this.getClass().getName());
+    private final Decrypter decrypter;
 
     public ResponseAssertionDecrypter(Credential credential) {
-        this.decrypter = new SAMLObjectDecrypter(credential);
+        this.decrypter = new DecrypterFactory().createDecrypter(Collections.singletonList(credential));
+        if (credential.getEntityId() != null && credential.getEntityId().equals(CloudHsmCredentialConfiguration.ID)) {
+            log.info("Using CloudHSM so set JCA provider to Cavium");
+            this.decrypter.setJCAProviderName("Cavium");
+        }
     }
 
     public Response decrypt(Response response) throws DecryptionException {
         response.getAssertions().clear();
         for (EncryptedAssertion encryptedAssertion : response.getEncryptedAssertions()) {
-            Assertion assertion = decrypter.decrypt(encryptedAssertion, Assertion.class);
+            Assertion assertion = decrypter.decrypt(encryptedAssertion);
             response.getAssertions().add(assertion);
         }
         response.getEncryptedAssertions().clear();


### PR DESCRIPTION
The stub-connector doesn't seem to know to use the Cavium provider when
it decrypts Assertions from the translator so let's force it.