### PR TITLE
Failed package builds should stick to same release #

### DIFF
--- a/ci/build/release-pipeline.yaml
+++ b/ci/build/release-pipeline.yaml
@@ -145,6 +145,7 @@ spec:
           trigger: true
         - get: vsp-src
           trigger: true
+        - get: release
       - in_parallel:
           limit: 3
           fail_fast: true
@@ -232,6 +233,8 @@ spec:
         - get: tests-image
           passed: ["build"]
           trigger: true
+        - get: release
+          passed: ["build"]
 
       - task: generate-chart-values
         config:
@@ -283,8 +286,6 @@ spec:
                 EOF
                 echo "merging with chart values..."
                 spruce merge ./src/chart/values.yaml ./overrides.yaml | tee -a chart-values/values.yaml
-
-      - get: release
 
       - task: generate-chart-version
         config:


### PR DESCRIPTION
A failing concourse build at package stage currently requests a new [github-release](https://github.com/concourse/github-release-resource).

Failing package builds will now use the same `release` until they go green.