### PR TITLE
Disable signing of docker images as latest

### DIFF
--- a/ci/build/release-pipeline.yaml
+++ b/ci/build/release-pipeline.yaml
@@ -155,7 +155,7 @@ spec:
               build_args:
                 component: proxy-node-gateway
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: translator-image
             params:
@@ -164,7 +164,7 @@ spec:
               build_args:
                 component: proxy-node-translator
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: parser-image
             params:
@@ -172,20 +172,20 @@ spec:
               build_args:
                 component: eidas-saml-parser
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: stub-connector-image
             params:
               build: src
               dockerfile: src/stub-connector/Dockerfile
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: cloudhsm-image
             params:
               build: src/cloudhsm
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: verify-service-provider-image
             params:
@@ -194,13 +194,13 @@ spec:
                 VERIFY_USE_PUBLIC_BINARIES: "false"
               dockerfile: src/proxy-node-vsp-config/Dockerfile.internal
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
           - put: tests-image
             params:
               build: src/proxy-node-acceptance-tests
               tag_file: src/.git/short_ref
-              tag_as_latest: true
+              tag_as_latest: false
               tag_prefix: v
 
     - name: package


### PR DESCRIPTION
There is an issue when signing docker images that results
in any image signed with the tag "latest" invalidating all
previously signed images.  This is an issue as it prevents
rolling back to a previous release.

This commit disables the signing of tag latest, but should
still result in an image being signed.  Deploying "latest"
should still succeed as the image will be signed any way.