### PR TITLE
use latest verify-saml-libs, built with OpenJDK 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,9 @@ subprojects {
             opensaml("com.google.guava:guava:24.1.1-jre") {
                 because "opensaml:3.4.0 has a dep on guava:20.0.0 which is vulnerable to CVE-2018-10237"
             }
+            dropwizard("org.eclipse.jetty:jetty-server:9.4.17.v20190418") {
+                because "org.eclipse.jetty:jetty-util:9.4.14.v20181114 is vulnerable to CVE-2019-10247"
+            }
         }
 
         eidas_saml(

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ subprojects {
         configurations.all {
             resolutionStrategy.dependencySubstitution {
                 substitute module("dom4j:dom4j:1.6.1") because "dom4j vulnerable to XML External Entity (XXE) Injection due to not validating the QName inputs, see CVE-2018-1000632" with module("org.dom4j:dom4j:2.1.1")
+                substitute module("org.eclipse.jetty:jetty-server") because "jetty-server dependency org.eclipse.jetty:jetty-util:9.4.14.v20181114 is vulnerable to CVE-2019-10247" with module("org.eclipse.jetty:jetty-server:9.4.17.v20190418")
+                
             }
         }
 
@@ -98,9 +100,6 @@ subprojects {
             }
             opensaml("com.google.guava:guava:24.1.1-jre") {
                 because "opensaml:3.4.0 has a dep on guava:20.0.0 which is vulnerable to CVE-2018-10237"
-            }
-            dropwizard("org.eclipse.jetty:jetty-server:9.4.17.v20190418") {
-                because "org.eclipse.jetty:jetty-util:9.4.14.v20181114 is vulnerable to CVE-2019-10247"
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     opensaml_version = '3.4.2'
     dropwizard_version = '1.3.9'
     utils_version = '2.0.0-351'
-    saml_lib_version = "${opensaml_version}-185"
+    saml_lib_version = "${opensaml_version}-188"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 


### PR DESCRIPTION
We want to standardise compile and runtimes to OpenJDK 11.

This PR will use the latest `verify-saml-libs`, compiled with with OpenJDK 11.