### PR TITLE
BAU: Mount metadata volumes directly

### DIFF
--- a/chart/templates/gateway-deployment.yaml
+++ b/chart/templates/gateway-deployment.yaml
@@ -30,14 +30,13 @@ spec:
           - key: metadata.xml
             path: metadata.xml
       containers:
-      - name: proxy-node-metadata
+      - name: gateway
+        image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+        imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         volumeMounts:
         - name: proxy-node-metadata-volume
           mountPath: /app/proxy-node-gateway/build/resources/main/metadata
           readOnly: true
-      - name: gateway
-        image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
-        imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         ports:
         - name: http
           containerPort: 80

--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -35,14 +35,13 @@ spec:
           - key: metadata.xml
             path: metadata.xml
       containers:
-      - name: connector-metadata
+      - name: connector
+        image: "{{ .Values.stubConnector.image.repository }}:{{ .Values.stubConnector.image.tag }}"
+        imagePullPolicy: {{ .Values.stubConnector.image.pullPolicy }}
         volumeMounts:
         - name: connector-metadata-volume
           mountPath: /app/stub-connector/build/resources/main/metadata
           readOnly: true
-      - name: connector
-        image: "{{ .Values.stubConnector.image.repository }}:{{ .Values.stubConnector.image.tag }}"
-        imagePullPolicy: {{ .Values.stubConnector.image.pullPolicy }}
         ports:
         - name: http
           containerPort: 80


### PR DESCRIPTION
Instead of creating new containers for them - mount them in the existing gateway and connector containers