### PR TITLE
EID-1502: Use ProxyNodeLogger everywhere

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.security.credential.UsageType;
 import org.opensaml.security.x509.X509Credential;
@@ -27,7 +28,6 @@ import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
 import uk.gov.ida.notification.saml.metadata.Metadata;
 import uk.gov.ida.notification.saml.validation.components.LoaValidator;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
-import uk.gov.ida.notification.shared.ProxyNodeLogger;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
@@ -88,7 +88,7 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
 
         connectorMetadata = new Metadata(connectorMetadataResolverBundle.getMetadataCredentialResolver());
         EidasAuthnRequestValidator eidasAuthnRequestValidator = createEidasAuthnRequestValidator(configuration, connectorMetadataResolverBundle);
-        SamlRequestSignatureValidator samlRequestSignatureValidator = createSamlRequestSignatureValidator(connectorMetadataResolverBundle);
+        SamlRequestSignatureValidator<AuthnRequest> samlRequestSignatureValidator = createSamlRequestSignatureValidator(connectorMetadataResolverBundle);
         String x509EncryptionCert = getX509EncryptionCert(configuration);
 
         environment.jersey().register(IstioHeaderMapperFilter.class);
@@ -102,8 +102,7 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
                         Metadata.getAssertionConsumerServiceLocation(
                                 configuration.getConnectorMetadataConfiguration().getExpectedEntityId(),
                                 connectorMetadataResolverBundle.getMetadataResolver()
-                        ),
-                        new ProxyNodeLogger())
+                        ))
         );
 
         registerMetadataHealthCheck(

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/AssertionConsumerServiceValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/AssertionConsumerServiceValidator.java
@@ -11,14 +11,18 @@ import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+import uk.gov.ida.notification.shared.ProxyNodeLogger;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.logging.Logger;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+import static java.text.MessageFormat.format;
+
 public class AssertionConsumerServiceValidator {
-    private static final Logger LOG = Logger.getLogger(AssertionConsumerServiceValidator.class.getName());
+
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
 
     private final MetadataResolver metadataResolver;
 
@@ -62,7 +66,7 @@ public class AssertionConsumerServiceValidator {
 
             return spssoDescriptor.getAssertionConsumerServices();
         } catch (ResolverException e) {
-            LOG.warning("Unable to resolve metadata for entity " + entityId);
+            LOG.logException(e, Level.WARNING, format("Unable to resolve metadata for entity {0}", entityId));
             return List.of();
         }
     }

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -44,7 +44,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         request = new EidasAuthnRequestBuilder()
                 .withIssuer(TestMetadataResource.CONNECTOR_ENTITY_ID)
                 .withDestination("http://proxy-node/eidasAuthnRequest");
-        samlObjectSigner = new SamlObjectSigner(X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, new ProxyNodeLogger());
+        samlObjectSigner = new SamlObjectSigner(X509CredentialFactory.build(TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     @Test
     public void shouldReturnHTTP400WhenAuthnRequestNotSignedCorrectly() throws Exception {
         AuthnRequest requestWithIncorrectSigningKey = request.build();
-        SamlObjectSigner samlObjectSignerIncorrectSigningKey = new SamlObjectSigner(X509CredentialFactory.build(STUB_COUNTRY_PUBLIC_PRIMARY_CERT, STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, new ProxyNodeLogger());
+        SamlObjectSigner samlObjectSignerIncorrectSigningKey = new SamlObjectSigner(X509CredentialFactory.build(STUB_COUNTRY_PUBLIC_PRIMARY_CERT, STUB_COUNTRY_PUBLIC_PRIMARY_PRIVATE_KEY), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
         samlObjectSignerIncorrectSigningKey.sign(requestWithIncorrectSigningKey, "response-id");
         assertErrorResponseWithMessage(
                 postEidasAuthnRequest(requestWithIncorrectSigningKey),

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -10,8 +10,8 @@ import org.eclipse.jetty.server.session.SessionHandler;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.notification.configuration.RedisServiceConfiguration;
 import uk.gov.ida.notification.exceptions.mappers.ErrorPageExceptionMapper;
-import uk.gov.ida.notification.exceptions.mappers.GenericExceptionMapper;
 import uk.gov.ida.notification.exceptions.mappers.ExceptionToSamlErrorResponseMapper;
+import uk.gov.ida.notification.exceptions.mappers.GenericExceptionMapper;
 import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.proxy.EidasSamlParserProxy;
 import uk.gov.ida.notification.proxy.TranslatorProxy;
@@ -21,7 +21,6 @@ import uk.gov.ida.notification.session.storage.InMemoryStorage;
 import uk.gov.ida.notification.session.storage.RedisStorage;
 import uk.gov.ida.notification.session.storage.SessionStore;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
-import uk.gov.ida.notification.shared.ProxyNodeLogger;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 
@@ -130,8 +129,7 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
                 espProxy,
                 vspProxy,
                 samlFormViewBuilder,
-                sessionStorage,
-                new ProxyNodeLogger()));
+                sessionStorage));
 
         environment.jersey().register(new HubResponseResource(
                 samlFormViewBuilder,

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/BaseExceptionToErrorPageMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/BaseExceptionToErrorPageMapper.java
@@ -37,7 +37,7 @@ public abstract class BaseExceptionToErrorPageMapper<TException extends Exceptio
     public abstract Level getLogLevel(TException exception);
 
     private void logException(TException exception) {
-        proxyNodeLogger.addContext(exception);
-        proxyNodeLogger.log(getLogLevel(exception), format("Error whilst contacting uri [{0}]", this.uriInfo.getPath()));
+        proxyNodeLogger.logException(exception, getLogLevel(exception),
+                format("Error whilst contacting uri [{0}]", this.uriInfo.getPath()));
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
@@ -49,7 +49,8 @@ public class ExceptionToSamlErrorResponseMapper implements ExceptionMapper<Failu
 
     @Override
     public Response toResponse(FailureSamlResponseException exception) {
-        logException(exception);
+        proxyNodeLogger.logException(exception, Level.WARNING,
+                format("Error whilst contacting uri [{0}]", uriInfo.getPath()));
 
         final String sessionId = httpServletRequest.getSession().getId();
         final GatewaySessionData sessionData = getSessionData(sessionId);
@@ -68,12 +69,6 @@ public class ExceptionToSamlErrorResponseMapper implements ExceptionMapper<Failu
                 sessionData.getEidasRelayState());
 
         return Response.ok().entity(samlFormView).build();
-    }
-
-    private void logException(FailureSamlResponseException exception) {
-        proxyNodeLogger.addContext(exception);
-
-        proxyNodeLogger.log(Level.WARNING, format("Error whilst contacting uri [{0}]", uriInfo.getPath()));
     }
 
     private GatewaySessionData getSessionData(String sessionId) {

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -28,29 +28,25 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.net.URI;
 
-import static java.util.logging.Level.INFO;
-
 @Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class EidasAuthnRequestResource {
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
 
     public static final String SUBMIT_BUTTON_TEXT = "Post Verify Authn Request to Hub";
     private final EidasSamlParserProxy eidasSamlParserService;
     private final VerifyServiceProviderProxy vspProxy;
     private final SamlFormViewBuilder samlFormViewBuilder;
     private final SessionStore sessionStorage;
-    private final ProxyNodeLogger proxyNodeLogger;
 
     public EidasAuthnRequestResource(
             EidasSamlParserProxy eidasSamlParserService,
             VerifyServiceProviderProxy vspProxy,
             SamlFormViewBuilder samlFormViewBuilder,
-            SessionStore sessionStorage,
-            ProxyNodeLogger proxyNodeLogger) {
+            SessionStore sessionStorage) {
         this.eidasSamlParserService = eidasSamlParserService;
         this.vspProxy = vspProxy;
         this.samlFormViewBuilder = samlFormViewBuilder;
         this.sessionStorage = sessionStorage;
-        this.proxyNodeLogger = proxyNodeLogger;
     }
 
 
@@ -90,13 +86,14 @@ public class EidasAuthnRequestResource {
                 eidasSamlParserResponse.getConnectorEncryptionPublicCertificate(),
                 10
         );
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, eidasSamlParserResponse.getIssuer());
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.CONNECTOR_PUBLIC_ENC_CERT_SUFFIX, connectorEncryptonPublicCerrt);
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.HUB_REQUEST_ID, vspResponse.getRequestId());
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.HUB_URL, vspResponse.getSsoLocation().toString());
-        proxyNodeLogger.log(INFO, "Authn requests received from ESP and VSP");
+
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, eidasSamlParserResponse.getIssuer());
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
+        LOG.addContext(ProxyNodeMDCKey.CONNECTOR_PUBLIC_ENC_CERT_SUFFIX, connectorEncryptonPublicCerrt);
+        LOG.addContext(ProxyNodeMDCKey.HUB_REQUEST_ID, vspResponse.getRequestId());
+        LOG.addContext(ProxyNodeMDCKey.HUB_URL, vspResponse.getSsoLocation().toString());
+        LOG.info("Authn requests received from ESP and VSP");
 
         return buildSamlFormView(vspResponse, eidasRelayState);
     }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestExceptionMapperResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestExceptionMapperResource.java
@@ -23,9 +23,9 @@ import java.util.UUID;
 @Path("/")
 public class TestExceptionMapperResource {
 
-    public final static String SESSION_ID = "aSessionId";
-    public final static String HUB_REQUEST_ID = "aHubRequestId";
-    public final static String EIDAS_REQUEST_ID = "anEidasRequestId";
+    public static final String SESSION_ID = "aSessionId";
+    public static final String HUB_REQUEST_ID = "aHubRequestId";
+    public static final String EIDAS_REQUEST_ID = "anEidasRequestId";
 
     @GET
     @Path("/SessionAlreadyExistsException")

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
@@ -1,6 +1,9 @@
 package uk.gov.ida.notification.resources;
 
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.dropwizard.logging.LoggingUtil;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -9,6 +12,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
 import uk.gov.ida.notification.SamlFormViewBuilder;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
@@ -23,8 +27,9 @@ import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 import javax.servlet.http.HttpSession;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.logging.Level;
 
-import static java.util.logging.Level.INFO;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,7 +68,7 @@ public class EidasAuthnRequestResourceTest {
     private AuthnRequestResponse vspResponse;
 
     @Mock
-    private ProxyNodeLogger proxyNodeLogger;
+    private Appender<ILoggingEvent> appender;
 
     @Captor
     private ArgumentCaptor<ILoggingEvent> captorILoggingEvent;
@@ -73,6 +78,8 @@ public class EidasAuthnRequestResourceTest {
 
     @Captor
     private ArgumentCaptor<GatewaySessionData> captorGatewaySessionData;
+
+    private Logger logger = (Logger) LoggerFactory.getLogger(ProxyNodeLogger.class);
 
     @Test
     public void testHappyPathRedirect() throws URISyntaxException {
@@ -89,6 +96,9 @@ public class EidasAuthnRequestResourceTest {
     }
 
     private void setupHappyPath() throws URISyntaxException {
+        LoggingUtil.hijackJDKLogging();
+        logger.addAppender(appender);
+
         when(eidasSamlParserService.parse(any(EidasSamlParserRequest.class), any(String.class))).thenReturn(eidasSamlParserResponse);
         when(vspProxy.generateAuthnRequest(any(String.class))).thenReturn(vspResponse);
         when(eidasSamlParserResponse.getConnectorEncryptionPublicCertificate()).thenReturn(UNCHAINED_PUBLIC_CERT);
@@ -106,20 +116,26 @@ public class EidasAuthnRequestResourceTest {
 
         verify(sessionStore).createOrUpdateSession(eq(sessionId), any(GatewaySessionData.class));
         verify(session).getId();
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, "eidas request id");
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.EIDAS_ISSUER, "issuer");
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, "destination");
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.CONNECTOR_PUBLIC_ENC_CERT_SUFFIX, StringUtils.right(UNCHAINED_PUBLIC_CERT, 10));
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.HUB_REQUEST_ID, "hub request id");
-        verify(proxyNodeLogger).addContext(ProxyNodeMDCKey.HUB_URL, "http://hub.bub");
-        verify(proxyNodeLogger).log(INFO, "Authn requests received from ESP and VSP");
+
+        verify(appender).doAppend(captorILoggingEvent.capture());
+        final ILoggingEvent logEvent = captorILoggingEvent.getValue();
+        final Map<String, String> mdc = logEvent.getMDCPropertyMap();
+
+        assertThat(mdc.get(ProxyNodeMDCKey.EIDAS_REQUEST_ID.name())).isEqualTo("eidas request id");
+        assertThat(mdc.get(ProxyNodeMDCKey.EIDAS_ISSUER.name())).isEqualTo("issuer");
+        assertThat(mdc.get(ProxyNodeMDCKey.EIDAS_DESTINATION.name())).isEqualTo("destination");
+        assertThat(mdc.get(ProxyNodeMDCKey.CONNECTOR_PUBLIC_ENC_CERT_SUFFIX.name())).isEqualTo(StringUtils.right(UNCHAINED_PUBLIC_CERT, 10));
+        assertThat(mdc.get(ProxyNodeMDCKey.HUB_REQUEST_ID.name())).isEqualTo("hub request id");
+        assertThat(mdc.get(ProxyNodeMDCKey.HUB_URL.name())).isEqualTo("http://hub.bub");
+        assertThat(logEvent.getLevel().toString()).isEqualTo(Level.INFO.toString());
+        assertThat(logEvent.getMessage()).isEqualTo("Authn requests received from ESP and VSP");
+
         verify(eidasSamlParserService).parse(captorEidasSamlParserRequest.capture(), any(String.class));
         verify(vspProxy).generateAuthnRequest(any(String.class));
         verify(samlFormViewBuilder).buildRequest("http://hub.bub", "hub blob", SUBMIT_BUTTON_TEXT, "eidas relay state");
-        verifyNoMoreInteractions(vspProxy, eidasSamlParserService, proxyNodeLogger, samlFormViewBuilder, session);
+        verifyNoMoreInteractions(vspProxy, eidasSamlParserService, appender, samlFormViewBuilder, session);
         verifyNoMoreInteractions(sessionStore);
 
         assertThat(captorEidasSamlParserRequest.getValue().getAuthnRequest()).isEqualTo("eidas blob");
-
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HubResponseResourceTest {
+
     @Mock
     TranslatorProxy translatorProxy;
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/CloudHsmCredentialConfiguration.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/CloudHsmCredentialConfiguration.java
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.xml.security.algorithms.JCEMapper;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Support;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
+import uk.gov.ida.notification.shared.ProxyNodeLogger;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;
@@ -16,33 +15,35 @@ import java.security.Provider;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 
+import static java.text.MessageFormat.format;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CloudHsmCredentialConfiguration extends CredentialConfiguration {
     public static final String ID = "CloudHsmCredentialConfiguration";
-    private static final Logger LOG = LoggerFactory.getLogger(CloudHsmCredentialConfiguration.class);
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
 
     @JsonCreator
     public CloudHsmCredentialConfiguration(
-        @JsonProperty("publicKey") DeserializablePublicKeyConfiguration publicKey,
-        @JsonProperty("hsmKeyLabel") String hsmKeyLabel
+            @JsonProperty("publicKey") DeserializablePublicKeyConfiguration publicKey,
+            @JsonProperty("hsmKeyLabel") String hsmKeyLabel
     ) throws CredentialConfigurationException {
         try {
-            LOG.info(String.format("Using CloudHsmCredentialConfiguration to sign eIDAS responses with HSM Key Label %s", hsmKeyLabel));
+            LOG.info(format("Using CloudHsmCredentialConfiguration to sign eIDAS responses with HSM Key Label {0}", hsmKeyLabel));
             X509Certificate certificate = X509Support.decodeCertificate(publicKey.getCert().getBytes());
             Provider caviumProvider = (Provider) ClassLoader.getSystemClassLoader()
-                .loadClass("com.cavium.provider.CaviumProvider")
-                .getConstructor()
-                .newInstance();
+                    .loadClass("com.cavium.provider.CaviumProvider")
+                    .getConstructor()
+                    .newInstance();
             Security.addProvider(caviumProvider);
             JCEMapper.setProviderId("Cavium");
             KeyStore cloudHsmStore = KeyStore.getInstance("Cavium");
             cloudHsmStore.load(null, null);
             BasicX509Credential credential = new BasicX509Credential(
-                certificate,
-                (PrivateKey) cloudHsmStore.getKey(hsmKeyLabel, null));
+                    certificate,
+                    (PrivateKey) cloudHsmStore.getKey(hsmKeyLabel, null));
             credential.setEntityId(ID);
             setCredential(credential);
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new CredentialConfigurationException(e);
         }
     }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/KeyFileCredentialConfiguration.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/configuration/KeyFileCredentialConfiguration.java
@@ -5,17 +5,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Support;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.PrivateKeyConfiguration;
+import uk.gov.ida.notification.shared.ProxyNodeLogger;
 
 import java.security.cert.X509Certificate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KeyFileCredentialConfiguration extends CredentialConfiguration {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KeyFileCredentialConfiguration.class);
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
 
     @JsonCreator
     public KeyFileCredentialConfiguration(

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
@@ -6,21 +6,21 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.encryption.support.DecryptionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.notification.configuration.CloudHsmCredentialConfiguration;
+import uk.gov.ida.notification.shared.ProxyNodeLogger;
 import uk.gov.ida.saml.security.DecrypterFactory;
 
 import java.util.Collections;
 
 public class ResponseAssertionDecrypter {
-    private final Logger log = LoggerFactory.getLogger(this.getClass().getName());
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
+
     private final Decrypter decrypter;
 
     public ResponseAssertionDecrypter(Credential credential) {
         this.decrypter = new DecrypterFactory().createDecrypter(Collections.singletonList(credential));
         if (credential.getEntityId() != null && credential.getEntityId().equals(CloudHsmCredentialConfiguration.ID)) {
-            log.info("Using CloudHSM so set JCA provider to Cavium");
+            LOG.info("Using CloudHSM so set JCA provider to Cavium");
             this.decrypter.setJCAProviderName("Cavium");
         }
     }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlObjectSigner.java
@@ -9,19 +9,15 @@ import org.opensaml.xmlsec.SignatureSigningParameters;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.ida.notification.shared.ProxyNodeLogger;
 import uk.gov.ida.notification.shared.ProxyNodeMDCKey;
 
-import java.util.logging.Level;
-
 public class SamlObjectSigner {
-    private final SignatureSigningParameters signingParams;
-    private ProxyNodeLogger proxyNodeLogger;
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
 
-    public SamlObjectSigner(BasicX509Credential signingCredential, String signingAlgorithm, ProxyNodeLogger proxyNodeLogger) {
-        this.proxyNodeLogger = proxyNodeLogger;
+    private final SignatureSigningParameters signingParams;
+
+    public SamlObjectSigner(BasicX509Credential signingCredential, String signingAlgorithm) {
         signingParams = SignatureSigningParametersHelper.build(signingCredential, signingAlgorithm);
     }
 
@@ -38,8 +34,8 @@ public class SamlObjectSigner {
     }
 
     private  void logSigningRequest(String responseId, String signingProvider) {
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, responseId);
-        proxyNodeLogger.addContext(ProxyNodeMDCKey.SIGNING_PROVIDER, signingProvider);
-        proxyNodeLogger.log(Level.INFO, "Signing eIDAS response");
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, responseId);
+        LOG.addContext(ProxyNodeMDCKey.SIGNING_PROVIDER, signingProvider);
+        LOG.info("Signing eIDAS response");
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SamlSignatureValidatorFactory.java
@@ -1,11 +1,10 @@
 package uk.gov.ida.notification.saml;
 
-import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
 import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.keyinfo.KeyInfoCredentialResolver;
 import org.opensaml.xmlsec.signature.support.impl.ExplicitKeySignatureTrustEngine;
-import uk.gov.ida.notification.saml.metadata.MetadataCredentialResolverInitializer;
 import uk.gov.ida.saml.metadata.bundle.MetadataResolverBundle;
 import uk.gov.ida.saml.security.MetadataBackedSignatureValidator;
 import uk.gov.ida.saml.security.SamlMessageSignatureValidator;
@@ -13,17 +12,16 @@ import uk.gov.ida.saml.security.validators.signature.SamlRequestSignatureValidat
 
 public class SamlSignatureValidatorFactory {
 
+    public static SamlRequestSignatureValidator<AuthnRequest> createSamlRequestSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
+        SamlMessageSignatureValidator samlMessageSignatureValidator = createSamlMessageSignatureValidator(metadataResolverBundle);
+        return new SamlRequestSignatureValidator<>(samlMessageSignatureValidator);
+    }
 
-    public static SamlMessageSignatureValidator createSamlMessageSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
+    private static SamlMessageSignatureValidator createSamlMessageSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
         MetadataCredentialResolver metadataCredentialResolver = metadataResolverBundle.getMetadataCredentialResolver();
         KeyInfoCredentialResolver keyInfoCredentialResolver = DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver();
         ExplicitKeySignatureTrustEngine explicitKeySignatureTrustEngine = new ExplicitKeySignatureTrustEngine(metadataCredentialResolver, keyInfoCredentialResolver);
         MetadataBackedSignatureValidator metadataBackedSignatureValidator = MetadataBackedSignatureValidator.withoutCertificateChainValidation(explicitKeySignatureTrustEngine);
         return new SamlMessageSignatureValidator(metadataBackedSignatureValidator);
-    }
-
-    public static SamlRequestSignatureValidator createSamlRequestSignatureValidator(MetadataResolverBundle metadataResolverBundle) {
-        SamlMessageSignatureValidator samlMessageSignatureValidator = createSamlMessageSignatureValidator(metadataResolverBundle);
-        return new SamlRequestSignatureValidator(samlMessageSignatureValidator);
     }
 }

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/SamlObjectSignerTest.java
@@ -9,7 +9,6 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureValidator;
 import uk.gov.ida.notification.SamlInitializedTest;
 import uk.gov.ida.notification.helpers.TestKeyPair;
-import uk.gov.ida.notification.shared.ProxyNodeLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,7 +23,7 @@ public class SamlObjectSignerTest extends SamlInitializedTest {
     @Test
     public void shouldSignAuthRequest() throws Throwable {
         BasicX509Credential signingCredential = testKeyPair.getX509Credential();
-        SamlObjectSigner samlObjectSigner = new SamlObjectSigner(signingCredential, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, new ProxyNodeLogger());
+        SamlObjectSigner samlObjectSigner = new SamlObjectSigner(signingCredential, SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
         AuthnRequest authnRequest = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
         samlObjectSigner.sign(authnRequest, "response-id");
         Signature signature = authnRequest.getSignature();

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/ProxyNodeLoggerTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/ProxyNodeLoggerTest.java
@@ -1,26 +1,103 @@
 package uk.gov.ida.notification.shared;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.dropwizard.logging.LoggingUtil;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Spy;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
 
-import java.util.logging.Level;
+import java.util.Map;
 
-import static org.mockito.AdditionalMatchers.not;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProxyNodeLoggerTest {
 
-    @Spy
+    @Mock
+    private Appender<ILoggingEvent> appender;
+
+    @Captor
+    private ArgumentCaptor<ILoggingEvent> loggingEventCaptor;
+
     private ProxyNodeLogger proxyNodeLogger = new ProxyNodeLogger();
+
+    private final Logger logger = (Logger) LoggerFactory.getLogger(ProxyNodeLogger.class);
+
+    @Before
+    public void setUp() {
+        LoggingUtil.hijackJDKLogging();
+        logger.addAppender(appender);
+    }
 
     @Test
     public void shouldNotLogProxyNodeLoggerAsTheLogLocation() {
-        proxyNodeLogger.log(Level.INFO, "stop your messing around");
-        verify(proxyNodeLogger).addContext(eq(ProxyNodeMDCKey.LOG_LOCATION), not(contains(ProxyNodeLogger.class.getName())));
+        proxyNodeLogger.info("test");
+
+        verify(appender).doAppend(loggingEventCaptor.capture());
+
+        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
+        assertThat(logEvent.getMDCPropertyMap().get(ProxyNodeMDCKey.LOG_LOCATION.name())).doesNotContain(ProxyNodeLogger.class.getName());
+        assertThat(logEvent.getMDCPropertyMap().get(ProxyNodeMDCKey.LOG_LOCATION.name())).contains("junit.runners");
+    }
+
+    @Test
+    public void shouldAddExceptionContext() {
+        Exception cause = new Exception("cause-message");
+        Exception exception = new Exception("exception-message", cause);
+
+        proxyNodeLogger.logException(exception, java.util.logging.Level.SEVERE, "log-message");
+
+        verify(appender).doAppend(loggingEventCaptor.capture());
+
+        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
+        assertThat(logEvent.getLevel()).isEqualTo(Level.ERROR);
+        assertThat(logEvent.getMessage()).isEqualTo("log-message");
+
+        final Map<String, String> mdc = logEvent.getMDCPropertyMap();
+        assertThat(mdc.get(ProxyNodeMDCKey.EXCEPTION_CAUSE.name())).isEqualTo("cause-message");
+        assertThat(mdc.get(ProxyNodeMDCKey.EXCEPTION_MESSAGE.name())).isEqualTo("exception-message");
+        assertThat(mdc.get(ProxyNodeMDCKey.EXCEPTION_STACKTRACE.name())).contains("java.lang.Exception: exception-message");
+    }
+
+    @Test
+    public void shouldLogCorrectlyWithInfoLevel() {
+        proxyNodeLogger.info("test-info");
+
+        verify(appender).doAppend(loggingEventCaptor.capture());
+
+        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
+        assertThat(logEvent.getMessage()).isEqualTo("test-info");
+        assertThat(logEvent.getLevel().toString()).isEqualTo(Level.INFO.toString());
+    }
+
+    @Test
+    public void shouldLogCorrectlyWithWarningLevel() {
+        proxyNodeLogger.warning("test-warn");
+
+        verify(appender).doAppend(loggingEventCaptor.capture());
+
+        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
+        assertThat(logEvent.getMessage()).isEqualTo("test-warn");
+        assertThat(logEvent.getLevel().toString()).isEqualTo(Level.WARN.toString());
+    }
+
+    @Test
+    public void shouldLogCorrectlyWithErrorLevel() {
+        proxyNodeLogger.error("test-error");
+
+        verify(appender).doAppend(loggingEventCaptor.capture());
+
+        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
+        assertThat(logEvent.getMessage()).isEqualTo("test-error");
+        assertThat(logEvent.getLevel().toString()).isEqualTo(Level.ERROR.toString());
     }
 }

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetadataResource.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetadataResource.java
@@ -24,8 +24,9 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SI
 
 @Path("/")
 public class TestMetadataResource {
-    public final static String CONNECTOR_ENTITY_ID = "http://connector-node/Metadata";
-    public final static String PROXY_NODE_ENTITY_ID = "http://proxy-node/Metadata";
+    public static final String CONNECTOR_ENTITY_ID = "http://connector-node/Metadata";
+    public static final String PROXY_NODE_ENTITY_ID = "http://proxy-node/Metadata";
+
     private String connectorMetadataXml;
     private String proxyNodeMetadataXml;
     private String hubMetadata;

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -18,7 +18,6 @@ import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
-import uk.gov.ida.notification.shared.ProxyNodeLogger;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 import uk.gov.ida.notification.translator.configuration.TranslatorConfiguration;
@@ -93,7 +92,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     private void registerResources(TranslatorConfiguration configuration, Environment environment) {
         final EidasResponseGenerator eidasResponseGenerator = createEidasResponseGenerator(configuration);
         final VerifyServiceProviderProxy vspProxy = configuration.getVspConfiguration().buildVerifyServiceProviderProxy(environment);
-        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy, new ProxyNodeLogger());
+        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy);
 
         environment.jersey().register(hubResponseTranslatorResource);
     }
@@ -112,7 +111,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
         );
 
         final CredentialConfiguration credentialConfiguration = configuration.getCredentialConfiguration();
-        final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(credentialConfiguration.getCredential(), credentialConfiguration.getAlgorithm(), new ProxyNodeLogger());
+        final SamlObjectSigner samlObjectSigner = new SamlObjectSigner(credentialConfiguration.getCredential(), credentialConfiguration.getAlgorithm());
 
         return new EidasResponseGenerator(hubResponseTranslator, failureResponseGenerator, samlObjectSigner);
     }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -29,19 +29,17 @@ import static uk.gov.ida.notification.translator.logging.HubResponseAttributesHa
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class HubResponseTranslatorResource {
-
+    private static final ProxyNodeLogger LOG = new ProxyNodeLogger();
     private static final SamlObjectMarshaller MARSHALLER = new SamlObjectMarshaller();
     private static final X509CertificateFactory X_509_CERTIFICATE_FACTORY = new X509CertificateFactory();
-    public static final String EIDAS_RESPONSE_LOGGER_MESSAGE = "eIDAS Response Attributes";
 
     private final EidasResponseGenerator eidasResponseGenerator;
     private final VerifyServiceProviderProxy verifyServiceProviderProxy;
-    private ProxyNodeLogger proxyNodeLogger;
 
-    public HubResponseTranslatorResource(EidasResponseGenerator eidasResponseGenerator, VerifyServiceProviderProxy verifyServiceProviderProxy, ProxyNodeLogger proxyNodeLogger) {
+    public HubResponseTranslatorResource(EidasResponseGenerator eidasResponseGenerator,
+                                         VerifyServiceProviderProxy verifyServiceProviderProxy) {
         this.eidasResponseGenerator = eidasResponseGenerator;
         this.verifyServiceProviderProxy = verifyServiceProviderProxy;
-        this.proxyNodeLogger = proxyNodeLogger;
     }
 
     @POST
@@ -88,11 +86,12 @@ public class HubResponseTranslatorResource {
         return Response.ok().entity(samlMessage).build();
     }
 
+    // TODO: Remove once we set all the headers correctly
     private void logSamlResponse(org.opensaml.saml.saml2.core.Response samlResponse) {
-            proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, Objects.requireNonNullElse(samlResponse.getInResponseTo(), ""));
-            proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, Objects.requireNonNullElse(samlResponse.getDestination(), ""));
-            proxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, samlResponse.getIssuer() != null ? samlResponse.getIssuer().getValue() : "");
-            proxyNodeLogger.log(Level.INFO, EIDAS_RESPONSE_LOGGER_MESSAGE);
-
-        }
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, Objects.requireNonNullElse(samlResponse.getInResponseTo(), ""));
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, Objects.requireNonNullElse(samlResponse.getDestination(), ""));
+        LOG.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, samlResponse.getIssuer() != null ? samlResponse.getIssuer().getValue() : "");
+        LOG.info("Received eIDAS Response Attributes from VSP");
     }
