### PR TITLE
EID-1532 implement correct pid translation

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: Fix not yet available
         expires: 2019-07-21T15:05:11.857Z
+  SNYK-JAVA-COMGOOGLEGUAVA-32236:
+    - '*':
+        reason: Fix not yet available
+        expires: 2019-07-24T13:00:48.365Z
 patch: {}

--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: CONNECTOR_NODE_ISSUER_ID
           value: {{ include "connector.entityID" . }}
         - name: CONNECTOR_NODE_NATIONALITY_CODE
-          value: "{{ .Values.translator.connectorNodeNationalityCode }}"
+          value: {{ .Values.translator.connectorNodeNationalityCode }}
         - name: PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL
           valueFrom:
             secretKeyRef:

--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -52,6 +52,8 @@ spec:
           value: "80"
         - name: CONNECTOR_NODE_ISSUER_ID
           value: {{ include "connector.entityID" . }}
+        - name: CONNECTOR_NODE_NATIONALITY_CODE
+          value: "{{ .Values.translator.connectorNodeNationalityCode }}"
         - name: PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL
           valueFrom:
             secretKeyRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,6 +37,7 @@ translator:
     repository: registry.tools.verify.govsvc.uk/eidas/translator@sha256
     tag: fd6ada0159c1cc5415cd51ffcdd41fc3f19c4cb827cafdecf9134a372024bc4a
     pullPolicy: IfNotPresent
+  connectorNodeNationalityCode: NL
 
 stubConnector:
   enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,7 +37,7 @@ translator:
     repository: registry.tools.verify.govsvc.uk/eidas/translator@sha256
     tag: fd6ada0159c1cc5415cd51ffcdd41fc3f19c4cb827cafdecf9134a372024bc4a
     pullPolicy: IfNotPresent
-  connectorNodeNationalityCode: NL
+  connectorNodeNationalityCode: EU
 
 stubConnector:
   enabled: false

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -73,6 +73,7 @@ spec:
             CLUSTER_NAME: ((cluster.name))
             CLUSTER_DOMAIN: ((cluster.domain))
             RELEASE_NAME: nl-integration
+            CONNECTOR_NODE_NATIONALITY_CODE: NL
             RELEASE_NAMESPACE: ((namespace-deployer.namespace))
             CLUSTER_PRIVATE_KEY: ((cluster.privateKey))
             CONNECTOR_ENTITY_ID: https://acc-eidas.minez.nl/EidasNodeC/ConnectorMetadata
@@ -100,6 +101,7 @@ spec:
                 --set "connector.entityID=${CONNECTOR_ENTITY_ID}" \
                 --set "connector.metadataURL=${CONNECTOR_METADATA_URL}" \
                 --set "connector.metadataSigningTruststoreBase64=${CONNECTOR_METADATA_SIGNING_TRUSTSTORE_BASE64}" \
