### PR TITLE
EID-1508: Set requestLog layout to access-json

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.4
+version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207:
@@ -10,4 +10,8 @@ ignore:
     - '*':
         reason: Fix not yet available
         expires: 2019-07-24T13:00:48.365Z
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917:
+    - '*':
+        reason: Fix not available yet
+        expires: 2019-07-26T16:07:31.690Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
                 "io.dropwizard:dropwizard-core:${dropwizard_version}",
                 "io.dropwizard:dropwizard-client:${dropwizard_version}",
                 "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
-                "io.dropwizard:dropwizard-views-mustache:${dropwizard_version}",
+                "io.dropwizard:dropwizard-json-logging:${dropwizard_version}",
                 "uk.gov.ida:dropwizard-logstash:1.3.5-68"
         )
 

--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -7,7 +7,9 @@ server:
       port: ${ADMIN_PORT:-6008}
   requestLog:
     appenders:
-      - type: logstash-console
+      - type: console
+        layout:
+          type: json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -9,7 +9,7 @@ server:
     appenders:
       - type: console
         layout:
-          type: json
+          type: access-json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -7,7 +7,9 @@ server:
       port: ${ADMIN_PORT:-6601}
   requestLog:
     appenders:
-      - type: logstash-console
+      - type: console
+        layout:
+          type: json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-gateway/src/dist/config.yml
+++ b/proxy-node-gateway/src/dist/config.yml
@@ -9,7 +9,7 @@ server:
     appenders:
       - type: console
         layout:
-          type: json
+          type: access-json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -9,7 +9,7 @@ server:
     appenders:
       - type: console
         layout:
-          type: json
+          type: access-json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -7,7 +7,9 @@ server:
       port: ${ADMIN_PORT:-6661}
   requestLog:
     appenders:
-      - type: logstash-console
+      - type: console
+        layout:
+          type: json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-vsp-config/verify-service-provider.yml
+++ b/proxy-node-vsp-config/verify-service-provider.yml
@@ -5,6 +5,11 @@ server:
   connector:
     type: http
     port: ${PORT:-50400}
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
 
 logging:
   level: ${LOG_LEVEL:-INFO}

--- a/proxy-node-vsp-config/verify-service-provider.yml
+++ b/proxy-node-vsp-config/verify-service-provider.yml
@@ -5,9 +5,6 @@ server:
   connector:
     type: http
     port: ${PORT:-50400}
-  requestLog:
-    appenders:
-      - type: logstash-console
 
 logging:
   level: ${LOG_LEVEL:-INFO}


### PR DESCRIPTION
`io.dropwizard:dropwizard-json-logging` will need to be made
available via artifactory for the build to go green. I think only an admin
can do that.

Setting the requestLog type to 'logstash-console' on its own, done 
in [PR#222](https://github.com/alphagov/verify-proxy-node/pull/222) didn't
work. In fact, it meant that no request logs at all were shipped. I
think this was due to dropwizard not being able to find the correct
type.

Rather than using the `logstash-console` type we can set the layout of the
requestLogs to json, as suggested by the docs: https://www.dropwizard.io/1.3.12/docs/manual/core.html

To do this we need to pull in the `dropwizard-json-logging` module.

This PR also removes the requestLog changes to the VSP. Due to the
new approach requiring a new library, a change would need to be implemented
and released in the VSP. The json logging lib has been added in alphagov/verify-service-provider#203

If this PR doesn't work (I can't test it locally unfortunately) then the
changes made in [PR#222](https://github.com/alphagov/verify-proxy-node/pull/222) will need reverting.