### PR TITLE
BAU: Fix Stub Connector entity ID mismatch causing invalid signature errors in ESP

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,16 +2,8 @@
 version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JAVA-COMFASTERXMLJACKSONCORE-450207:
+  SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
-        reason: Fix not yet available
-        expires: 2019-07-21T15:05:11.857Z
-  SNYK-JAVA-COMGOOGLEGUAVA-32236:
-    - '*':
-        reason: Fix not yet available
-        expires: 2019-07-24T13:00:48.365Z
-  SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917:
-    - '*':
-        reason: Fix not available yet
-        expires: 2019-07-26T16:07:31.690Z
+        reason: Fix not available
+        expires: 2019-11-30T19:21:05.816Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ repositories {
 
 ext {
     opensaml_version = '3.4.2'
-    dropwizard_version = '1.3.12'
-    utils_version = '2.0.0-360'
-    saml_lib_version = "${opensaml_version}-203"
+    dropwizard_version = '1.3.13'
+    utils_version = '2.0.0-370'
+    saml_lib_version = "${opensaml_version}-206"
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 
@@ -102,9 +102,8 @@ subprojects {
     dependencies {
         configurations.all {
             resolutionStrategy.dependencySubstitution {
-                substitute module("dom4j:dom4j:1.6.1") because "dom4j vulnerable to XML External Entity (XXE) Injection due to not validating the QName inputs, see CVE-2018-1000632" with module("org.dom4j:dom4j:2.1.1")
-                substitute module("org.eclipse.jetty:jetty-server") because "jetty-server dependency org.eclipse.jetty:jetty-util:9.4.14.v20181114 is vulnerable to CVE-2019-10247" with module("org.eclipse.jetty:jetty-server:9.4.17.v20190418")
-                substitute module("com.fasterxml.jackson.core:jackson-databind") because "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736" with module("com.fasterxml.jackson.core:jackson-databind:2.9.9")
+                substitute module("com.fasterxml.jackson.core:jackson-databind") because "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-174736" with module("com.fasterxml.jackson.core:jackson-databind:2.9.9.1")
+                substitute module("ca.juliusdavies:not-yet-commons-ssl:0.3.9") because "https://snyk.io/vuln/SNYK-JAVA-CAJULIUSDAVIES-30073" with module("ca.juliusdavies:not-yet-commons-ssl:0.3.11")
 
                 exclude group: "commons-beanutils", module: "commons-beanutils"
             }

--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -64,6 +64,8 @@ spec:
           value: "80"
         - name: CONNECTOR_NODE_BASE_URL
           value: https://{{ include "stubConnector.host" . }}
+        - name: CONNECTOR_NODE_ENTITY_ID
+          value: {{ include "connector.entityID" . }}
         - name: PROXY_NODE_ENTITY_ID
           valueFrom:
             secretKeyRef:

--- a/chart/templates/stub-connector-metadata.yaml
+++ b/chart/templates/stub-connector-metadata.yaml
@@ -27,7 +27,7 @@ spec:
     expiryMonths: 2
     organization: EU Member State
     organizationUnit: Test
-    location: EU
+    location: European Union
   certificateAuthority:
     secretName: {{ .Release.Name }}-connector-metadata-signing-cert
     namespace: {{ .Release.Namespace }}

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -79,6 +79,7 @@ spec:
       source:
         <<: *github_source
         pre_release: true
+        release: false
         
     - name: release
       type: github-release

--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -24,7 +24,7 @@ connectorMetadataConfiguration:
   trustStore:
     type: ${TRUSTSTORE_TYPES:-encoded}
     store: ${CONNECTOR_NODE_METADATA_TRUSTSTORE:-DefaultNotUsed}
-    password: ${CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD:-DefaultNotUsed}
+    password: ${CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
 
 replayChecker:
   redisUrl: ${REDIS_SERVER_URI:-http://DefaultNotUsed}

--- a/libs/eidas-saml-parser/pom.xml
+++ b/libs/eidas-saml-parser/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-gateway/pom.xml
+++ b/libs/proxy-node-gateway/pom.xml
@@ -273,7 +273,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-shared/pom.xml
+++ b/libs/proxy-node-shared/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-test/pom.xml
+++ b/libs/proxy-node-test/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-translator/pom.xml
+++ b/libs/proxy-node-translator/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/stub-connector/pom.xml
+++ b/libs/stub-connector/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/proxy-node-vsp-config/Dockerfile.internal
+++ b/proxy-node-vsp-config/Dockerfile.internal
@@ -8,10 +8,8 @@ COPY build.gradle build.gradle
 COPY settings.gradle settings.gradle
 COPY src src
 
-RUN gradle installDist
-
-ENTRYPOINT ["gradle"]
-CMD ["tasks"]
+RUN gradle --no-daemon installDist
+ENTRYPOINT ["gradle", "--no-daemon"]
 
 FROM openjdk:11-jre-slim
 

--- a/stub-connector/src/dist/config.yml
+++ b/stub-connector/src/dist/config.yml
@@ -12,6 +12,7 @@ logging:
     - type: logstash-console
 
 connectorNodeBaseUrl: ${CONNECTOR_NODE_BASE_URL}
+connectorNodeEntityId: ${CONNECTOR_NODE_ENTITY_ID}
 
 metadataPublishingConfiguration:
   metadataFilePath: ${CONNECTOR_METADATA_FILE_PATH:-/app/metadata/metadata.xml}
@@ -24,7 +25,7 @@ proxyNodeMetadataConfiguration:
   trustStore:
     type: ${TRUSTSTORE_TYPES:-encoded}
     store: ${PROXY_NODE_METADATA_TRUSTSTORE}
-    password: ${PROXY_NODE_METADATA_TRUSTSTORE_PASSWORD}
+    password: ${PROXY_NODE_METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
 
 credentialConfiguration:
   type: ${SIGNER_CONFIG_TYPE:-file}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
@@ -20,6 +20,11 @@ public class StubConnectorConfiguration extends Configuration {
     @Valid
     @NotNull
     @JsonProperty
+    private URI connectorNodeEntityId;
+
+    @Valid
+    @NotNull
+    @JsonProperty
     private CredentialConfiguration credentialConfiguration;
 
     @Valid
@@ -34,6 +39,10 @@ public class StubConnectorConfiguration extends Configuration {
 
     public URI getConnectorNodeBaseUrl() {
         return connectorNodeBaseUrl;
+    }
+
+    public URI getConnectorNodeEntityId() {
+        return connectorNodeEntityId;
     }
 
     public String getProxyNodeEntityId() {

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/ReceiveResponseResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/ReceiveResponseResource.java
@@ -78,7 +78,7 @@ public class ReceiveResponseResource {
 
         String authnRequestId = (String) session.getAttribute("authn_id");
 
-        ValidationContext validationContext = new ValidationContext(buildStaticParemeters(authnRequestId));
+        ValidationContext validationContext = new ValidationContext(buildStaticParameters(authnRequestId));
 
         ValidationResult validate = responseValidator.validate(response, validationContext);
 
@@ -117,7 +117,7 @@ public class ReceiveResponseResource {
         return new ResponseView(attributesByName, loa, validate.toString(), eidasRequestId, SAML_OBJECT_MARSHALLER.transformToString(decrypted));
     }
 
-    private Map<String, Object> buildStaticParemeters(String authnRequestId) {
+    private Map<String, Object> buildStaticParameters(String authnRequestId) {
         String responseDestination = configuration.getConnectorNodeBaseUrl() + "/SAML2/Response/POST";
 
         HashMap<String, Object> params = new HashMap<>();

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -105,7 +105,7 @@ public class SendAuthnRequestResource {
 
     private MessageContext generateAuthnRequestContext(HttpSession session, EidasLoaEnum loaType) throws ResolverException, ComponentInitializationException, MessageHandlerException {
         String proxyNodeEntityId = configuration.getProxyNodeMetadataConfiguration().getExpectedEntityId();
-        String connectorEntityId = configuration.getConnectorNodeBaseUrl().toString();
+        String connectorEntityId = configuration.getConnectorNodeEntityId().toString();
         Endpoint proxyNodeEndpoint = proxyNodeMetadata.getEndpoint(proxyNodeEntityId, IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
 
         List<String> requestedAttributes = Arrays.asList(

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -44,6 +44,13 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
     }
 
     @Test
+    public void shouldUseCorrectEntityIdInAuthnRequest() throws IOException, URISyntaxException {
+        final AuthnRequest authnRequest = getEidasAuthnRequest();
+
+        assertThat(authnRequest.getIssuer().getValue()).isEqualTo(ENTITY_ID);
+    }
+
+    @Test
     public void shouldReturnValidSamlResponse() throws Exception {
         String authnId = getAuthnRequestIdFromSession();
 
@@ -78,12 +85,14 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
         hasValidity(validSamlMessage, "INDETERMINATE");
     }
 
-
-    private String getAuthnRequestIdFromSession() throws URISyntaxException, IOException {
+    private AuthnRequest getEidasAuthnRequest() throws IOException, URISyntaxException {
         String html = getEidasRequest();
         String decodedSaml = HtmlHelpers.getValueFromForm(html, "SAMLRequest");
-        AuthnRequest request = new SamlParser().parseSamlString(decodedSaml);
-        return request.getID();
+        return new SamlParser().parseSamlString(decodedSaml);
+    }
+
+    private String getAuthnRequestIdFromSession() throws IOException, URISyntaxException {
+        return getEidasAuthnRequest().getID();
     }
 
     private void hasValidity(String samlMessage, String validity) throws URISyntaxException {

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/base/StubConnectorAppRuleTestBase.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/base/StubConnectorAppRuleTestBase.java
@@ -30,7 +30,9 @@ import static uk.gov.ida.saml.core.test.builders.CertificateBuilder.aCertificate
 public class StubConnectorAppRuleTestBase {
 
     protected static final String METADATA_PUBLISH_PATH = "/stub-connector-md-publish-path";
-    protected static final String METADATA_FILE_PATH =
+    protected static final String ENTITY_ID = "http://stub-connector/Connector";
+
+    private static final String METADATA_FILE_PATH =
             StubConnectorAppRuleTestBase.class.getClassLoader().getResource("metadata/test-stub-connector-metadata.xml").getPath();
 
     private Map<String, NewCookie> cookies;
@@ -66,6 +68,7 @@ public class StubConnectorAppRuleTestBase {
     @Rule
     public StubConnectorAppRule stubConnectorAppRule = new StubConnectorAppRule(
             ConfigOverride.config("connectorNodeBaseUrl", "http://stub-connector"),
+            ConfigOverride.config("connectorNodeEntityId", ENTITY_ID),
 
             ConfigOverride.config("proxyNodeMetadataConfiguration.url", metadataClientRule.baseUri() + "/proxy-node/metadata"), //
             ConfigOverride.config("proxyNodeMetadataConfiguration.expectedEntityId", "http://proxy-node/Metadata"),


### PR DESCRIPTION
Added a config value to the Stub Connector to ensure it uses the same entity ID in its SAML messages as is advertised in its metadata

Also make chart in the build pipeline a proper pre-release so Concourse won't publish the new release before it passes the tests, as per the [Concourse GitHub Release Resource documentation](https://github.com/concourse/github-release-resource).

Bump OpenSAML and Dropwizard versions.