### PR TITLE
Reinstate ignored Proxy Node acceptance tests

### DIFF
--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -16,18 +16,14 @@ Feature: proxy-node feature
         Given the proxy node is sent a LOA 'High' request
         Then the user should be presented with an error page
 
-    # This probably works but needs a deployment of stub connector to test if it works.
-    @ignore
     Scenario: Stub connector Generates Authn Failure
         Given the stub connector supplies a bad authn request
         Then the user should be presented with an error page
 
-    @ignore
     Scenario: Show 404 if page doesnt exist
         Given the user accesses a invalid page
         Then the user should be presented with an error page
 
-    @ignore
     Scenario: Show 405 if route is not accessible
         Given the user accesses a route they shouldn't
         And they progress through verify


### PR DESCRIPTION
Add three error scenario tests to acceptance suite. We want to observe them pass on the proxy node promotion pipeline.