### PR TITLE
EID-1553: Set correct intermediate metadata cert validity period

### DIFF
--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -23,7 +23,7 @@ spec:
   samlSigningCertRequest:
     countryCode: GB
     commonName: Verify Proxy Node SAML Signing
-    expiryMonths: 2
+    expiryMonths: 3
     organization: Cabinet Office
     organizationUnit: GDS
     location: London

--- a/chart/templates/stub-connector-metadata.yaml
+++ b/chart/templates/stub-connector-metadata.yaml
@@ -24,7 +24,7 @@ spec:
   samlSigningCertRequest:
     countryCode: EU
     commonName: Stub Connector SAML Signing
-    expiryMonths: 2
+    expiryMonths: 3
     organization: EU Member State
     organizationUnit: Test
     location: European Union

--- a/ci/prod/intermediate-certificate-request.yaml
+++ b/ci/prod/intermediate-certificate-request.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   countryCode: GB
   commonName: Verify Proxy Node Metadata CA
-  expiryMonths: 120
+  expiryMonths: 60
   organization: Cabinet Office
   organizationUnit: GDS
   location: London


### PR DESCRIPTION
Intermediate metadata certs in prod should have a validity of 5 years, the same as our current certs.
SAML signing certs are rotated every 3 months.