### PR TITLE
EID-1506 Use ProxyNode Journey ID for the relay-state when sending requests to the hub

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -55,7 +55,7 @@ public class EidasAuthnRequestResource {
             @QueryParam(SamlFormMessageType.SAML_REQUEST) String encodedEidasAuthnRequest,
             @QueryParam("RelayState") String relayState,
             @Session HttpSession session) {
-        return handleAuthnRequest(encodedEidasAuthnRequest, relayState, session.getId());
+        return handleAuthnRequest(encodedEidasAuthnRequest, relayState, session);
     }
 
     @POST
@@ -65,10 +65,11 @@ public class EidasAuthnRequestResource {
             @FormParam(SamlFormMessageType.SAML_REQUEST) String encodedEidasAuthnRequest,
             @FormParam(RelayState.DEFAULT_ELEMENT_LOCAL_NAME) String eidasRelayState,
             @Session HttpSession session) {
-        return handleAuthnRequest(encodedEidasAuthnRequest, eidasRelayState, session.getId());
+        return handleAuthnRequest(encodedEidasAuthnRequest, eidasRelayState, session);
     }
 
-    private View handleAuthnRequest(String encodedEidasAuthnRequest, String eidasRelayState, String sessionId) {
+    private View handleAuthnRequest(String encodedEidasAuthnRequest, String eidasRelayState, HttpSession session) {
+        final String sessionId = session.getId();
         final EidasSamlParserResponse eidasSamlParserResponse = parseEidasRequest(encodedEidasAuthnRequest, sessionId);
         final AuthnRequestResponse vspResponse = generateHubRequestWithVsp(sessionId);
 
@@ -94,7 +95,7 @@ public class EidasAuthnRequestResource {
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.HUB_URL, vspResponse.getSsoLocation().toString());
         ProxyNodeLogger.info("Authn requests received from ESP and VSP");
 
-        return buildSamlFormView(vspResponse, eidasRelayState);
+        return buildSamlFormView(vspResponse, (String) session.getAttribute(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name()));
     }
 
     private EidasSamlParserResponse parseEidasRequest(String encodedEidasAuthnRequest, String sessionId) {

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/EidasAuthnRequestAppRuleTests.java
@@ -18,6 +18,7 @@ import uk.gov.ida.notification.apprule.rules.TestTranslatorResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderResource;
 import uk.gov.ida.notification.apprule.rules.TestVerifyServiceProviderServerErrorResource;
 import uk.gov.ida.notification.helpers.HtmlHelpers;
+import uk.gov.ida.notification.shared.ProxyNodeMDCKey;
 
 import javax.ws.rs.core.Response;
 import javax.xml.parsers.ParserConfigurationException;
@@ -124,7 +125,9 @@ public class EidasAuthnRequestAppRuleTests extends GatewayAppRuleTestBase {
         );
         HtmlHelpers.assertXPath(
                 htmlString,
-                "//form[@action='http://www.hub.com']/input[@name='RelayState'][@value='relay-state']"
+                String.format("//form[@action='http://www.hub.com']/input[@name='RelayState'][@value='%s']",
+                              response.getHeaders().getFirst(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name())
+                              )
         );
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
@@ -109,6 +109,7 @@ public class EidasAuthnRequestResourceTest {
         when(vspResponse.getSsoLocation()).thenReturn(new URI("http://hub.bub"));
         when(vspResponse.getSamlRequest()).thenReturn("hub blob");
         when(session.getId()).thenReturn("some session id");
+        when(session.getAttribute(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name())).thenReturn("journey id");
     }
 
     private void verifyHappyPath() {
@@ -132,7 +133,8 @@ public class EidasAuthnRequestResourceTest {
 
         verify(eidasSamlParserService).parse(captorEidasSamlParserRequest.capture(), any(String.class));
         verify(vspProxy).generateAuthnRequest(any(String.class));
-        verify(samlFormViewBuilder).buildRequest("http://hub.bub", "hub blob", SUBMIT_BUTTON_TEXT, "eidas relay state");
+        verify(samlFormViewBuilder).buildRequest("http://hub.bub", "hub blob", SUBMIT_BUTTON_TEXT, "journey id");
+        verify(session).getAttribute(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name());
         verifyNoMoreInteractions(vspProxy, eidasSamlParserService, appender, samlFormViewBuilder, session);
         verifyNoMoreInteractions(sessionStore);
 


### PR DESCRIPTION
Use the ProxyNode Journey ID for the relay-state when sending request to the hub.  This will help us track journeys across microservice boundaries.

Get the ProxyNode Journey ID from the http session when handling authn requests and put it in the relay-state of the saml form that sends the request to the hub.

Update tests accordingly.

Co-authored by: Karol Gancarz <karol.gancarz@digital.cabinet-office.gov.uk>