### PR TITLE
EID-1412: Handle internal errors - redirect to static error page

### DIFF
--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -35,3 +35,5 @@ translatorService:
 redisService:
   local: ${USE_REDIS_LOCAL:-false}
   url: ${REDIS_SERVER_URI}
+
+errorPageRedirectUrl: ${PROXY_NODE_ERROR_PAGE_URI:-}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayConfiguration.java
@@ -9,6 +9,7 @@ import uk.gov.ida.notification.configuration.VerifyServiceProviderConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.net.URI;
 
 public class GatewayConfiguration extends Configuration {
 
@@ -32,6 +33,10 @@ public class GatewayConfiguration extends Configuration {
     @NotNull
     private RedisServiceConfiguration redisService;
 
+    @JsonProperty
+    @Valid
+    private URI errorPageRedirectUrl;
+
 
     public TranslatorServiceConfiguration getTranslatorServiceConfiguration() { return translatorService; }
 
@@ -39,8 +44,11 @@ public class GatewayConfiguration extends Configuration {
 
     public VerifyServiceProviderConfiguration getVerifyServiceProviderConfiguration() { return verifyServiceProviderService; }
 
-
     public RedisServiceConfiguration getRedisService() {
         return redisService;
+    }
+
+    public URI getErrorPageRedirectUrl() {
+        return errorPageRedirectUrl;
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/EidasSamlParserResponseExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/EidasSamlParserResponseExceptionMapper.java
@@ -5,19 +5,19 @@ import uk.gov.ida.exceptions.ApplicationException;
 import uk.gov.ida.notification.exceptions.EidasSamlParserResponseException;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 public class EidasSamlParserResponseExceptionMapper extends ExceptionToErrorPageMapper<EidasSamlParserResponseException> {
+
+    public EidasSamlParserResponseExceptionMapper(URI errorPageRedirectUrl) {
+        super(errorPageRedirectUrl);
+    }
 
     @Override
     protected Response.Status getResponseStatus(EidasSamlParserResponseException exception) {
         ApplicationException cause = (ApplicationException) exception.getCause();
         return cause.getExceptionType() == ExceptionType.CLIENT_ERROR ?
                 Response.Status.BAD_REQUEST : Response.Status.INTERNAL_SERVER_ERROR;
-    }
-
-    @Override
-    protected String getErrorPageMessage(EidasSamlParserResponseException exception) {
-        return "Something went wrong when contacting the ESP";
     }
 
     @Override

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToErrorPageMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToErrorPageMapper.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -18,8 +19,14 @@ public abstract class ExceptionToErrorPageMapper<TException extends Exception> i
 
     private static final Logger LOG = LoggerFactory.getLogger(ExceptionToErrorPageMapper.class);
 
+    private final URI errorPageRedirectUrl;
+
     private UriInfo uriInfo;
     private String logId;
+
+    ExceptionToErrorPageMapper(URI errorPageRedirectUrl) {
+        this.errorPageRedirectUrl = errorPageRedirectUrl;
+    }
 
     @Context
     public void setUriInfo(UriInfo uriInfo) {
@@ -30,14 +37,14 @@ public abstract class ExceptionToErrorPageMapper<TException extends Exception> i
     public Response toResponse(TException exception) {
         logException(exception);
 
-        return Response.status(getResponseStatus(exception))
-                .entity(new ErrorPageView(getErrorPageMessage(exception)))
-                .build();
+        return errorPageRedirectUrl != null ?
+                Response.seeOther(errorPageRedirectUrl).build() :
+                Response.status(getResponseStatus(exception))
+                        .entity(new ErrorPageView())
+                        .build();
     }
 
     protected abstract Response.Status getResponseStatus(TException exception);
-
-    protected abstract String getErrorPageMessage(TException exception);
 
     String getLogId() {
         return logId;

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
@@ -34,7 +34,7 @@ public abstract class ExceptionToSamlErrorResponseMapper<TException extends Exce
     private UriInfo uriInfo;
     private String logId;
 
-    public ExceptionToSamlErrorResponseMapper(SamlFormViewBuilder samlFormViewBuilder, TranslatorProxy translatorProxy, SessionStore sessionStorage) {
+    ExceptionToSamlErrorResponseMapper(SamlFormViewBuilder samlFormViewBuilder, TranslatorProxy translatorProxy, SessionStore sessionStorage) {
         this.samlFormViewBuilder = samlFormViewBuilder;
         this.translatorProxy = translatorProxy;
         this.sessionStorage = sessionStorage;

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/FailureResponseGenerationExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/FailureResponseGenerationExceptionMapper.java
@@ -3,17 +3,17 @@ package uk.gov.ida.notification.exceptions.mappers;
 import uk.gov.ida.notification.exceptions.FailureResponseGenerationException;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 public class FailureResponseGenerationExceptionMapper extends ExceptionToErrorPageMapper<FailureResponseGenerationException> {
+
+    public FailureResponseGenerationExceptionMapper(URI errorPageRedirectUrl) {
+        super(errorPageRedirectUrl);
+    }
 
     @Override
     protected Response.Status getResponseStatus(FailureResponseGenerationException exception) {
         return Response.Status.INTERNAL_SERVER_ERROR;
-    }
-
-    @Override
-    protected String getErrorPageMessage(FailureResponseGenerationException exception) {
-        return "Failed to generate failure response";
     }
 
     @Override

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/GenericExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/GenericExceptionMapper.java
@@ -1,16 +1,16 @@
 package uk.gov.ida.notification.exceptions.mappers;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 public class GenericExceptionMapper extends ExceptionToErrorPageMapper<Exception> {
+
+    public GenericExceptionMapper(URI errorPageRedirectUrl) {
+        super(errorPageRedirectUrl);
+    }
 
     @Override
     protected Response.Status getResponseStatus(Exception exception) {
         return Response.Status.INTERNAL_SERVER_ERROR;
-    }
-
-    @Override
-    protected String getErrorPageMessage(Exception exception) {
-        return exception.getMessage();
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionMissingExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/SessionMissingExceptionMapper.java
@@ -3,16 +3,16 @@ package uk.gov.ida.notification.exceptions.mappers;
 import uk.gov.ida.notification.exceptions.SessionMissingException;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 public class SessionMissingExceptionMapper extends ExceptionToErrorPageMapper<SessionMissingException> {
+
+    public SessionMissingExceptionMapper(URI errorPageRedirectUrl) {
+        super(errorPageRedirectUrl);
+    }
 
     @Override
     protected Response.Status getResponseStatus(SessionMissingException exception) {
         return Response.Status.BAD_REQUEST;
-    }
-
-    @Override
-    protected String getErrorPageMessage(SessionMissingException exception) {
-        return "Something went wrong; session does not exist";
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/VerifyServiceProviderRequestExceptionMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/VerifyServiceProviderRequestExceptionMapper.java
@@ -3,17 +3,17 @@ package uk.gov.ida.notification.exceptions.mappers;
 import uk.gov.ida.notification.exceptions.proxy.VerifyServiceProviderRequestException;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 public class VerifyServiceProviderRequestExceptionMapper extends ExceptionToErrorPageMapper<VerifyServiceProviderRequestException> {
+
+    public VerifyServiceProviderRequestExceptionMapper(URI errorPageRedirectUrl) {
+        super(errorPageRedirectUrl);
+    }
 
     @Override
     protected Response.Status getResponseStatus(VerifyServiceProviderRequestException exception) {
         return Response.Status.INTERNAL_SERVER_ERROR;
-    }
-
-    @Override
-    protected String getErrorPageMessage(VerifyServiceProviderRequestException exception) {
-        return "Something went wrong when contacting the VSP";
     }
 
     @Override

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/base/GatewayAppRuleTestBase.java
@@ -34,9 +34,13 @@ public class GatewayAppRuleTestBase {
     private final SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
 
     protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest, GatewayAppRule proxyNodeAppRule) throws URISyntaxException {
+        return postEidasAuthnRequest(eidasAuthnRequest, proxyNodeAppRule, true);
+    }
+
+    protected Response postEidasAuthnRequest(AuthnRequest eidasAuthnRequest, GatewayAppRule proxyNodeAppRule, boolean followRedirects) throws URISyntaxException {
         String encodedRequest = Base64.encodeAsString(marshaller.transformToString(eidasAuthnRequest));
         Form postForm = new Form().param(SamlFormMessageType.SAML_REQUEST, encodedRequest).param("RelayState", "relay-state");
-        return proxyNodeAppRule.target("/SAML2/SSO/POST").request().post(Entity.form(postForm));
+        return proxyNodeAppRule.target("/SAML2/SSO/POST", followRedirects).request().post(Entity.form(postForm));
     }
 
     protected Response redirectEidasAuthnRequest(AuthnRequest eidasAuthnRequest, GatewayAppRule proxyNodeAppRule) throws URISyntaxException {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/views/ErrorPageView.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/views/ErrorPageView.java
@@ -1,34 +1,10 @@
 package uk.gov.ida.notification.views;
 
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.views.View;
-import uk.gov.ida.saml.core.domain.TransactionIdaStatus;
-
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
 
 public class ErrorPageView extends View {
 
-    private final String issue;
-
-    public ErrorPageView(String issue) {
+    public ErrorPageView() {
         super("error-page.mustache");
-        this.issue = issue;
-    }
-
-    public ErrorPageView(Throwable e) {
-        super("error-page.mustache");
-        this.issue = e.getMessage();
-    }
-
-    public String getIssue() {
-        return issue;
-    }
-
-    public String getReaction() {
-        final List<String> reactions = ImmutableList.of("😧","😮","😢","😭","👎","😶","🙃");
-        final int reaction = new Random().nextInt(reactions.size());
-        return reactions.get(reaction);
     }
 }

--- a/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/error-page.mustache
+++ b/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/error-page.mustache
@@ -1,45 +1,48 @@
 <html>
 <head>
-    <title>Sorry, something went wrong</title>
-    <meta charset="utf-8"/>
-    <meta content="width=device-width,initial-scale=1.0" name="viewport"/>
+  <title>Sorry, something went wrong</title>
+  <meta charset="utf-8"/>
+  <meta content="width=device-width,initial-scale=1.0" name="viewport"/>
 </head>
+
 <style>
-    .main {
-        color: rgb(51, 51, 51);
-        font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
-        text-align: center;
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    .logo {
-        /* maximum that displays in Chrome/macOS */
-        font-size: 7em;
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    .title {
-        font-weight: 700;
-        font-size: 3em;
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    .issues {
-        font-weight: 300;
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
-    .help {
-        margin-top: 20px;
-        margin-bottom: 20px;
-    }
+  .main {
+    color: rgb(51, 51, 51);
+    font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+    text-align: center;
+    padding-top: 100px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .title {
+    font-weight: 700;
+    font-size: 3em;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .issues {
+    font-weight: 300;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .help {
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
 </style>
-<body class="main">
-<div>
-<div class="logo">{{reaction}}</div>
-<div class="title">Sorry, something went wrong</div>
-<div class="issues">{{issue}}</div>
-<div class="help">Go back to a service and try again.</div>
+
+<body>
+
+<div class="main">
+  <div class="title">Sorry, something went wrong</div>
+  <div class="issues">This may be because your session timed out or there was a system error.</div>
+  <div class="help">Because you were using a secure service from another European country, you’ll need to go back to
+    the page where you started using that service.
+  </div>
 </div>
+
 </body>
 </html>


### PR DESCRIPTION
Redirect to a static error page hosted in verify-frontend when a failure SAML message cannot be generated and returned to the connector node that sent the authn request.

For the time being, we will redirect to the current error page (hosted by the proxy node) if no redirect URL has been configured. This is to enable the app run locally. In the future, once we have a local env, we will want to make the redirect URL mandatory and have the startup script host a static local error page to redirect to.