### PR TITLE
EID-1483 Update acceptance tests again

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -27,7 +27,7 @@ Given("the stub connector supplies an authn request with {string}") do |issue|
     "a missing signature": "/MissingSignature",
     "an invalid signature": "/InvalidSignature"
   }
-  visit(ENV.fetch('STUB_CONNECTOR_URL') + scenario_path_map[issue])
+  visit(ENV.fetch('STUB_CONNECTOR_URL') + scenario_path_map[issue.to_sym])
 end
 
 Given('they login to stub idp') do


### PR DESCRIPTION
Need to convert the string to a symbol or the hash just returns `nil`.