### PR TITLE
Fix to permit NL cert to pass size validation

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/PEMCertificateValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/PEMCertificateValidator.java
@@ -12,9 +12,10 @@ import java.util.Date;
 
 public class PEMCertificateValidator implements ConstraintValidator<ValidPEM, String> {
 
-    // self-signed test cert is ~900-1000 chars
+    // Self-signed test cert is ~900-1000 chars.
+    // NL cert comes in at just over 2070 chars.
     public static final int MinLength = 512;
-    public static final int MaxLength = 2048;
+    public static final int MaxLength = 4096;
 
     @Override
     public void initialize(ValidPEM constraint) { /* intentionally blank */ }


### PR DESCRIPTION
- NL cert comes in at just over 2070 bytes.
- Increase upper bound on cert size to 4096, previous bound was 2048.