### PR TITLE
EID-1495 Configure EIDAS's VSP to use logstash for logging and Java 1…

### DIFF
--- a/proxy-node-vsp-config/Dockerfile.internal
+++ b/proxy-node-vsp-config/Dockerfile.internal
@@ -1,0 +1,27 @@
+FROM gradle:5.1-jdk11 as build
+ARG VERIFY_USE_PUBLIC_BINARIES=false
+WORKDIR /verify-service-provider
+USER root
+ENV GRADLE_USER_HOME ~/.gradle
+
+COPY build.gradle build.gradle
+COPY settings.gradle settings.gradle
+COPY src src
+
+RUN gradle installDist
+
+ENTRYPOINT ["gradle"]
+CMD ["tasks"]
+
+FROM openjdk:11-jre-slim
+
+WORKDIR /verify-service-provider
+
+RUN apt-get update && apt-get install curl
+
+RUN curl -sSLO https://raw.githubusercontent.com/alphagov/verify-proxy-node/master/proxy-node-vsp-config/verify-service-provider.yml
+
+COPY --from=build /verify-service-provider/build/install/verify-service-provider .
+
+ENTRYPOINT ["sh", "-c"]
+CMD ["bin/verify-service-provider", "server", "verify-service-provider.yml"]

--- a/proxy-node-vsp-config/verify-service-provider.yml
+++ b/proxy-node-vsp-config/verify-service-provider.yml
@@ -1,0 +1,34 @@
+server:
+  type: simple
+  applicationContextPath: /
+  adminContextPath: /admin
+  connector:
+    type: http
+    port: ${PORT:-50400}
+
+logging:
+  level: ${LOG_LEVEL:-INFO}
+  appenders:
+    - type: logstash-console
+    - type: file
+      currentLogFilename: logs/verify-service-provider.log
+      archivedLogFilenamePattern: logs/verify-service-provider.log.%d.gz
+
+clockSkew: ${CLOCK_SKEW:-PT30s}
+
+serviceEntityIds: ${SERVICE_ENTITY_IDS:-[]}
+
+hashingEntityId: ${HASHING_ENTITY_ID:-}
+
+verifyHubConfiguration:
+  environment: ${VERIFY_ENVIRONMENT:-}
+
+samlSigningKey: ${SAML_SIGNING_KEY:-}
+
+samlPrimaryEncryptionKey: ${SAML_PRIMARY_ENCRYPTION_KEY:-}
+
+samlSecondaryEncryptionKey: ${SAML_SECONDARY_ENCRYPTION_KEY:-}
+
+europeanIdentity:
+  enabled: ${EUROPEAN_IDENTITY_ENABLED:-false}
+


### PR DESCRIPTION
…1 for running and building

Create verify-proxy-node-vsp-config directory.  Put custom Dockerfile in that directory along with a custom verify-service-provider.yml.

This can and should be deployed before changes to verify-eidas-pipelines.