### PR TITLE
Intermediate certs for use with new metadata-controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ buildNumber.properties
 
 # Gradle
 .gradle
-build/
+/build/
 eidas-saml-parser/build/
 proxy-node-gateway/build/
 proxy-node-shared/build/

--- a/chart/templates/metadata-signing-cert.yaml
+++ b/chart/templates/metadata-signing-cert.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+    name: {{ .Release.Name }}-metadata-cert
+    namespace: {{ .Release.Namespace }}
+  spec:
+    countryCode: GB
+    commonName: Verify Proxy Node Metadata Signing
+    expiryMonths: 3
+    organization: Cabinet Office
+    organizationUnit: GDS
+    location: London
+    CACert: false
+    certificateAuthority:
+      secretName: proxy-node-ca
+      namespace: {{ .Release.Namespace }}

--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -19,3 +19,13 @@ spec:
     contactSurname: Support
     contactEmail: idasupport@digital.cabinet-office.gov.uk
   enabled: true
+  samlSigningCertRequest:
+    countryCode: GB
+    commonName: Verify Proxy Node SAML Signing
+    expiryMonths: 4
+    organization: Cabinet Office
+    organizationUnit: GDS
+    location: London
+  certificateAuthority:
+    secretName: {{ .Release.Name }}-metadata-cert
+    namespace: {{ .Release.Namespace }}

--- a/ci/build/intermediate-certificate-request.yaml
+++ b/ci/build/intermediate-certificate-request.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: proxy-node-ca
+spec:
+  countryCode: GB
+  commonName: Verify Test Metadata CA
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true
+  certificateAuthority:
+    secretName: verify-root-ca-test
+    namespace: verify-metadata-controller

--- a/ci/integration/intermediate-certificate-request.yaml
+++ b/ci/integration/intermediate-certificate-request.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: proxy-node-ca
+spec:
+  countryCode: GB
+  commonName: Verify Test Metadata CA
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true
+  certificateAuthority:
+    secretName: verify-root-ca-test
+    namespace: verify-metadata-controller

--- a/ci/prod/intermediate-certificate-request.yaml
+++ b/ci/prod/intermediate-certificate-request.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: verify.gov.uk/v1beta1
+kind: CertificateRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: proxy-node-ca
+spec:
+  countryCode: GB
+  commonName: Verify Proxy Node Metadata CA
+  expiryMonths: 120
+  organization: Cabinet Office
+  organizationUnit: GDS
+  location: London
+  CACert: true
+  certificateAuthority:
+    secretName: verify-root-ca-production
+    namespace: verify-metadata-controller


### PR DESCRIPTION
updates the metadata config and adds metadata signing cert for the
proxy-node after the CertificateRequest changes to metadata-controller

we now add have a per-cluster root ca ... a per-namespace intermediate
ca and per-instance metadata signing certs.