### PR TITLE
EID-1483 Extend stub-connector authn request error scenarios

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
 
     configurations {
         common
+        dev_pki
         dropwizard
         dropwizard_assets
         opensaml
@@ -169,6 +170,10 @@ subprojects {
                 because "saml_lib_version 185 has a dep on bcprov-jdk15on:1.59 which is vulnerable to CVE-2018-1000180"
             }
         }
+
+        dev_pki(
+                "uk.gov.ida:ida-dev-pki:1.1.0-38"
+        )
 
         verify_saml_test(
                 "uk.gov.ida:saml-test:${saml_lib_version}",

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -4,4 +4,4 @@
 # Any new gradle configurations to be tested should be added here.
 
 # shellcheck disable=SC2034
-CONFIGURATIONS="common dropwizard eidas_saml ida_utils opensaml soft_hsm verify_saml"
+CONFIGURATIONS="common dropwizard eidas_saml ida_utils opensaml soft_hsm verify_saml dev_pki"

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -11,6 +11,7 @@ dependencies {
             configurations.opensaml,
             configurations.eidas_saml,
             configurations.common,
+            configurations.dev_pki,
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
@@ -41,19 +41,30 @@
         margin-bottom: 20px;
     }
     .submitBtn {
+      display: inline-block;
       font-family: Arial, sans-serif;
-      background-color: #00823b;
       color: #fff;
       padding: 10px;
+      margin: 5px;
       font-size: 1em;
       line-height: 1.25;
       border: none;
-      box-shadow: 0 2px 0 #003618;
       cursor: pointer;
       text-decoration: unset;
     }
-    .submitBtn:hover, .submitBtn:focus {
+    .submitBtnGreen {
+        background-color: #00823b;
+        box-shadow: 0 2px 0 #003618;
+    }
+    .submitBtnGreen:hover, .submitBtnGreen:focus {
       background-color: #00692f;
+    }
+    .submitBtnRed {
+        background-color: #E30707;
+        box-shadow: 0 2px 0 #9A0000;
+    }
+    .submitBtnRed:hover, .submitBtnRed:focus {
+      background-color: #D60C0C;
     }
 </style>
 <body class="main">
@@ -61,10 +72,15 @@
     <div class="logo"></div>
     <h1>Welcome to the eIDAS Proxy Node Connector Node</h1>
     <p>To start a Journey press the button below</p>
-    <a href="./RequestLow" class="submitBtn">Start Journey LOA Low</a>
-    <a href="./RequestSubstantial" class="submitBtn">Start Journey LOA Substantial</a>
-    <a href="./RequestHigh" class="submitBtn">Start Journey LOA High</a>
-    <a href="./BadRequest" class="submitBtn">Send Bad Request</a>
+    <div>
+        <a href="./RequestLow" class="submitBtn submitBtnGreen">Start Journey LOA Low</a>
+        <a href="./RequestSubstantial" class="submitBtn submitBtnGreen">Start Journey LOA Substantial</a>
+        <a href="./RequestHigh" class="submitBtn submitBtnGreen">Start Journey LOA High</a>
+    </div>
+    <div>
+        <a href="./MissingSignature" class="submitBtn submitBtnRed">Send request with missing signature</a>
+        <a href="./InvalidSignature" class="submitBtn submitBtnRed">Send request with invalid signature</a>
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Adds an extra error scenario to the stub-connector for an invalid
signature. It uses the test private key from the dev-pki repo. This key
does not match the certificate the proxy-node ESP will be using and so
should result in an invalid signature response.

Also updates the homepage and some styling to differentiate between
valid and invalid journeys.