### PR TITLE
EID-1487 Send Istio headers with ProxyNodeJsonClient requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 
 ext {
     opensaml_version = '3.4.2'
-    dropwizard_version = '1.3.9'
+    dropwizard_version = '1.3.12'
     utils_version = '2.0.0-360'
     saml_lib_version = "${opensaml_version}-192"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -5,6 +5,7 @@ import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -29,6 +30,7 @@ import uk.gov.ida.notification.saml.deprecate.DestinationValidator;
 import uk.gov.ida.notification.saml.metadata.Metadata;
 import uk.gov.ida.notification.saml.validation.components.LoaValidator;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.saml.metadata.MetadataConfiguration;
 import uk.gov.ida.saml.metadata.MetadataHealthCheck;
@@ -112,6 +114,7 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
                 environment,
                 "connector-metadata");
         registerExceptionMappers(environment);
+        registerInjections(environment);
     }
 
     private void registerMetadataHealthCheck(MetadataResolver metadataResolver, MetadataConfiguration connectorMetadataConfiguration, Environment environment, String name) {
@@ -156,5 +159,14 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
                 credential.getEntityCertificate().getEncoded());
 
         return x509EncryptionCert;
+    }
+
+    private void registerInjections(Environment environment) {
+        environment.jersey().register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(IstioHeaderStorage.class).to(IstioHeaderStorage.class);
+            }
+        });
     }
 }

--- a/libs/eidas-saml-parser/pom.xml
+++ b/libs/eidas-saml-parser/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-gateway/pom.xml
+++ b/libs/proxy-node-gateway/pom.xml
@@ -273,7 +273,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-shared/pom.xml
+++ b/libs/proxy-node-shared/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-test/pom.xml
+++ b/libs/proxy-node-test/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-translator/pom.xml
+++ b/libs/proxy-node-translator/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/stub-connector/pom.xml
+++ b/libs/stub-connector/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.12</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
 import uk.gov.ida.notification.configuration.RedisServiceConfiguration;
 import uk.gov.ida.notification.exceptions.mappers.ErrorPageExceptionMapper;
@@ -22,6 +23,7 @@ import uk.gov.ida.notification.session.storage.InMemoryStorage;
 import uk.gov.ida.notification.session.storage.RedisStorage;
 import uk.gov.ida.notification.session.storage.SessionStore;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
@@ -86,9 +88,11 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
                 .getTranslatorServiceConfiguration()
                 .buildTranslatorProxy(environment);
 
+
         registerProviders(environment);
         registerResources(configuration, environment, samlFormViewBuilder, translatorProxy, sessionStorage);
         registerExceptionMappers(environment, samlFormViewBuilder, translatorProxy, sessionStorage, configuration.getErrorPageRedirectUrl());
+        registerInjections(environment);
     }
 
     private void registerProviders(Environment environment) {
@@ -161,5 +165,14 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
                 translatorProxy,
                 sessionStorage
         ));