+}
+

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -3,7 +3,6 @@ package uk.gov.ida.notification.translator.apprule;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.assertj.core.api.Assertions;
 import org.glassfish.jersey.internal.util.Base64;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +49,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.verify;
-import static uk.gov.ida.notification.translator.resources.HubResponseTranslatorResource.EIDAS_RESPONSE_LOGGER_MESSAGE;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PRIVATE_SIGNING_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_ENCRYPTION_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.HUB_TEST_PUBLIC_SIGNING_CERT;
@@ -62,11 +60,11 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_IDP_PUBLIC_P
 @RunWith(MockitoJUnitRunner.class)
 public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase {
 
+    private static final String EIDAS_RESPONSE_LOGGER_MESSAGE = "Received eIDAS Response Attributes from VSP";
     private static final String PROXY_NODE_ENTITY_ID = "http://proxy-node.uk";
     private static final String EIDAS_TEST_CONNECTOR_DESTINATION = "http://proxy-node/SAML2/SSO/Response";
     private static final SamlObjectMarshaller MARSHALLER = new SamlObjectMarshaller();
     private static final X509CertificateFactory X_509_CERTIFICATE_FACTORY = new X509CertificateFactory();
-
     private static final String publicBuild = System.getenv("VERIFY_USE_PUBLIC_BINARIES");
 
     private BasicCredential hubSigningCredential;
@@ -181,10 +179,10 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
         ILoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
         Map<String, String> mdcPropertyMap = loggingEvent.getMDCPropertyMap();
 
-        Assertions.assertThat(loggingEvent.getMessage()).contains(EIDAS_RESPONSE_LOGGER_MESSAGE);
-        Assertions.assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_DESTINATION.name())).isEqualTo(EIDAS_TEST_CONNECTOR_DESTINATION);
-        Assertions.assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_REQUEST_ID.name())).isEqualTo(ResponseBuilder.DEFAULT_REQUEST_ID);
-        Assertions.assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_ISSUER.name())).isEqualTo(eidasResponse.getIssuer().getValue());
+        assertThat(loggingEvent.getMessage()).contains(EIDAS_RESPONSE_LOGGER_MESSAGE);
+        assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_DESTINATION.name())).isEqualTo(EIDAS_TEST_CONNECTOR_DESTINATION);
+        assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_REQUEST_ID.name())).isEqualTo(ResponseBuilder.DEFAULT_REQUEST_ID);
+        assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.EIDAS_ISSUER.name())).isEqualTo(eidasResponse.getIssuer().getValue());
     }
 
     @Test
