### PR TITLE
Limit scope of hub egress rules to current namespace only.

### DIFF
--- a/chart/templates/hub-egress-destination-rules.yaml
+++ b/chart/templates/hub-egress-destination-rules.yaml
@@ -12,3 +12,5 @@ spec:
   host: istio-egressgateway.istio-system.svc.cluster.local
   subsets:
   - name: {{ .Release.Name }}-hub-egress
+  exportTo:
+  - "."

--- a/chart/templates/hub-egress-virtual-service.yaml
+++ b/chart/templates/hub-egress-virtual-service.yaml
@@ -27,3 +27,5 @@ spec:
         port:
           number: 443
       weight: 100
+  exportTo:
+  - "."


### PR DESCRIPTION
Fix an issue with overlapping rules getting in each other's way.