### PR TITLE
BAU: Fix NetworkPolicy name collisions

### DIFF
--- a/chart/templates/esp-network-policy.yaml
+++ b/chart/templates/esp-network-policy.yaml
@@ -1,8 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: esp-network-policy
+  name: {{ .Release.Name }}-esp-network-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: esp
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/esp-redis-network-policy.yaml
+++ b/chart/templates/esp-redis-network-policy.yaml
@@ -1,8 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: esp-redis-network-policy
+  name: {{ .Release.Name }}-esp-redis-network-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: esp-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/gateway-redis-network-policy.yaml
+++ b/chart/templates/gateway-redis-network-policy.yaml
@@ -1,8 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: gateway-redis-network-policy
+  name: {{ .Release.Name }}-gateway-redis-network-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gateway
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/translator-network-policy.yaml
+++ b/chart/templates/translator-network-policy.yaml
@@ -1,8 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: translator-network-policy
+  name: {{ .Release.Name }}-translator-network-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: translator
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:

--- a/chart/templates/vsp-network-policy.yaml
+++ b/chart/templates/vsp-network-policy.yaml
@@ -1,8 +1,13 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: vsp-network-policy
+  name: {{ .Release.Name }}-vsp-network-policy
   namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vsp
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   podSelector:
     matchLabels:


### PR DESCRIPTION
We're deploying these _n_ times to the same namespace so we need to
include something extra in the NetworkPolicy names.