### PR TITLE
EID-1490: Switch to pulling dependencies from Artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 
+env:
+  global:
+    - VERIFY_USE_PUBLIC_BINARIES=true
+
 jdk:
   - openjdk11
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,19 @@
 buildscript {
     repositories {
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        jcenter()
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
     dependencies {
-        classpath 'com.github.spullara.mustache.java:compiler:0.8.10',
-                'org.yaml:snakeyaml:1.10',
-                'com.google.guava:guava:14.0.1',
-                'com.github.ben-manes:gradle-versions-plugin:0.17.0'
+        classpath 'com.github.spullara.mustache.java:compiler:0.9.6',
+                'org.yaml:snakeyaml:1.24',
+                'com.google.guava:guava:27.1-jre',
+                'com.github.ben-manes:gradle-versions-plugin:0.20.0'
     }
 }
 
@@ -17,8 +23,8 @@ apply plugin: 'com.github.ben-manes.versions'
 ext {
     opensaml_version = '3.4.2'
     dropwizard_version = '1.3.9'
-    utils_version = '2.0.0-359'
-    saml_lib_version = "${opensaml_version}-190"
+    utils_version = '2.0.0-360'
+    saml_lib_version = "${opensaml_version}-192"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -37,10 +43,16 @@ subprojects {
     }
 
     repositories {
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        maven { url 'https://dl.bintray.com/alphagov/maven' }
-        maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-        jcenter()
+        if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
+            logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/whitelisted-repos for production builds.\n\n')
+            maven { url 'https://dl.bintray.com/alphagov/maven-test' }
+            maven { url 'https://dl.bintray.com/alphagov/maven' }
+            maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
+            jcenter()
+        }
+        else {
+            maven { url 'https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory/whitelisted-repos' }
+        }
     }
 
     sourceSets {
@@ -67,7 +79,6 @@ subprojects {
             resolutionStrategy.dependencySubstitution {
                 substitute module("dom4j:dom4j:1.6.1") because "dom4j vulnerable to XML External Entity (XXE) Injection due to not validating the QName inputs, see CVE-2018-1000632" with module("org.dom4j:dom4j:2.1.1")
                 substitute module("org.eclipse.jetty:jetty-server") because "jetty-server dependency org.eclipse.jetty:jetty-util:9.4.14.v20181114 is vulnerable to CVE-2019-10247" with module("org.eclipse.jetty:jetty-server:9.4.17.v20190418")
-                
             }
         }
 
@@ -88,7 +99,12 @@ subprojects {
         opensaml(
                 "org.opensaml:opensaml-core:${opensaml_version}",
                 "org.opensaml:opensaml-saml-impl:${opensaml_version}",
-                "org.opensaml:opensaml-storage-impl:${opensaml_version}",
+
+                compile("org.opensaml:opensaml-storage-impl:${opensaml_version}") {
+                    exclude group: 'org.ldaptive', module: 'ldaptive'
+                    exclude group: 'org.glassfish', module: 'javax.json'
+                    exclude group: 'org.hibernate', module: 'hibernate-entitymanager'
+                }
         )
 
         constraints {
@@ -135,11 +151,11 @@ subprojects {
         testCompile(
                 "org.junit.jupiter:junit-jupiter-api:5.4.2",
                 'org.junit.jupiter:junit-jupiter-params:5.4.2',
-                "org.assertj:assertj-core:3.11.1",
+                "org.assertj:assertj-core:3.12.2",
                 "org.mockito:mockito-core:2.27.0",
                 "org.mockito:mockito-junit-jupiter:2.27.0",
                 "io.dropwizard:dropwizard-testing:${dropwizard_version}",
-                "net.sourceforge.htmlunit:htmlunit:2.28",
+                "net.sourceforge.htmlunit:htmlunit:2.35.0",
                 "com.github.stefanbirkner:system-rules:1.19.0",
                 "com.github.fppt:jedis-mock:0.1.9",
                 "it.ozimov:embedded-redis:0.7.2",
@@ -147,7 +163,7 @@ subprojects {
                 project(':proxy-node-test'),
         )
 
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.4.2'
     }
 }
 


### PR DESCRIPTION
For all prod builds we need to ensure that the Proxy Node pulls dependencies from Artifactory instead of Bintray. Travis still needs to access Bintray as it cannot access Artifactory.

  - Added `VERIFY_USE_PUBLIC_BINARIES` flag which is set to `true` for Travis builds
  - If the flag is `false` (default), set `gradle` to pull dependencies from Artifactory
  - Exclude unnecessary transitive dependencies
  - Update libraries to latest versions