### PR TITLE
EID-1508 Log requestLogs with logstash-console

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.4
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207:
+    - '*':
+        reason: Fix not yet available
+        expires: 2019-07-21T15:05:11.857Z
+patch: {}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ The latter will rebuild all services and possibly reassign the minikube ip addre
 1. To run the tests manually, execute: `./gradlew clean test`.
 1. Test results are output to `./build/test-results`.  
 
+## Snyk
+Snyk is run by our Travis builds and does two things, test and monitor. We use the CLI rather than the GitHub integration as the integration has big problems with multi project Gradle builds like we have.
+
+#### Test
+* After the tests are run in the build Travis checks all our dependencies against a database for known vulnerabilities.
+* If any are found it exists with a non-zero code and the build fails. The build logs tell you what happened.
+* If no vulnerabilities are found then we move on to monitoring.
+
+#### Monitor
+* Snyk sends a list of all our dependencies to their server, and will alert us via email if any new vulnerabilities are found for them.
+* The vulnerabilities can be found in [our Snyk dashboard](https://app.snyk.io/org/verify-eidas)
+* You can be added to the Snyk verify-eidas organisation by an existing member.
+
+#### Troubleshooting Snyk
+* The most common issue is a build failing due to a new vulnerability. Follow the link in the logs, or visit the dashboard and see what's up.
+* Most issues will have a resolution strategy. Most often you'll need to bump a library verion. This can also be a transitive dependency. Good luck.
+* If there is currently no solution, you can temporarily ignore the vulnerability. You'll need the Snyk ID of the issue which you can grab from the last segment of the URL of the issue - find it in the Travis build logs where the vulnerability is reported.
+* Run `snyk ignore --id=<IssueID> --reason='The reason you're ignoring it'` and commit the `.snyk` file generated. Push.
+
+
 ## License
 
 [MIT](https://github.com/alphagov/verify-proxy-node/blob/master/LICENCE)

--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -5,6 +5,9 @@ server:
   adminConnectors:
     - type: http
       port: ${ADMIN_PORT:-6008}
+  requestLog:
+    appenders:
+      - type: logstash-console
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -5,6 +5,9 @@ server:
   adminConnectors:
     - type: http
       port: ${ADMIN_PORT:-6601}
+  requestLog:
+    appenders:
+      - type: logstash-console
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -5,6 +5,9 @@ server:
   adminConnectors:
     - type: http
       port: ${ADMIN_PORT:-6661}
+  requestLog:
+    appenders:
+      - type: logstash-console
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-vsp-config/verify-service-provider.yml
+++ b/proxy-node-vsp-config/verify-service-provider.yml
@@ -5,6 +5,9 @@ server:
   connector:
     type: http
     port: ${PORT:-50400}
+  requestLog:
+    appenders:
+      - type: logstash-console
 
 logging:
   level: ${LOG_LEVEL:-INFO}


### PR DESCRIPTION
The app logs being sent to Splunk are all in json format which is
processed nicely by Splunk. The access logs however are not.

Here's an example of a request log next to an app log:
<img width="1203" alt="Screen Shot 2019-06-21 at 15 52 51" src="https://user-images.githubusercontent.com/13836290/59931372-bb219680-943c-11e9-8392-1e21cdbb9796.png">
