### PR TITLE
BAU: Make Proxy Node metadata entityID match the URL

### DIFF
--- a/chart/templates/saml-metadata.yaml
+++ b/chart/templates/saml-metadata.yaml
@@ -8,7 +8,7 @@ spec:
   id: _entities
   type: proxy
   data:
-    entityID: https://{{ include "gateway.host" . }}
+    entityID: https://{{ include "metadata.host" . }}/metadata.xml
     postURL: https://{{ include "gateway.host" . }}/SAML2/SSO/POST
     redirectURL: https://{{ include "gateway.host" . }}/Redirect
     orgName: {{ .Release.Name }}


### PR DESCRIPTION
In eIDAS world the entityID has to match the Metadata URL
