### PR TITLE
Acceptance tests for EID-1517

### DIFF
--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -27,3 +27,27 @@ Feature: proxy-node feature
     Scenario: Show error page if route is not accessible
         Given the user accesses the gateway response url directly
         Then the user should be presented with an error page
+
+    Scenario: Show IDP error page if No Authn Context Event
+        Given the proxy node is sent a LOA 'Substantial' request
+        And they progress through verify
+        And they login to stub idp with error event 'No Authn Context Event'
+        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+
+    Scenario: Show IDP error page if Authn Failure Event
+        Given the proxy node is sent a LOA 'Substantial' request
+        And they progress through verify
+        And they login to stub idp with error event 'Authn Failure'
+        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+
+    Scenario: Show IDP error page if Submit Requester Error Event
+        Given the proxy node is sent a LOA 'Substantial' request
+        And they progress through verify
+        And they login to stub idp with error event 'Submit Requester Error'
+        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+
+    Scenario: Show IDP error page if Submit Fraud Event
+        Given the proxy node is sent a LOA 'Substantial' request
+        And they progress through verify
+        And they login to stub idp with error event 'Submit Fraud Event'
+        Then the user should be presented with a Hub error page indicating IDP could not sign you in

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -33,6 +33,12 @@ Given('they login to stub idp') do
   click_on('I Agree')
 end
 
+Given('they login to stub idp with error event {string}') do |error_button_text|
+  fill_in('username', with: ENV.fetch('STUB_IDP_USER'))
+  fill_in('password', with: 'bar')
+  click_on(error_button_text)
+end
+
 Given("the user accesses a invalid page") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/asdfasdfasfsaf')
 end
@@ -48,7 +54,7 @@ Then('they should arrive at the success page') do
   assert_text('1984-02-29')
 end
 
-Then("the user should be presented with an hub error page") do
+Then("the user should be presented with a Hub error page indicating IDP could not sign you in") do
   assert_text('Stub Idp Demo One couldn’t sign you in')
   assert_text('You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.')
 end

--- a/proxy-node-acceptance-tests/run-staging-tests.sh
+++ b/proxy-node-acceptance-tests/run-staging-tests.sh
@@ -4,8 +4,8 @@ set -eu
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-export PROXY_NODE_URL="https://test-proxy-node.staging.verify.govsvc.uk"
-export STUB_CONNECTOR_URL="https://test-connector.staging.verify.govsvc.uk"
+export PROXY_NODE_URL="https://test-proxy-node.london.verify.govsvc.uk"
+export STUB_CONNECTOR_URL="https://test-connector.london.verify.govsvc.uk"
 export STUB_IDP_USER="stub-idp-demo-one"
 docker-compose up --abort-on-container-exit | grep acceptance-tests_1 --colour=never
 docker cp $(docker ps -a -q -f name="acceptance-tests"):/testreport .


### PR DESCRIPTION
New Acceptance tests for Proxy Node journeys, to show the correct error pages based on [this Hub PR](https://github.com/alphagov/verify-hub/pull/294)