### PR TITLE
Use GitHub release pre-releases

### DIFF
--- a/ci/build/release-pipeline.yaml
+++ b/ci/build/release-pipeline.yaml
@@ -78,7 +78,7 @@ spec:
       icon: file-document
       source:
         <<: *github_source
-        drafts: true
+        pre_release: true
         
     - name: release
       type: github-release


### PR DESCRIPTION
Drafts don't have tags. This means the `package` step fails to bump the
version number:

```
generate-chart-version

11:38:54 bumping release number...
11:38:54 cat: can't open 'release/tag': No such file or directory
```