### PR TITLE
EID-1530: Add more detail to the Stub Connector response page

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -36,10 +36,9 @@ import static uk.gov.ida.saml.core.test.builders.AuthnRequestBuilder.anAuthnRequ
 @RunWith(MockitoJUnitRunner.class)
 public class EidasSamlResourceTest {
 
-    private final static String TEST_CONNECTOR_DESTINATION = "https://stub_country.acme.eu/stub-country-one/destination";
+    private static final String TEST_CONNECTOR_DESTINATION = "https://stub_country.acme.eu/stub-country-one/destination";
 
     private static EidasAuthnRequestValidator eidasAuthnRequestValidator = mock(EidasAuthnRequestValidator.class);
-
     private static SamlRequestSignatureValidator<AuthnRequest> samlRequestSignatureValidator = mock(SamlRequestSignatureValidator.class);
 
     @ClassRule

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
@@ -51,8 +51,9 @@ public class EidasAssertionBuilder {
         assertion.setConditions(createConditions(audienceUri));
         return this;
     }
-    public EidasAssertionBuilder addAuthnStatement(String loa, DateTime authnIssueInstant) {
-        assertion.getAuthnStatements().add(createAuthnStatement(loa, authnIssueInstant));
+
+    public EidasAssertionBuilder addAuthnStatement(String authnStatement, DateTime authnIssueInstant) {
+        assertion.getAuthnStatements().add(createAuthnStatement(authnStatement, authnIssueInstant));
         return this;
     }
 
@@ -95,11 +96,11 @@ public class EidasAssertionBuilder {
         return attributeStatement;
     }
 
-    private AuthnStatement createAuthnStatement(String loa, DateTime authnStatementAuthnInstant) {
+    private AuthnStatement createAuthnStatement(String authnStatementValue, DateTime authnStatementAuthnInstant) {
         AuthnStatement authnStatement = SamlBuilder.build(AuthnStatement.DEFAULT_ELEMENT_NAME);
         AuthnContext authnContext = SamlBuilder.build(AuthnContext.DEFAULT_ELEMENT_NAME);
         AuthnContextClassRef authnContextClassRef = SamlBuilder.build(AuthnContextClassRef.DEFAULT_ELEMENT_NAME);
-        authnContextClassRef.setAuthnContextClassRef(loa);
+        authnContextClassRef.setAuthnContextClassRef(authnStatementValue);
         authnContext.setAuthnContextClassRef(authnContextClassRef);
         authnStatement.setAuthnContext(authnContext);
         authnStatement.setAuthnInstant(authnStatementAuthnInstant);

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
@@ -65,14 +65,18 @@ public class EidasResponseBuilder {
         return this;
     }
 
+    public EidasResponseBuilder addAssertionAttributeStatement(List<Attribute> attributes) {
+        assertionBuilder.addAttributeStatement(attributes);
+        return this;
+    }
+
     public EidasResponseBuilder addAssertionAuthnStatement(String authnStatement, DateTime authnIssueInstant) {
         assertionBuilder.addAuthnStatement(authnStatement, authnIssueInstant);
         return this;
     }
 
-    public EidasResponseBuilder addAssertionAttributeStatement(List<Attribute> attributes) {
-        assertionBuilder.addAttributeStatement(attributes);
-        return this;
+    public EidasResponseBuilder withLoa(String loa, DateTime authnIssueInstant) {
+        return addAssertionAuthnStatement(loa, authnIssueInstant);
     }
 
     public EidasResponseBuilder withAssertionConditions(String assertionConditions) {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -81,9 +81,9 @@ public class HubResponseTranslator {
                 .withIssueInstant(now)
                 .withDestination(hubResponseContainer.getDestinationURL())
                 .withAssertionSubject(hubResponseContainer.getPid())
-                .addAssertionAuthnStatement(getMappedLoa(hubResponseContainer.getLevelOfAssurance()), now)
-                .addAssertionAttributeStatement(eidasAttributes)
                 .withAssertionConditions(connectorNodeIssuerId)
+                .withLoa(getMappedLoa(hubResponseContainer.getLevelOfAssurance()), now)
+                .addAssertionAttributeStatement(eidasAttributes)
                 .build();
     }
 

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerParameterizedTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerParameterizedTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.when;
 @RunWith(Parameterized.class)
 public class EidasResponseAttributesHashLoggerParameterizedTest {
 
-    private final static String REQUEST_ID = "request-id";
-    private final static String DESTINATION_URL = "http://connnector.eu";
+    private static final String REQUEST_ID = "request-id";
+    private static final String DESTINATION_URL = "http://connnector.eu";
 
     @Mock
     private Appender<ILoggingEvent> appender;

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -40,7 +40,7 @@ public class HubResponseTranslatorTest {
         }
     }
 
-    private static HubResponseTranslator TRANSLATOR =
+    private static final HubResponseTranslator TRANSLATOR =
             new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
 
     private AttributesBuilder attributesBuilder;

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
@@ -3,21 +3,30 @@ package uk.gov.ida.notification.stubconnector.views;
 import io.dropwizard.views.View;
 
 import java.util.List;
+import java.util.Map.Entry;
 
 public class ResponseView extends View {
-    private final List<String> attributes;
+    private final List<Entry<String, String>> attributes;
+    private final String loa;
     private final String validity;
     private final String eidasRequestId;
+    private String samlMessage;
 
-    public ResponseView(List<String> attributes, String validity, String eidasRequestId) {
+    public ResponseView(List<Entry<String, String>> attributes, String loa, String validity, String eidasRequestId, String samlMessage) {
         super("response.mustache");
         this.attributes = attributes;
+        this.loa = loa;
         this.validity = validity;
         this.eidasRequestId = eidasRequestId;
+        this.samlMessage = samlMessage;
     }
 
-    public List<String> getAttributes() {
+    public List<Entry<String, String>> getAttributes() {
         return attributes;
+    }
+
+    public String getLoa() {
+        return loa;
     }
 
     public String getValidity() {
@@ -26,5 +35,9 @@ public class ResponseView extends View {
 
     public String getEidasRequestId() {
         return eidasRequestId;
+    }
+
+    public String getSamlMessage() {
+        return samlMessage;
     }
 }

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
@@ -2,12 +2,26 @@
 
 <h2>Saml Validity: {{validity}}</h2>
 <h2>eIDAS Request Id: {{eidasRequestId}}</h2>
+<h2>LOA: {{loa}}</h2>
 
 <h2>Attributes</h2>
-<ul>
-    {{#attributes}}
-    <li>{{.}}</li>
-    {{/attributes}}
+<ul style="list-style: none;">
+  {{#attributes}}
+    {{#.}}
+      <li>
+        <label style="display: block; float: left; text-align: right; width: 120px; padding-right: .75em;">
+          <b>{{key}}:</b>
+        </label>
+        <span>{{value}}</span>
+      </li>
+    {{/.}}
+  {{/attributes}}
 </ul>
 
-<a href="/">Start Again</a>
+<h3>SAML Message</h3>
+<details>
+  <summary><i>Click to expand</i></summary>
+  <textarea readonly style="width: 750px; height: 500px;">{{samlMessage}}</textarea>
+</details>
+
+<p><a href="/">Start Again</a></p>

--- a/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
@@ -39,7 +39,7 @@ public class EidasAuthnRequestContextFactoryTest {
         try {
             factory.generate(
                     destinationEndpoint,
-                    "a connecter entity id",
+                    "connector-entity-id",
                     SPTypeEnumeration.PUBLIC,
                     Collections.emptyList(),
                     EidasLoaEnum.LOA_SUBSTANTIAL,


### PR DESCRIPTION
  - Display LOA
  - Display attribute names
  - Display decoded SAML message to easily verify against the eIDAS spec

  - Encrypt assertions in Stub Connector tests
  - Slightly refactor `EidasAssertionBuilder` methods to make it easier to understand where LOA is set

Test Connector response page will look like this:
<img width="703" alt="stub-connector-response-page" src="https://user-images.githubusercontent.com/3608562/59832013-d86e3c00-933a-11e9-8a54-938d7d4217ef.png">

