### PR TITLE
🙈Temporarily log istio tracing headers

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilter.java
@@ -5,6 +5,9 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static uk.gov.ida.notification.shared.IstioHeaders.ISTIO_HEADERS;
 
@@ -14,11 +17,17 @@ public class IstioHeaderMapperFilter implements ContainerResponseFilter {
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         MultivaluedMap<String, String> incomingHeaders = requestContext.getHeaders();
-
-        for (String istioHeader : ISTIO_HEADERS) {
+        List<String> valuesToLog = new ArrayList<>();
+        for (String istioHeader : ISTIO_HEADERS)
             if (incomingHeaders.containsKey(istioHeader)) {
-                responseContext.getHeaders().add(istioHeader, incomingHeaders.getFirst(istioHeader));
+                MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
+                List<String> headerValues = incomingHeaders.get(istioHeader);
+                if (headerValues != null) {
+                    headerValues.stream().forEach(v -> responseHeaders.add(istioHeader, v));
+                    valuesToLog.add(String.format("%s=%s", istioHeader, headerValues));
+                }
             }
-        }
+        // TODO remove once istio tracing works
+        ProxyNodeLogger.info("Istio headers: " + valuesToLog.stream().collect(Collectors.joining("|")));
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/ProxyNodeLoggingFilter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/ProxyNodeLoggingFilter.java
@@ -16,6 +16,8 @@ import static uk.gov.ida.notification.shared.IstioHeaders.X_B3_TRACEID;
 public class ProxyNodeLoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     public static final String JOURNEY_ID_KEY = ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name();
+    public static final String MESSAGE_INGRESS = "Ingress";
+    public static final String MESSAGE_EGRESS = "Egress";
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
@@ -28,7 +30,7 @@ public class ProxyNodeLoggingFilter implements ContainerRequestFilter, Container
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.REFERER, requestContext.getHeaderString(HttpHeaders.REFERER));
         Optional.ofNullable(requestContext.getUriInfo()).ifPresent(u -> ProxyNodeLogger.addContext(ProxyNodeMDCKey.RESOURCE_PATH, u.getAbsolutePath().toString()));
         Optional.ofNullable(requestContext.getMediaType()).ifPresent(m -> ProxyNodeLogger.addContext(ProxyNodeMDCKey.INGRESS_MEDIA_TYPE, m.toString()));
-        ProxyNodeLogger.info("Ingress");
+        ProxyNodeLogger.info(MESSAGE_INGRESS);
 
         MDC.remove(ProxyNodeMDCKey.INGRESS_MEDIA_TYPE.name());
     }
@@ -38,7 +40,7 @@ public class ProxyNodeLoggingFilter implements ContainerRequestFilter, Container
         Optional.ofNullable(responseContext.getLocation()).ifPresent(uri -> ProxyNodeLogger.addContext(ProxyNodeMDCKey.EGRESS_LOCATION, uri.toString()));
         Optional.ofNullable(responseContext.getStatus()).ifPresent(code -> ProxyNodeLogger.addContext(ProxyNodeMDCKey.RESPONSE_STATUS, String.valueOf(code)));
         Optional.ofNullable(responseContext.getMediaType()).ifPresent(mt -> ProxyNodeLogger.addContext(ProxyNodeMDCKey.EGRESS_MEDIA_TYPE, mt.toString()));
-        ProxyNodeLogger.info("Egress");
+        ProxyNodeLogger.info(MESSAGE_EGRESS);
 
         responseContext.getHeaders().add(JOURNEY_ID_KEY, getJourneyId(requestContext));
 

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilterTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilterTest.java
@@ -1,0 +1,36 @@
+package uk.gov.ida.notification.shared;
+
+import org.junit.Test;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IstioHeaderMapperFilterTest {
+
+    @Test
+    public void shouldTransmitIstioHeadersInResponseContext() {
+        var requestHeaders = new MultivaluedHashMap<String, String>();
+        var responseHeaders = new MultivaluedHashMap<String, Object>();
+        var requestContext = mock(ContainerRequestContext.class);
+        var responseContext = mock(ContainerResponseContext.class);
+        requestHeaders.put(IstioHeaders.X_B3_TRACEID, List.of("foo", "bar"));
+        requestHeaders.putSingle(IstioHeaders.X_REQUEST_ID, "baz");
+        requestHeaders.put(IstioHeaders.X_B3_SPANID, null);
+        when(requestContext.getHeaders()).thenReturn(requestHeaders);
+        when(responseContext.getHeaders()).thenReturn(responseHeaders);
+        new IstioHeaderMapperFilter().filter(requestContext, responseContext);
+        verify(requestContext).getHeaders();
+        verify(responseContext, times(3)).getHeaders();
+        assertThat(responseHeaders.get(IstioHeaders.X_B3_TRACEID)).isEqualTo(List.of("foo", "bar"));
+        assertThat(responseHeaders.get(IstioHeaders.X_REQUEST_ID)).isEqualTo(List.of("baz"));
+        assertThat(responseHeaders.get(IstioHeaders.X_B3_SPANID)).isNull();
+    }
+}


### PR DESCRIPTION
In order to validate that we are shipping Istio tracing headers among our microservices, we want to temporarily log a set of known Istio tracing headers on resource egress.

The change is in `IstioHeaderMapperFilter.java`.
Also ensure multi-valued Istio headers are sent.


