### PR TITLE
show eidas request id in stub connector result page

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
@@ -7,11 +7,13 @@ import java.util.List;
 public class ResponseView extends View {
     private final List<String> attributes;
     private final String validity;
+    private final String eidasRequestId;
 
-    public ResponseView(List<String> attributes, String validity) {
+    public ResponseView(List<String> attributes, String validity, String eidasRequestId) {
         super("response.mustache");
         this.attributes = attributes;
         this.validity = validity;
+        this.eidasRequestId = eidasRequestId;
     }
 
     public List<String> getAttributes() {
@@ -20,5 +22,9 @@ public class ResponseView extends View {
 
     public String getValidity() {
         return validity;
+    }
+
+    public String getEidasRequestId() {
+        return eidasRequestId;
     }
 }

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
@@ -1,6 +1,7 @@
 <h1>Response successfully received</h1>
 
 <h2>Saml Validity: {{validity}}</h2>
+<h2>eIDAS Request Id: {{eidasRequestId}}</h2>
 
 <h2>Attributes</h2>
 <ul>


### PR DESCRIPTION
To help in tracking a user journey through logs, surface the eidas request id in `stub-connector` logs  and result page.