### PR TITLE
Fix Proxy Node acceptance tests

### DIFF
--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -20,10 +20,10 @@ Feature: proxy-node feature
         Given the stub connector supplies a bad authn request
         Then the user should be presented with an error page
 
-    Scenario: Show 404 if page doesnt exist
+    Scenario: Show error page if page doesnt exist
         Given the user accesses a invalid page
         Then the user should be presented with an error page
 
-    Scenario: Show 405 if route is not accessible
-        Given the user accesses a route they shouldn't
+    Scenario: Show error page if route is not accessible
+        Given the user accesses the gateway response url directly
         Then the user should be presented with an error page

--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -26,5 +26,4 @@ Feature: proxy-node feature
 
     Scenario: Show 405 if route is not accessible
         Given the user accesses a route they shouldn't
-        And they progress through verify
         Then the user should be presented with an error page

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -37,7 +37,7 @@ Given("the user accesses a invalid page") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/asdfasdfasfsaf')
 end
 
-Given("the user accesses a route they shouldn't") do
+Given("the user accesses the gateway response url directly") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/SAML2/SSO/Response/POST')
 end
 

--- a/proxy-node-acceptance-tests/run-staging-tests.sh
+++ b/proxy-node-acceptance-tests/run-staging-tests.sh
@@ -4,7 +4,7 @@ set -eu
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-export PROXY_NODE_URL="https://test-connector.staging.verify.govsvc.uk"
+export PROXY_NODE_URL="https://test-proxy-node.staging.verify.govsvc.uk"
 export STUB_CONNECTOR_URL="https://test-connector.staging.verify.govsvc.uk"
 export STUB_IDP_USER="stub-idp-demo-one"
 docker-compose up --abort-on-container-exit | grep acceptance-tests_1 --colour=never


### PR DESCRIPTION
- Rename some acceptance tests for clarity
- Fix the script which runs tests against staging
- Remove an unneeded step in an error scenario

This PR will make [the promotion pipeline](https://ci.tools.verify.govsvc.uk/teams/main/pipelines/promotion) go green 🤞 