### PR TITLE
BAU: Misc fixes to Denmark pipeline and certs publisher

### DIFF
--- a/ci/build/metadata-ca-cert-request-test.yaml
+++ b/ci/build/metadata-ca-cert-request-test.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxy-node-metadata-ca
 spec:
   countryCode: GB
-  commonName: Verify Test Metadata CA
+  commonName: Proxy Node Test Metadata CA
   expiryMonths: 120
   organization: Cabinet Office
   organizationUnit: GDS

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -77,11 +77,10 @@ spec:
             RELEASE_NAMESPACE: ((namespace-deployer.namespace))
             CLUSTER_PRIVATE_KEY: ((cluster.privateKey))
             ERROR_PAGE_URL: https://www.integration.signin.service.gov.uk/proxy-node-error
-            CONNECTOR_ENTITY_ID: https://eidasconnector.test.eid.digst.dk/metadata
+            CONNECTOR_ENTITY_ID: https://eidasconnector.test.eid.digst.dk/Metadata
             CONNECTOR_METADATA_FQDN: eidasconnector.test.eid.digst.dk
-            HUB_FQDN: www.integration.signin.service.gov.uk
-            CONNECTOR_METADATA_PATH: /EidasNodeC/ConnectorMetadata
-            CONNECTOR_METADATA_SIGNING_TRUSTSTORE_BASE64: MIIHTgIBAzCCBwcGCSqGSIb3DQEHAaCCBvgEggb0MIIG8DCCBuwGCSqGSIb3DQEHBqCCBt0wggbZAgEAMIIG0gYJKoZIhvcNAQcBMCkGCiqGSIb3DQEMAQYwGwQUoc/NYEzJP3G1bZ9ImS0N8p1WU58CAwDDUICCBpjlFWznHraI5uRkuDyi9O7hvIAZm/Q5WE2LbFF1eEw/QVbUNwRR6cum+NZ/oAYxKe7boxrKYb5RjKSFH7vdb7McQA312lVTJpN/F1S6TDAFx5v4hUbYIDNOyo+SkkclqVhudTxMCCtv9n/8mkoBZf0DwbfObVVg4RD4A80UCYmwMOVjCIizUkCXUSNxMUGTi1C9Yci55zhXiTfydyQTb5sDKyfqE8hYYDns5J5zk5s6Y/TYwFiEjKWdjNNeVXMokTGnVp+kORL3XPnSOJrJbDkPBEv3ATPbZ2K+E0wfoZkTuCEJKgQxriKeyE0Fmx1x47yl8abFLrbExdwnzcbdhrrImere95rc1i/QO0kujnYiggXoSbcpNyN1BplAvrgeRATQfo5LZD0jQXO4fhCWNl4EQRK0OmNRHGCGHs/bcDaG3Lz+/Oq0wpnzbwkyl7UQWnJ0/IUjD+nEdAoeUskqGMNtxrSUgSrR/6Se1CWzUvEun5fgdPhKlyXyoonWm2KlmxSDyZy3X9LkVXfVryF0m5QpU3+8qC0Ppes25VOS2nApk78OBRZZlt2v4YMUm6tiXTBzmN3VQkfO1kx2y7I5bcwEo+6Y/FzcyEQ533xWU1JS1RialYboYEXgpG0ORolshzsYY6mgYZIYETczJ1pBckmSfQVA5fSYGA7F2ObZ/wK3XedPP/Lu8o/CuSb6073J/Ix/xWZ6AAzxGdwchhwiRWGa5QHpXdy/wskcaGIRKw4eO6whmQrIkosRS+3jLlAfsaseX1ItVEQfKvpFru+IW12fEkdh4ckr7YbjrqB2LnPQdK2mGPxuV48VLfo9IcUEKT/wtCVQvd1Ccr6PPgJZ2BftckA14aI7YpGJoJwB8jYIT/iAYytDKKTWLtWUJTOA4fRIYFEUpjRbcnV96yNCttv43dmVstUnY1NXKHY/gPW7wgbT8qcTMxFsC6BsXLE66Mzrtb2zZcKqHfKRzme3QbYkHM18dulf27PqgYgpcPU2EXNt7EbcJmk42JskdrgilQYkTHlxdfDRvwBYA18B283u1q9eabJv8DfpD+DaHH9IKNMPmSS57fND/cdDTtE2Y1afMvSFw69S9FAoW2FOzz31UhTPs0RtB9ioyx47tKpC6URexr1mkCBXxesvfMWCGbG8IIEFSO3ldYyU/zE2eiWQS26ldXY89outyS0Od3+P7msl3UzO7IBz2ZAF0O13i0l2aUlKI9B/1Nlp/1vm96MU+g9qfVcHrWIuC78hY54SIA/mGR8XErrHf80KQcU6l81FQDga6I9GF+6ZcVCCuEtyHEVU8kmjBSqS9KQmR9v6u4yrru7vtgtHndZR91ouQWZX89pQ6hDesLYtaQ4CAgSUr1Hob951Kl2MsLRmjRepzewlMxi36MieV5jM2dXMth00Ze5rTta4/tle2LZzKg6lZVc8jjOGsDTGuDsa7Z/iE8sShiKllktaCVyQUXc9H6JK5gfaps1FpoZO+OHy0qcQbAfEBIYpJ2+5qaHMUBDqvoEzTZl90PSRq3GYeI4n0zO+5QrQMrTpKeT6Tpi3teVpahylWEug66vg7AntnLgM6AL8h7jMJpqzSQNKA3mG/+F8Fgx75BRAThtOxAvVOuHzkAYa9DtVhdQcx44wBHybLHYk3wpK0Ycnob5LYMUPgmKFOUgQyNjqLH9lfvssKHzsg08/WlKYW6Fu9mgdJpD33oncRJe5UYl9CgkDtVCGoplMbPq8YriVBF0yTtw8AeLYofZrNQr2od8Tqi4nkDjQMfQ+34KZBKq9b+bHKkKB6om2bCCZ6lN2DQtK2AgbJZfkwvWkuYWC/Y2fICUV3Neo6h1V385TWos5xkoFWMIdG2DLlMqGPCvUyR8UmWjfTAy1F5WzSEdfZJoqu1oSs2KZqSODCedJIuXfYrwFYElcTe0ikk48aWzIqGi/I2LdHSxu56blgAT0211nAQOHMrbMQHSO4+UUyeEX4pQZxj4yelxRAeQia0z7l5tfPKFprqtB2k7hsDoMP6ZnrC6NHW1NNKYX9JIhJBxcMK+ahW7pVPJMGkrXyEscOK23f6B9V0wGER72BWSbWlaBzYX/VjfKmvCdXEFZhLnw+XUVGQ9zr79YewRD9GeCZdv6a0B35+LYBg5Kt1C5I0NOgli5aYqPmNFMMGo+1UPMwgSUce/ZaS2A4vGkn7WsRdeEgECHJFSZQxEzCSQHvbIUXPifJeby/zUEc/4qaW3FMCSe9qbMeivU20J6/YN4sTA+MCEwCQYFKw4DAhoFAAQU708rbMGeBfiz387bR2B1x3TFSG4EFLOzs68Na9FdYrAHclJjB7+zIQKkAgMBhqA
+            CONNECTOR_METADATA_PATH: /metadata
+            CONNECTOR_METADATA_SIGNING_TRUSTSTORE_BASE64: MIIGvgIBAzCCBncGCSqGSIb3DQEHAaCCBmgEggZkMIIGYDCCBlwGCSqGSIb3DQEHBqCCBk0wggZJAgEAMIIGQgYJKoZIhvcNAQcBMCkGCiqGSIb3DQEMAQYwGwQUo1ZSAm9Ckpy2xmF/IkdJZ1Vdq6ACAwDDUICCBgi3+GYHdirV+Ze/yzTrgMbHgzox5JxUC3FK7pcuUh49rFD41aiYqEJXeRqgA83/VDYA3Bn5dp4qLV64kJ4KTudd8cuWIEiWLmJ1RpfaDGZQpnT/RvkqBnHx+8CJiNaBOhThnDQh9ZqUO8htvTwMADEnw8RJMk5YWKe/0KRv5usR0LK85UVAB6oAQITPenSUDJ4Ca0/3CjfGjo32DGog9eEa1pXdNoUlfcyw4aZA1yZZJG2SABZR7VZJjeTrqh2+uU7S7YMCFj7W3HeDmoDxHqsgYih8Bui8HaF5uJKtML3cYX+ssYn82deklzJokC6ToTpUTCa/jGOKxOqXO1i8MRgb+8nySmjZzM5VLqSiOn60x630HV2ffB/8cdyDbDnjXJhDHAu0jASimvZ5QOKmmRhNBTU+2Og864BjhdfOSnQkQ8ZTtlYf1e8GP33pSI7U8mSZz8M1DE389XkcWoA2vOytKc+4+qbdWtY3EvSx46ToWm9BpvI0XiQpZACYeFrUa+e15NuWSrt8CW/6JPDswsWCoT5Tib+7mknR8sWbR3ChtVCV/cwpwEZVxfMFeV7kT+WFZ6j5PYWzRC5d2c6xPkNYLNE/DsptONTdr5GXCaEgJNsvOvtwGQxRQkkn8BZZ1EWHhzhxnih9d9ucj9Dn4SCXVi4Zt5fyS93ROXxeoatVH4bs1l1L/THqDzlExwRr/mcZPfrjhzsPCrRAtd79byXF069KVbSkoRfdV85OMYlMDT546sbaxu/wKESmjm7EiuUFBZo8d90SnG4w3RYPMVOfKMBaVJgYFjNyjD1Jqe+2XaTo/bvrv2QMRVwBiBT89lKFZIR+tVnlr5PkeNhKK35oc0e4U56RzHx5OL/rSeL00rJ7Paq74Hm/j+8iIffjiNu1hji/8N7QaWMKtlNWIg7dU5ywc4VxyMtTFNH51RQiOlp3XVEzQhVusyHCZt+bkG2hFGTK0GbplGDjwyuC/NGmaFyA88dLwdMxK6B3BVEWdg2y5boDtApjKjOmIkqVxtyAh/oFUSquLbtcYtuZHV1jsFDyg580OVra/wIxv5UnO2iZDb6p79sE34V751v9SG48I8/+ojLrj467x9vaQLkrsqmrgWUO0j9TE92bQWVjqgCDQv+r+E5P1ATQxcbEOIEAiqWbWJd/+7xmXjKMrh3u/w374GLmsTMd59/sxlMhMq+8Y2h8jjt04R+LJCjaeuXQVyQ/7pRc7DjoNWyHf5uJmgnsWmsn3C5go0taA3YoyKsxlug+/nyTQwLYojDPIljNcTxAC86lYKNW1Wd29t7mx5U5/DCi8S5Qe6s0s45RZ6tCska7i3sDEdWJjJghn6B6v7arkUPx7W/4DFYJd3DLj275o7FSGCW5063IC1+m0ltwU5bGY4FJdtxPl8iAUxJ3G+fJZsyxfD55lxycQNKcYI7tx9Fi4EVCGCt1OjUVVoH4nXqcXcp6ST+NsVIvvvml6RQbwc76qOCjcQX+79HsEza+YOVEtkZ+qkWbTT+9lO4U8Nzw96P/p+imDH6yWxX6MlcTUv8Yoyny8olnL8SVly2W9xj21NIO2SwLG3KoRraFv+4gThwX5IfXzpzDe1OoefnSDnggwlmKDMo2fVXChArFcNhKxzVWsC5ZtL7JLRRZpa8/4FUc9L/LmiDov1VJq3cGoYQTtPp0+roKYNpPxgyES/xlZ2XiPJLU1Ox8ya2AMjvRBi68/xtvOhlluq267DEyIC3r+O4Ng7uyyaTgl209f3zyyQHZTf3twcqjA1//I14YcZ/YeK9ndjpvCKAAoS3XBiIDWhcFWeHVpWafvJia4I4qnIIgaL6Cjl8UccvoofDTCMaYnLtY+w0v5N9iLoeDGCYFhP0/ebJ4E3cOrdnIjSLzEXoyJIrD3R95t+Y8ONt0jBywXdNxgITa5ubArivTjMxHLEYpgha6YzkKwA2YYjNuy1Siz8n7NAoNV1VcQxYcVBGUn9VwrqYmOXBGmSr3FiTGQjwF3EiSEdAe2csA28JfzBn3+SpXwy3hIGr143/d0TRBj9K5KU0TtuuXeAKKvHkxxDA+MCEwCQYFKw4DAhoFAAQUh6lkOj7q0LTc7DzYOXdSwVruB5kEFEFIPKQbCc3szmUtiZ5BM3u5L9/PAgMBhqA=
             CLOUDHSM_IP: ((cluster.cloudHsmIp))
           run:
             path: /bin/bash
