### PR TITLE
add verification and testing for SamlFailureResponseGenerationRequest

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/SamlFailureResponseGenerationRequest.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/SamlFailureResponseGenerationRequest.java
@@ -1,22 +1,26 @@
 package uk.gov.ida.notification.contracts;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.ida.notification.validations.ValidDestinationUriString;
+import uk.gov.ida.notification.validations.ValidSamlId;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.Response;
 
 public class SamlFailureResponseGenerationRequest {
 
-    @NotNull
     @JsonProperty
+    @NotNull
     private Response.Status responseStatus;
 
-    @NotNull
     @JsonProperty
+    @NotNull
+    @ValidSamlId
     private String eidasRequestId;
 
-    @NotNull
     @JsonProperty
+    @NotNull
+    @ValidDestinationUriString
     private String destinationUrl;
 
     @SuppressWarnings("Needed for JSON serialisation")

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/validations/SamlFailureResponseGenerationRequestValidationTests.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/validations/SamlFailureResponseGenerationRequestValidationTests.java
@@ -1,0 +1,52 @@
+package uk.gov.ida.notification.validations;
+
+import org.junit.Test;
+import uk.gov.ida.notification.contracts.SamlFailureResponseGenerationRequest;
+
+import javax.validation.ConstraintViolation;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SamlFailureResponseGenerationRequestValidationTests extends AbstractDtoValidationsTest<SamlFailureResponseGenerationRequest> {
+
+    @Test
+    public void shouldFailValidationWithAllNullParameters() {
+        SamlFailureResponseGenerationRequest nullRequest = new SamlFailureResponseGenerationRequest(
+                null,
+                null,
+                null);
+
+        Map<String, List<ConstraintViolation<SamlFailureResponseGenerationRequest>>> nullViolationsMap = validateAndMap(nullRequest);
+
+        assertThat(nullViolationsMap.size()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldPassValidationWithValidParameters() {
+        SamlFailureResponseGenerationRequest goodRequest = new SamlFailureResponseGenerationRequest(
+                Response.Status.OK, // null is the only 'malformed' Response.Status
+                ValidationTestDataUtils.sample_eidasRequestId,
+                ValidationTestDataUtils.sample_destinationUrl);
+
+        Map<String, List<ConstraintViolation<SamlFailureResponseGenerationRequest>>> goodViolationsMap = validateAndMap(goodRequest);
+
+        assertThat(goodViolationsMap.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldFailValidationWithInvalidParameters() {
+        // NB. null is the only 'malformed' Response.Status.
+        // Even error statuses are accepted by validation and if they indicate problems they are handled elsewhere.
+        SamlFailureResponseGenerationRequest badRequest = new SamlFailureResponseGenerationRequest(
+                null,
+                "SAML Ids cannot have spaces",
+                "ftp://that.is/not/a/good/protocol");
+
+        Map<String, List<ConstraintViolation<SamlFailureResponseGenerationRequest>>> badViolationsMap = validateAndMap(badRequest);
+
+        assertThat(badViolationsMap.size()).isEqualTo(3);
+    }
+}

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -71,7 +71,7 @@ public class HubResponseTranslatorResource {
 
     @POST
     @Path(Urls.TranslatorUrls.GENERATE_FAILURE_RESPONSE_PATH)
-    public Response failureResponse(SamlFailureResponseGenerationRequest failureResponseRequest) {
+    public Response failureResponse(@Valid SamlFailureResponseGenerationRequest failureResponseRequest) {
 
         final org.opensaml.saml.saml2.core.Response failureEidasResponse = eidasResponseGenerator.generateFailureResponse(
                 failureResponseRequest.getResponseStatus(),


### PR DESCRIPTION
- Add @Valid annotation where `SamlFailureResponseGenerationRequest` is used in the Resource.
- Add validation annotations to the fields in `SamlFailureResponseGenerationRequest`.
- Add tests for the validation.