+                --set "translator.connectorNodeNationalityCode"=${CONNECTOR_NODE_NATIONALITY_CODE} \
                 --output-dir "./manifests/" \
                 ./release/*.tgz
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 public class EidasAssertionBuilder {
 
-    public static final String TEMPORARY_PID_TRANSLATION = "UK/EU/";
-
     private final Assertion assertion;
 
     public EidasAssertionBuilder() {
@@ -69,7 +67,7 @@ public class EidasAssertionBuilder {
     private Subject createSubject(String pid) {
         Subject subject = SamlBuilder.build(Subject.DEFAULT_ELEMENT_NAME);
         NameID nameID = SamlBuilder.build(NameID.DEFAULT_ELEMENT_NAME);
-        nameID.setValue(TEMPORARY_PID_TRANSLATION + pid);
+        nameID.setValue(pid);
         nameID.setFormat(NameIDType.PERSISTENT);
         subject.setNameID(nameID);
         return subject;

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
@@ -60,8 +60,8 @@ public class EidasResponseBuilder {
         return this;
     }
 
-    public EidasResponseBuilder withAssertionSubject(String subject) {
-        assertionBuilder.withSubject(subject);
+    public EidasResponseBuilder withAssertionSubject(String pid) {
+        assertionBuilder.withSubject(pid);
         return this;
     }
 

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
@@ -46,7 +46,7 @@ public class TranslatedHubResponseTestAssertions {
         final Attribute PidAttribute = attributes.get(3);
         assertThat(PidAttribute.getName()).isEqualTo(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME);
         assertThat(PidAttribute.getFriendlyName()).isEqualTo(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_FRIENDLY_NAME);
-        assertThat(getAttributeValue(PidAttribute)).isEqualTo("UK/EU/123456");
+        assertThat(getAttributeValue(PidAttribute)).isEqualTo("UK/NATIONALITY_CODE/123456");
     }
 
     public static void checkAssertionStatementsValid(Response decryptedEidasResponse) {

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -18,6 +18,8 @@ proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_U
 
 connectorNodeIssuerId: ${CONNECTOR_NODE_ISSUER_ID}
 
+connectorNodeNationalityCode: ${CONNECTOR_NODE_NATIONALITY_CODE}
+
 vspConfiguration:
   url: ${VERIFY_SERVICE_PROVIDER_URL}
   clientConfig:

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -101,7 +101,8 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
         final HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
                 EidasResponseBuilder::instance,
                 configuration.getConnectorNodeIssuerId(),
-                configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
+                configuration.getProxyNodeMetadataForConnectorNodeUrl().toString(),
+                configuration.getConnectorNodeNationalityCode()
         );
 
         final EidasFailureResponseGenerator failureResponseGenerator = new EidasFailureResponseGenerator(

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
@@ -31,6 +31,11 @@ public class TranslatorConfiguration extends Configuration {
     @JsonProperty
     private String connectorNodeIssuerId;
 
+    @Valid
+    @NotNull
+    @JsonProperty
+    private String connectorNodeNationalityCode;
+
     public URI getProxyNodeMetadataForConnectorNodeUrl() {
         return proxyNodeMetadataForConnectorNodeUrl;
     }
@@ -39,11 +44,11 @@ public class TranslatorConfiguration extends Configuration {
         return vspConfiguration;
     }
 
-    public String getConnectorNodeIssuerId() {
-        return connectorNodeIssuerId;
-    }
+    public String getConnectorNodeIssuerId() { return connectorNodeIssuerId; }
 
     public CredentialConfiguration getCredentialConfiguration() {
         return credentialConfiguration;
     }
+
+    public String getConnectorNodeNationalityCode() { return connectorNodeNationalityCode; }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
@@ -32,6 +32,7 @@ public class TranslatorAppRuleTestBase {
             ConfigOverride.config("proxyNodeMetadataForConnectorNodeUrl", "http://proxy-node.uk"),
             ConfigOverride.config("connectorNodeIssuerId", "http://connector-node:8080/ConnectorMetadata"),
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri() + "/vsp"),
+            ConfigOverride.config("connectorNodeNationalityCode", "NATIONALITY_CODE"),
             ConfigOverride.config("credentialConfiguration.type", "file"),
             ConfigOverride.config("credentialConfiguration.publicKey.type", "x509"),
             ConfigOverride.config("credentialConfiguration.publicKey.cert", TEST_PUBLIC_CERT),

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -41,7 +41,7 @@ public class HubResponseTranslatorTest {
     }
 
     private static final HubResponseTranslator TRANSLATOR =
-            new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL");
+            new HubResponseTranslator(EidasResponseBuilder::instance, "Issuer", "connectorMetadataURL", "NATIONALITY_CODE");
 
     private AttributesBuilder attributesBuilder;
 


### PR DESCRIPTION
The eIDAS specification states that a PID should be prefixed with
"{Identifying country nationality code}/{destination country nationality
code}".

This allows a nationality code to be provided via the configuration.
This is a short term solution as it only allows for the proxy node to be
connected to one country.

When we restructure to allow multiple countries this will need
revisiting.