+    }
+
+    private void registerInjections(Environment environment) {
+        environment.jersey().register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(IstioHeaderStorage.class).to(IstioHeaderStorage.class);
+            }
+        });
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/EidasSamlParserServiceConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/EidasSamlParserServiceConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.proxy.EidasSamlParserProxy;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 
@@ -39,7 +40,8 @@ public class EidasSamlParserServiceConfiguration extends Configuration {
         Client client = new JerseyClientBuilder(environment).using(clientConfig).build("eidas-saml-parser");
         ProxyNodeJsonClient jsonClient = new ProxyNodeJsonClient(
             new ErrorHandlingClient(client),
-            new JsonResponseProcessor(environment.getObjectMapper())
+            new JsonResponseProcessor(environment.getObjectMapper()),
+            new IstioHeaderStorage()
         );
 
         return new EidasSamlParserProxy(

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/configuration/TranslatorServiceConfiguration.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.proxy.TranslatorProxy;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 
 import javax.validation.Valid;
@@ -41,7 +42,8 @@ public class TranslatorServiceConfiguration extends Configuration {
         Client client = new JerseyClientBuilder(environment).using(clientConfig).build("translator-client");
         ProxyNodeJsonClient jsonClient = new ProxyNodeJsonClient(
             new ErrorHandlingClient(client),
-            new JsonResponseProcessor(environment.getObjectMapper())
+            new JsonResponseProcessor(environment.getObjectMapper()),
+            new IstioHeaderStorage()
         );
         return new TranslatorProxy(
             jsonClient,

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
@@ -10,6 +10,7 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.exceptions.EidasSamlParserResponseException;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeMDCKey;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 
@@ -125,7 +126,8 @@ public class EidasSamlParserProxyTest {
         ObjectMapper objectMapper = new ObjectMapper();
         ProxyNodeJsonClient jsonClient = new ProxyNodeJsonClient(
                 new ErrorHandlingClient(ClientBuilder.newClient()),
-                new JsonResponseProcessor(objectMapper)
+                new JsonResponseProcessor(objectMapper),
+                new IstioHeaderStorage()
         );
 
         return new EidasSamlParserProxy(

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
@@ -13,6 +13,7 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.exceptions.TranslatorResponseException;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeMDCKey;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 
@@ -70,7 +71,8 @@ public class TranslatorProxyTest {
     @Spy
     ProxyNodeJsonClient jsonClient = new ProxyNodeJsonClient(
             new ErrorHandlingClient(ClientBuilder.newClient()),
-            new JsonResponseProcessor(new ObjectMapper())
+            new JsonResponseProcessor(new ObjectMapper()),
+            new IstioHeaderStorage()
     );
 
     @Test

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilter.java
@@ -1,33 +1,29 @@
 package uk.gov.ida.notification.shared;
 
+import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static uk.gov.ida.notification.shared.IstioHeaders.ISTIO_HEADERS;
+import java.io.IOException;
 
 @Provider
-public class IstioHeaderMapperFilter implements ContainerResponseFilter {
+public class IstioHeaderMapperFilter implements ContainerResponseFilter, ContainerRequestFilter {
+
+    @Inject
+    private IstioHeaderStorage istioHeaderStorage;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        istioHeaderStorage.captureHeaders(requestContext.getHeaders());
+    }
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
-        MultivaluedMap<String, String> incomingHeaders = requestContext.getHeaders();
-        List<String> valuesToLog = new ArrayList<>();
-        for (String istioHeader : ISTIO_HEADERS)
-            if (incomingHeaders.containsKey(istioHeader)) {
-                MultivaluedMap<String, Object> responseHeaders = responseContext.getHeaders();
-                List<String> headerValues = incomingHeaders.get(istioHeader);
-                if (headerValues != null) {
-                    headerValues.stream().forEach(v -> responseHeaders.add(istioHeader, v));
-                    valuesToLog.add(String.format("%s=%s", istioHeader, headerValues));
-                }
-            }
+        istioHeaderStorage.appendIstioHeadersToResponseContextHeaders(responseContext);
         // TODO remove once istio tracing works
-        ProxyNodeLogger.info("Istio headers: " + valuesToLog.stream().collect(Collectors.joining("|")));
+        ProxyNodeLogger.info(istioHeaderStorage.toString());
+        istioHeaderStorage.clear();
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderStorage.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/IstioHeaderStorage.java
@@ -1,0 +1,63 @@
+package uk.gov.ida.notification.shared;
+
+import javax.inject.Singleton;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.ida.notification.shared.IstioHeaders.ISTIO_HEADERS;
+
+@Singleton
+public class IstioHeaderStorage {
+    private static ThreadLocal<MultivaluedMap<String, Object>> storage;
+    static {
+        storage = new ThreadLocal<>();
+    }
+
+    public void captureHeaders(MultivaluedMap<String, String> requestHeaders) {
+        MultivaluedMap<String, Object> istioHeaders = new MultivaluedHashMap<>();
+
+        for (String istioHeader : ISTIO_HEADERS) {
+            if (requestHeaders.containsKey(istioHeader)) {
+                List<String> headers = requestHeaders.get(istioHeader);
+                if(headers != null) {
+                    headers.stream().forEach(v -> istioHeaders.add(istioHeader, v));
+                }
+            }
+        }
+        IstioHeaderStorage.storage.set(istioHeaders);
+    }
+
+    public void appendIstioHeadersToResponseContextHeaders(ContainerResponseContext responseContext) {
+        if(storage.get() != null) {
+            storage.get().forEach((k, v) -> responseContext.getHeaders().addAll(k, v));
+        }
+    }
+
+    public MultivaluedMap<String, Object> getMultiMapIstioHeaders() {
+        return storage.get();
+    }
+
+    public Optional<Map<String, String>> getIstioHeaders() {
+        Map<String, String> firstIstioHeaders = new HashMap<>();
+        if (this.getMultiMapIstioHeaders() != null) {
+            this.getMultiMapIstioHeaders().forEach((k, v) -> firstIstioHeaders.put(k, v.get(0).toString()));
+        }
+        return Optional.ofNullable(firstIstioHeaders);
+    }
+
+    public void clear() {
+        storage.remove();
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer stringBuffer = new StringBuffer("Istio headers: ");
+        this.getMultiMapIstioHeaders().forEach((k, v) -> stringBuffer.append(String.format("%s=%s |", k, v)));
+        return stringBuffer.toString();
+    }
+}

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/proxy/ProxyNodeJsonClient.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/proxy/ProxyNodeJsonClient.java
@@ -4,9 +4,9 @@ import org.slf4j.MDC;
 import uk.gov.ida.jerseyclient.ErrorHandlingClient;
 import uk.gov.ida.jerseyclient.JsonClient;
 import uk.gov.ida.jerseyclient.JsonResponseProcessor;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeMDCKey;
 
-import javax.inject.Inject;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,20 +14,20 @@ import java.util.Map;
 public class ProxyNodeJsonClient {
 
     private final JsonClient jsonClient;
+    private final IstioHeaderStorage istioHeaderStorage;
 
-    @Inject
-    public ProxyNodeJsonClient(ErrorHandlingClient errorHandlingClient, JsonResponseProcessor responseProcessor) {
+    public ProxyNodeJsonClient(ErrorHandlingClient errorHandlingClient, JsonResponseProcessor responseProcessor, IstioHeaderStorage istioHeaderStorage) {
         this.jsonClient = new JsonClient(errorHandlingClient, responseProcessor);
+        this.istioHeaderStorage = istioHeaderStorage;
     }
 
     public <T> T post(Object postBody, URI uri, Class<T> clazz) {
-        return jsonClient.post(postBody, uri, clazz, getJourneyIdHeader());
+        return jsonClient.post(postBody, uri, clazz, getHeaders());
     }
 
-    private Map<String, String> getJourneyIdHeader() {
-        Map<String, String> header = new HashMap<>();
-        header.put(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name(), MDC.get(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name()));
-        return header;
+    private Map<String, String> getHeaders() {
+        Map<String, String> headers = this.istioHeaderStorage.getIstioHeaders().orElse(new HashMap<>());
+        headers.put(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name(), MDC.get(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name()));
+        return headers;
     }
-
 }

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilterTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/IstioHeaderMapperFilterTest.java
@@ -1,10 +1,15 @@
 package uk.gov.ida.notification.shared;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.core.MultivaluedHashMap;
+import java.io.IOException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,10 +18,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class IstioHeaderMapperFilterTest {
 
+    @Spy
+    IstioHeaderStorage istioHeaderStorage = new IstioHeaderStorage();
+    @InjectMocks
+    IstioHeaderMapperFilter filter;
+
     @Test
-    public void shouldTransmitIstioHeadersInResponseContext() {
+    public void shouldTransmitIstioHeadersInResponseContext() throws IOException {
         var requestHeaders = new MultivaluedHashMap<String, String>();
         var responseHeaders = new MultivaluedHashMap<String, Object>();
         var requestContext = mock(ContainerRequestContext.class);
@@ -26,9 +37,11 @@ public class IstioHeaderMapperFilterTest {
         requestHeaders.put(IstioHeaders.X_B3_SPANID, null);
         when(requestContext.getHeaders()).thenReturn(requestHeaders);
         when(responseContext.getHeaders()).thenReturn(responseHeaders);
-        new IstioHeaderMapperFilter().filter(requestContext, responseContext);
+
+        filter.filter(requestContext);
+        filter.filter(requestContext, responseContext);
         verify(requestContext).getHeaders();
-        verify(responseContext, times(3)).getHeaders();
+        verify(responseContext, times(2)).getHeaders();
         assertThat(responseHeaders.get(IstioHeaders.X_B3_TRACEID)).isEqualTo(List.of("foo", "bar"));
         assertThat(responseHeaders.get(IstioHeaders.X_REQUEST_ID)).isEqualTo(List.of("baz"));
         assertThat(responseHeaders.get(IstioHeaders.X_B3_SPANID)).isNull();

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/proxy/ProxyNodeJsonClientTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/proxy/ProxyNodeJsonClientTest.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.notification.shared.proxy;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.jerseyclient.ErrorHandlingClient;
+import uk.gov.ida.jerseyclient.JsonResponseProcessor;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProxyNodeJsonClientTest {
+    @Mock
+    ErrorHandlingClient errorHandlingClient; // Sends request and provides response
+    @Mock
+    JsonResponseProcessor responseProcessor;
+    @Mock
+    IstioHeaderStorage istioHeaderStorage;
+
+    @Spy
+    @InjectMocks
+    private ProxyNodeJsonClient proxyNodeJsonClient;
+
+    @Test
+    public void shouldSendIstioHeadersInPostRequest() throws URISyntaxException {
+
+        Map<String, String> headers = new HashMap<>();
+
+        headers.put("header-1", "value1");
+        headers.put("header-2", "value2");
+
+        when(istioHeaderStorage.getIstioHeaders()).thenReturn(Optional.of(headers));
+
+        URI uri = new URI("http://foo.bar");
+        Object postBody = new Object();
+        proxyNodeJsonClient.post(postBody, uri, Object.class);
+        verify(errorHandlingClient).post(eq(uri), eq(headers), eq(postBody));
+    }
+
+}

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -6,6 +6,7 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import uk.gov.ida.dropwizard.logstash.LogstashBundle;
@@ -18,6 +19,7 @@ import uk.gov.ida.notification.healthcheck.ProxyNodeHealthCheck;
 import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.notification.saml.SamlObjectSigner;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.shared.proxy.VerifyServiceProviderProxy;
 import uk.gov.ida.notification.translator.configuration.TranslatorConfiguration;
@@ -80,6 +82,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
 
         registerExceptionMappers(environment);
         registerResources(configuration, environment);
+        registerInjections(environment);
 
     }
 
@@ -117,5 +120,14 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
                                                                        credentialConfiguration.getKeyHandle());
 
         return new EidasResponseGenerator(hubResponseTranslator, failureResponseGenerator, samlObjectSigner);
+    }
+
+    private void registerInjections(Environment environment) {
+        environment.jersey().register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(IstioHeaderStorage.class).to(IstioHeaderStorage.class);
+            }
+        });
     }
 }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorApplication.java
@@ -7,6 +7,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import org.eclipse.jetty.server.session.SessionHandler;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
@@ -19,6 +20,7 @@ import uk.gov.ida.notification.saml.converters.AuthnRequestParameterProvider;
 import uk.gov.ida.notification.saml.converters.ResponseParameterProvider;
 import uk.gov.ida.notification.saml.metadata.Metadata;
 import uk.gov.ida.notification.shared.IstioHeaderMapperFilter;
+import uk.gov.ida.notification.shared.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.stubconnector.resources.ReceiveResponseResource;
 import uk.gov.ida.notification.stubconnector.resources.SendAuthnRequestResource;
@@ -103,6 +105,7 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
 
         registerProviders(environment);
         registerResources(configuration, environment);
+        registerInjections(environment);
     }
 
     private void registerProviders(Environment environment) {
@@ -141,4 +144,14 @@ public class StubConnectorApplication extends Application<StubConnectorConfigura
 
         environment.healthChecks().register(metadataHealthCheck.getName(), metadataHealthCheck);
     }
+
+    private void registerInjections(Environment environment) {
+        environment.jersey().register(new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(IstioHeaderStorage.class).to(IstioHeaderStorage.class);
+            }
+        });
+    }
+
 }


### PR DESCRIPTION
Create an IstioHeaderStorage class that uses ThreadLocal to store Istio headers.  Use a request filter to capture the Istio headers on the way in.  Update ProxyNodeJsonClient so that it has access to an instance of IstioHeaderStorage for retrieving the current request’s Istio headers to pass on.  Append Istio headers to response on the way out and clear the headers out of the thread local.