### PR TITLE
remove trip hyphen from resource header

### DIFF
--- a/chart/templates/metadata-signing-cert.yaml
+++ b/chart/templates/metadata-signing-cert.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: verify.gov.uk/v1beta1
 kind: CertificateRequest
 metadata:


### PR DESCRIPTION
I _think_ the tripple hyphen at top of the CertificateRequest is causing a problem where something is interpreting it as a list