### PR TITLE
EID-1483 Update acceptance tests to use regex

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -22,7 +22,7 @@ And('they progress through verify') do
   find('button', :text => 'Stub Idp Demo One').click
 end
 
-Given("the stub connector supplies an authn request with {string}") do |issue|
+Given(/^the stub connector supplies an authn request with (.*)$/) do |issue|
   scenario_path_map = {
     "a missing signature": "/MissingSignature",
     "an invalid signature": "/InvalidSignature"


### PR DESCRIPTION
**Sigh**

Cucumber wasn't recognising the changed scenario definitions and
linking them with a user step. Hopefully changing to use a regex will
help.