### PR TITLE
EID 1384 Rename selenium hub env variable

### DIFF
--- a/proxy-node-acceptance-tests/features/support/env.rb
+++ b/proxy-node-acceptance-tests/features/support/env.rb
@@ -26,7 +26,7 @@ if ENV['TEST_ENV'] == 'local' || show_browser
     Capybara.javascript_driver = :firefox_driver
   end
 else
-  selenium_hub_url = ENV['HUB'] || 'http://selenium-hub:4444/wd/hub'
+  selenium_hub_url = ENV['SELENIUM_HUB_URL'] || 'http://selenium-hub:4444/wd/hub'
   Capybara.register_driver :selenium_remote_firefox do |app|
     Capybara::Selenium::Driver.new(app, browser: :remote, url: selenium_hub_url, desired_capabilities: :firefox)
   end


### PR DESCRIPTION
This avoids possible confusion with the verify hub.

This variable is useful for our acceptance tests running in the deploy
pipeline. It allows us to use the selenium hub running in the tools
account rather than spinning up a new one each time.