### PR TITLE
EID-1384 Tweak acceptance tests

### DIFF
--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -14,21 +14,21 @@ Feature: proxy-node feature
 
     Scenario: Proxy node happy path - LOA High
         Given the proxy node is sent a LOA 'High' request
-        Then the user should be presented with an '400' page
+        Then the user should be presented with an error page
 
     # This probably works but needs a deployment of stub connector to test if it works.
     @ignore
     Scenario: Stub connector Generates Authn Failure
         Given the stub connector supplies a bad authn request
-        Then the user should be presented with an hub error page
+        Then the user should be presented with an error page
 
     @ignore
     Scenario: Show 404 if page doesnt exist
         Given the user accesses a invalid page
-        Then the user should be presented with an '404' page
+        Then the user should be presented with an error page
 
     @ignore
     Scenario: Show 405 if route is not accessible
         Given the user accesses a route they shouldn't
         And they progress through verify
-        Then the user should be presented with an '405' page
+        Then the user should be presented with an error page

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -17,7 +17,7 @@ Given("the proxy node is sent a LOA {string} request") do |load_type|
 end
 
 And('they progress through verify') do
-  find('label', :text => 'I’ve used Verify before').click
+  find('label', :text => 'I’ve used GOV.UK Verify before').click
   click_button('Continue')
   find('button', :text => 'Stub Idp Demo One').click
 end
@@ -53,8 +53,7 @@ Then("the user should be presented with an hub error page") do
   assert_text('You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.')
 end
 
-
-Then("the user should be presented with an {string} page") do |http_error_code|
+Then("the user should be presented with an error page") do
   assert_text('Sorry, something went wrong')
-  assert_text('HTTP ' + http_error_code)
+  assert_text('This may be because your session timed out or there was a system error.')
 end


### PR DESCRIPTION
As part of getting the acceptance tests to run in the release pipeline
it'd be useful if the ones we have ran green. These tests need more work
in general but that's out of scope for this ticket.

The error page we serve from the frontend does not include the http
status code. Also selenium does not currently support access to the
status code of a request, so the error page test has been changed to
just check the content.