@@ -200,12 +198,13 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
         if (!"true".equals(publicBuild)) {
             // Proxy Node logs in json format
             String consoleOutoutString = consoleOutput.toString();
-            Assertions.assertThat(consoleOutoutString).contains(EIDAS_RESPONSE_LOGGER_MESSAGE,
+            assertThat(consoleOutoutString).contains(EIDAS_RESPONSE_LOGGER_MESSAGE,
                     String.format("\"%s\":\"%s\"", ProxyNodeMDCKey.EIDAS_DESTINATION.name(), EIDAS_TEST_CONNECTOR_DESTINATION),
                     String.format("\"%s\":\"%s\"", ProxyNodeMDCKey.EIDAS_REQUEST_ID.name(), ResponseBuilder.DEFAULT_REQUEST_ID),
                     String.format("\"%s\":\"%s\"", ProxyNodeMDCKey.EIDAS_ISSUER.name(), eidasResponse.getIssuer().getValue())
             );
         }
+
         System.setOut(defaultConsolePrintStream);
     }
 

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -18,9 +18,7 @@ import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.notification.saml.SamlObjectMarshaller;
 import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.saml.SamlParser;
-import uk.gov.ida.notification.shared.ProxyNodeLogger;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -68,7 +66,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
     }
 
 
-    private String getAuthnRequestIdFromSession() throws URISyntaxException, IOException, ParserConfigurationException {
+    private String getAuthnRequestIdFromSession() throws URISyntaxException, IOException {
         String html = getEidasRequest();
         String decodedSaml = HtmlHelpers.getValueFromForm(html, "SAMLRequest");
         AuthnRequest request = new SamlParser().parseSamlString(decodedSaml);
@@ -77,7 +75,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
 
     private void hasValidity(String samlMessage, String validity) throws URISyntaxException {
         String html = postEidasResponse(samlMessage);
-        assertThat(html).contains("Saml Validity: "+validity);
+        assertThat(html).contains("Saml Validity: " + validity);
     }
 
     private Response getEidasSamlMessage(String authid) {
@@ -110,9 +108,8 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
 
     private Response signResponse(Response response) throws Exception {
         SamlObjectSigner signer = new SamlObjectSigner(X509CredentialFactory.build(
-                    TEST_RP_PUBLIC_SIGNING_CERT,
-                    TEST_RP_PRIVATE_SIGNING_KEY
-                ), SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, new ProxyNodeLogger());
+                TEST_RP_PUBLIC_SIGNING_CERT, TEST_RP_PRIVATE_SIGNING_KEY),
+                SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
 
         signer.sign(response, "response-id");
 


### PR DESCRIPTION
Make logging more consistent by always using the same logger

Summary of changes:
  - Changes to the ProxyNodeLogger to make it easier and more consistent to use
  - Replace all instances of `java.util.logging` and `SLF4J` loggers with the new ProxyNodeLogger
  - Remove `ProxyNodeLogger` from all constructors as it can be easily instantiated within any class
  - Test MDC params by capturing the log event and extracting the MDC param map