### PR TITLE
BAU: Fix the integration deployment

### DIFF
--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -144,7 +144,7 @@ spec:
                 --allow-ns "${RELEASE_NAMESPACE}" \
                 --app "${RELEASE_NAME}-${APP_NAME}" \
                 --diff-changes \
-                --labels "app=${APP_NAME}" \
+                --labels "${RELEASE_NAME}-${APP_NAME}" \
                 -f ./manifests/
 
 
@@ -239,7 +239,7 @@ spec:
                 -y \
                 --namespace "${RELEASE_NAMESPACE}" \
                 --allow-ns "${RELEASE_NAMESPACE}" \
-                --app "${RELEASE_NAME}-${APP_NAME}" \
+                --app "${APP_NAME}" \
                 --diff-changes \
                 --labels "app=${APP_NAME}" \
                 -f ./manifests/

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -234,12 +234,15 @@ spec:
               kubectl config set-context deployer --user deployer --cluster self
               kubectl config use-context deployer
 
+              echo "Deleting old version of the deployment..."
+              kapp delete -a ${APP_NAME}
+
               echo "applying chart to ${RELEASE_NAMESPACE} namespace..."
               kapp deploy \
                 -y \
                 --namespace "${RELEASE_NAMESPACE}" \
                 --allow-ns "${RELEASE_NAMESPACE}" \
-                --app "${APP_NAME}" \
+                --app "${RELEASE_NAME}-${APP_NAME}" \
                 --diff-changes \
-                --labels "app=${APP_NAME}" \
+                --labels "app=${RELEASE_NAME}-${APP_NAME}" \
                 -f ./manifests/


### PR DESCRIPTION
`kapp` labels should match app names and each deployment in the same namespace should have a unique app/label name