### PR TITLE
Remove opensaml dependencies from gateway

### DIFF
--- a/proxy-node-gateway/build.gradle
+++ b/proxy-node-gateway/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     compile configurations.dropwizard,
-            configurations.opensaml,
             configurations.common,
             configurations.ida_utils,
             project(':proxy-node-shared')

--- a/proxy-node-gateway/build.gradle
+++ b/proxy-node-gateway/build.gradle
@@ -3,6 +3,14 @@ dependencies {
             configurations.common,
             configurations.ida_utils,
             project(':proxy-node-shared')
+        configurations.all {
+            exclude group: "se.litsec.eidas", module: "eidas-opensaml3"
+            exclude group: "org.opensaml", module: "opensaml-storage-impl"
+            exclude group: "org.springframework", module: "spring-context"
+            exclude group: "org.springframework", module: "spring-core"
+            exclude group: "org.springframework", module: "spring-beans"
+            exclude group: "uk.gov.ida", module: "verify-event-emitter"
+        }
 }
 
 group = 'uk.gov.ida.notification.gateway'


### PR DESCRIPTION
the public facing gateway service does not do saml processing so it should not require the opensaml libraries.
These are largely set via transitive dependencies within the `proxy-node-shared` module.

You can check gateway dependencies using:
`./gradlew proxy-node-gateway:dependencies --configuration compile`

This PR removes these dependencies, reducing attack surface area available via the gateway classpath.

