### PR TITLE
[DO NOT MERGE] BAU: stop pipeline stalling if `test` fails

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -98,6 +98,14 @@ spec:
         pre_release: true
         release: false
         
+    - name: last-release
+      type: github-release
+      icon: file-document
+      source:
+        <<: *github_source
+        pre_release: true
+        release: true
+        
     - name: release
       type: github-release
       icon: tag
@@ -305,7 +313,7 @@ spec:
           passed: ["build-base-images"]
           trigger: true
           params: {skip_download: true}
-        - get: release
+        - get: last-release
 
       - task: generate-chart-values
         config:
@@ -363,7 +371,7 @@ spec:
           platform: linux
           image_resource: *task_toolbox
           inputs:
-          - name: release
+          - name: last-release
           outputs:
           - name: chart-version
           params:
@@ -375,7 +383,7 @@ spec:
             - -c
             - |
               echo "bumping release number..."
-              CURRENT_TAG=$(cat release/tag)
+              CURRENT_TAG=$(cat last-release/tag)
               awk -F. '/[0-9]+\./{$NF++;print}' OFS=. <<< "${CURRENT_TAG}" > chart-version/tag
               NEW_TAG=$(cat chart-version/tag)
               echo "${NEW_TAG}" > chart-version/name


### PR DESCRIPTION
Currently, if `test` fails, then the release will remain in the pre-release state. This means that it will not get picked up by the new run of the pipeline. Thus, the next run of package will just republish the old release and thus test will never trigger again.

We discovered this bug in the DCS pipeline, which is very similar to the proxy node's. See https://github.com/alphagov/doc-checking/commit/c32445c95c055545228013904f2ca25bafafd769 for the equivalent change to the DCS pipeline.