@@ -104,7 +103,6 @@ spec:
                 --set "global.cluster.domain=${CLUSTER_DOMAIN}" \
                 --set "global.cloudHsm.ip=${CLOUDHSM_IP}" \
                 --set "gateway.errorPageURL=${ERROR_PAGE_URL}" \
-                --set "hubFqdn=${HUB_FQDN}" \
                 --set "connector.entityID=${CONNECTOR_ENTITY_ID}" \
                 --set "connector.metadata.fqdn=${CONNECTOR_METADATA_FQDN}" \
                 --set "connector.metadata.path=${CONNECTOR_METADATA_PATH}" \
@@ -112,6 +110,43 @@ spec:
                 --set "translator.connectorNodeNationalityCode=${CONNECTOR_NODE_NATIONALITY_CODE}" \
                 --output-dir "./manifests/" \
                 ./release/*.tgz
+
+      - task: deploy-manifests
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+          - name: manifests
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            KUBERNETES_API: kubernetes.default.svc
+            RELEASE_NAME: dk-integration
+            RELEASE_NAMESPACE: ((namespace-deployer.namespace))
+            APP_NAME: proxy-node
+          run:
+            path: /bin/bash
+            args:
+            - -eu
+            - -c
+            - |
+              echo "configuring kubectl"
+              echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+              kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+              kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+              kubectl config set-context deployer --user deployer --cluster self
+              kubectl config use-context deployer
+
+              echo "applying chart to ${RELEASE_NAMESPACE} namespace..."
+              kapp deploy \
+                -y \
+                --namespace "${RELEASE_NAMESPACE}" \
+                --allow-ns "${RELEASE_NAMESPACE}" \
+                --app "${APP_NAME}" \
+                --diff-changes \
+                --labels "app=${APP_NAME}" \
+                -f ./manifests/
+
 
     - name: deploy-nl-integration
       serial: true

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -142,7 +142,7 @@ spec:
                 -y \
                 --namespace "${RELEASE_NAMESPACE}" \
                 --allow-ns "${RELEASE_NAMESPACE}" \
-                --app "${APP_NAME}" \
+                --app "${RELEASE_NAME}-${APP_NAME}" \
                 --diff-changes \
                 --labels "app=${APP_NAME}" \
                 -f ./manifests/
@@ -176,7 +176,6 @@ spec:
             ERROR_PAGE_URL: https://www.integration.signin.service.gov.uk/proxy-node-error
             CONNECTOR_ENTITY_ID: https://acc-eidas.minez.nl/EidasNodeC/ConnectorMetadata
             CONNECTOR_METADATA_FQDN: acc-eidas.minez.nl
-            HUB_FQDN: www.integration.signin.service.gov.uk
             CONNECTOR_METADATA_PATH: /EidasNodeC/ConnectorMetadata
             CONNECTOR_METADATA_SIGNING_TRUSTSTORE_BASE64: MIII3gIBAzCCCJcGCSqGSIb3DQEHAaCCCIgEggiEMIIIgDCCCHwGCSqGSIb3DQEHBqCCCG0wgghpAgEAMIIIYgYJKoZIhvcNAQcBMCkGCiqGSIb3DQEMAQYwGwQUZxb5GxfKDI2ORlrCoHrZZNk089sCAwDDUICCCCh9k7vzD6Ng+qaSICDv99LzLPOxKE2cCEr68Xqwig4iCIM7rlCXp1dZYxcxFrRLyZLwPmQMve5UwMq1JVuxcq2FiuQl/uHXSv2orYO0KYJ/ldvcwDLxObvIMkUFKTIvN27VT/wdGzz9Vo3Nv1TKXpd9kyV74woSPR1syqQC2MwriXyxa6w+R+l5I7DCFfgZVAF+YSJOWzS1AGQ4HU1CQbw5dDhmhSkJmC4Mq+Paq3x89eSTv6NUE7Rr3BlrquNhcVDtdEXup7gm/fyZTPyB6feaW6eWij0HtiQ7jZa5MMfR2+olfPEuuE+QiNYTJrTx5WcyHLRBaYKQFPw5Napgvv99gTFiG/SWjjXblKgsp8KlhnyfYAjHbJEB+AzpffuKbkbejGoAROYuBAUwMZ7Rcf2yHFM+HoqTsBJ8eoOSwHj99DB9JM9SyJlcI9+OdlUOP3XTJXIRyevs/pKuwWf39BA+ECwK6xPXiCgQK4iA1NdRpqhPK5pMKcbrUhe5uzn6hDlScdfTbSFBDpsP8V8/JLLQoQs8Reobn+55JPVLKJxmSZjPKQZCYMTl56DhziklRkOFJ8+KkHoobYqYRsGlXZO7nvVh9bHgOk0q/wkNIa22KW7yUKBYDe6J3tp7C5SWymvP++FrpLl7g+DAnpcLaHb1j6jX2GlCi79Y3rJUja5T85Y6pBH4svTzlZ1/SYon2nAJGbwv+rgn3W7Ke1hqLJB/QxfgwKM5ECAWSuw/psrc0G5YGCPVVNrgKq65lZeCks+bSIkaLvrSBXSEAVFOYeBzaJa1pKmxMfwu6wG44RLy94IaRjsW1C60zEhhfKei+oCUmRwnpBd70GjIwx+afEF1Lwc3U5Z5PVE6O/FZRnBsdoOlFSlIMir3XRLq8eQZdU8YfpApNoAbd/xILuSKv4gVkX39QKi1UAtwKPopya+SuyGRvfB+I/IraMJaSHlqWAy0KRWNHB1quIneq16l/QHGxGkG5x6r1lMWMVAOvMDxg0wSDn7tpar6CSwVLwZ7864zyeWQUQe+SJTMjQ2Cgue1w0qdMnXd3nTmylaWaS4FK1mBDpaRPHzZMQuLQxgSc25Pt1fums/exeY/hQufWoL6F12wSMfrrW60Md4tHNQpAfXAfqraDWyo4jszJ7nQ4U7qkpl7z4Lh2EgSkgJXyLkzIeey2EtZw++wVH4rQ2aUlZNicRITycMKNbGWs6Ly9K/F+BbJP28z8OLXF+WxSW28Xxg0LRlt14WEcYrHW5Ozf4GtJiCUmYSGoEFZ91LCR37GRDOWCS9h/kKScfWUOeP0v0MXkd5hjQoFKtE0jk6jck3BqjZcWMXDgQRZtbGEismu0/N4yFCcZVwDI2EZWroZD1buYk+jUFZo/ub3WcTQgFRbKq54PgNf9EzGJdjVcOsdkiX43od2GpPfA70wpfMUPXqgjgs50+ysM88biN2IsFyZ8BmJekie9l2CodMJrT2u2f4CkKLU7TZ5IfBP/tmdIGHDIKMf3TjxKm1JFJhPd7cBq1fqcef56UbUwGXWjwPhiavLYLgGfFz+/f4EypBFyNSl4kB+7Z4F6L+eEUeA7kswlcsxnQFaGnTMUiUmAFWIBZfcbGazTFtnB/BJ4E9ijbQ37q+ObxZso+7DJRsGc1TQAYTmUkQdB7p3xkHzVP6fm/eAiFYXZCokaxGRKjdORsEYjM8eBzOre1Pn+gWXMTxD+GOyjbsQ+3AI3YzVslPRBtNese7d5APrLEB1+ly4SDhTrVbKhbOaacw1EuSMIJIrq6sSzzs9j4Jivsc9+Gwuh7xyJ+yoiOUPSpMQfNs7c7v6Ak/0RWC2Sl5e4BPzeKdJe+ijjntKJ0F3Y8papTmujNbbS3GATvlBMK3BX8wqUvgwKYyyQpCCIUXuwissaGS4l1YHoE85UznukIpEkeew3AYZo3miAGjXA9lnOi4cNMgiawPie0Rkfn1pikZGmS2bBaL7VWMHOtJ9h+zlwXPTy1lse8L4xsxWVxt0ml6FOwN5+GIlJUDyrQplHMJEiHU49VBqY+oownI9wOAfJ346/AcCqeD4txoSuVbAXniet8+igOBF4d+yqW9+L/TDT0R+++a9Dhw5be0A2N716R+Rlf/7kEWARWBS1C6JJYTwVm9FBkzh5VkGRsrHSUERAAS3yiU15Fayi9aRBseDheW8EFzlu/ys8xeYOLwUQcaUnQ3xRvkHnPo5v5fDDES5gNHp6Vmp6Ix+FmBweFnQEOt2aN+3W+XUFGs7RILbCFai20bp9QwJkLoFAI9GISHjazJ/7wDWsuh2B1SrIh1eVTb9LXBUmy5SPZml/y7EFVcRqShZTulTLmNuNOb/A8sxAenapDTEa7vzsiWAGFZsHITp52Uhva8/GA3CF9F9Xvl/u1I9mbhgztEw5mrUvAoTtWoOAcWyEiDYSECbcYTdTbMkEhpnxtx2Uj9uWp0VlpGh7UZLOucl5dQlYpDuWTFML9jaEiVDPlEnAWdMfrKWmtEJfJRao7ge8sDd0754bxp1dsn3yNRXP3k85TesFtbRDFNMWhlaH7btNqMyEEQorc0y5yFbPKcUK3kihRzciXbV0pIs+iZ2ROYjs+ku2Lc80x3yILeJ0Vl8CqUAuTSB8iugt2UNtg9lYlyW1fE1T4xWLz42Od9JEtIJ67ZoeClD4Bc2h4EywxCuBqL0qMI/S2VQBqMHDXbJZ5xcRh0HJTLo2uBvt1efhnv6e4IrvsNmLKd4DPWesRINSaT5AHBYfbx55EAAg+550lSHE9zS/N9tGMaw+mxGLTUwPjAhMAkGBSsOAwIaBQAEFISTISszKL1zNdAk/1Nfw4TcSeScBBTghZOjGy64pGOjSh5pqlB4vMmB6gIDAYag
             CLOUDHSM_IP: ((cluster.cloudHsmIp))
@@ -201,7 +200,6 @@ spec:
                 --set "global.cluster.domain=${CLUSTER_DOMAIN}" \
                 --set "global.cloudHsm.ip=${CLOUDHSM_IP}" \
                 --set "gateway.errorPageURL=${ERROR_PAGE_URL}" \
-                --set "hubFqdn=${HUB_FQDN}" \
                 --set "connector.entityID=${CONNECTOR_ENTITY_ID}" \
                 --set "connector.metadata.fqdn=${CONNECTOR_METADATA_FQDN}" \
                 --set "connector.metadata.path=${CONNECTOR_METADATA_PATH}" \
@@ -241,7 +239,7 @@ spec:
                 -y \
                 --namespace "${RELEASE_NAMESPACE}" \
                 --allow-ns "${RELEASE_NAMESPACE}" \
-                --app "${APP_NAME}" \
+                --app "${RELEASE_NAME}-${APP_NAME}" \
                 --diff-changes \
                 --labels "app=${APP_NAME}" \
                 -f ./manifests/

--- a/ci/integration/metadata-ca-cert-request-integration.yaml
+++ b/ci/integration/metadata-ca-cert-request-integration.yaml
@@ -7,7 +7,7 @@ metadata:
   name: proxy-node-metadata-ca
 spec:
   countryCode: GB
-  commonName: Verify Integration Metadata CA
+  commonName: Proxy Node Integration Metadata CA
   expiryMonths: 120
   organization: Cabinet Office
   organizationUnit: GDS

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlApplication.java
@@ -133,7 +133,7 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
         environment.jersey().register(new CatchAllExceptionMapper());
     }
 
-    private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlParserConfiguration configuration, MetadataResolverBundle hubMetadataResolverBundle) throws Exception {
+    private EidasAuthnRequestValidator createEidasAuthnRequestValidator(EidasSamlParserConfiguration configuration, MetadataResolverBundle connectorMetadataResolverBundle) throws Exception {
         MessageReplayChecker replayChecker = configuration.getReplayChecker().createMessageReplayChecker("eidas-saml-parser");
         DestinationValidator destinationValidator = new DestinationValidator(
                 configuration.getProxyNodeAuthnRequestUrl(), configuration.getProxyNodeAuthnRequestUrl().getPath());
@@ -146,7 +146,7 @@ public class EidasSamlApplication extends Application<EidasSamlParserConfigurati
                 replayChecker,
                 new ComparisonValidator(),
                 destinationValidator,
-                new AssertionConsumerServiceValidator(hubMetadataResolverBundle.getMetadataResolver())
+                new AssertionConsumerServiceValidator(connectorMetadataResolverBundle.getMetadataResolver())
         );
     }
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/metadata/MetadataCertsPublishingResource.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/metadata/MetadataCertsPublishingResource.java
@@ -86,8 +86,8 @@ public class MetadataCertsPublishingResource {
                 .filter(s -> !s.isBlank())
                 .map(c -> c.substring(0, c.indexOf(END_LINE)))
                 .map(c -> c.replace("\n", ""))
-                .filter(c -> !c.equals(metadataSigningCertBase64.replace("\n", "").trim()))
                 .map(String::trim)
+                .filter(c -> !c.equals(metadataSigningCertBase64.replace("\n", "").trim()))
                 .map(this::createCert)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
- Add missing DK deployment config
- Remove `HUB_FQDN` as `www.integration.signin.service.gov.uk` is the default value in `values.yml`
- Give deployments different unique names
- Filter certs on sanitised values
- Make cert naming consistent
- Rename metadata resolver to correct name