### PR TITLE
[DO NOT MERGE] ZDD pipeline

### DIFF
--- a/ci/build/zdd-pipeline.yaml
+++ b/ci/build/zdd-pipeline.yaml
@@ -151,13 +151,13 @@ resources:
 
 groups:
   - name: proxy-node
-    jobs: [build, package, roll-test, test, release]
+    jobs: [build, package, roll-test, test, zdd, release]
   - name: base-images
     jobs: [build-base-images]
   - name: test
-    jobs: [roll-test, test]
+    jobs: [roll-test, test, zdd]
   - name: all
-    jobs: [build-base-images, build, package, roll-test, test, release]
+    jobs: [build-base-images, build, package, roll-test, test, zdd, release]
 
 jobs:
 
@@ -404,6 +404,14 @@ jobs:
                   --key "${KEY_ID}" \
                   "./${CHART_NAME}"
 
+      - put: tests-image
+        get_params: {skip_download: true}
+        params:
+          cache: true
+          build: src/proxy-node-acceptance-tests
+          tag_file: src/.git/short_ref
+          tag_as_latest: true
+          tag_prefix: v
       - put: chart
         params:
           name: chart-version/name
@@ -411,6 +419,8 @@ jobs:
           globs:
             - chart-package/*
             -
+
+
   - name: roll-test
     serial: true
     serial_groups: ["package"]
@@ -495,14 +505,6 @@ jobs:
                   --app "${RELEASE_NAME}-${APP_NAME}" \
                   --diff-changes \
                   -f ./manifests/
-      - put: tests-image
-        get_params: {skip_download: true}
-        params:
-          cache: true
-          build: src/proxy-node-acceptance-tests
-          tag_file: src/.git/short_ref
-          tag_as_latest: true
-          tag_prefix: v
       - put: chart
 
   - name: test
@@ -511,9 +513,9 @@ jobs:
     plan:
 
       - get: tests-image
-        passed: ["roll-test"]
       - get: chart
         passed: ["roll-test"]
+        trigger: true
 
       - task: test-chart-package
         image: tests-image
@@ -526,6 +528,38 @@ jobs:
             STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                cd /
+                bundle exec cucumber --strict --tags "not @ignore"
+
+
+
+  - name: zdd
+    serial: true
+    serial_groups: ["package"]
+    plan:
+
+      - get: tests-image
+        passed: ["package"]
+        trigger: true
+
+      - task: test-chart-package
+        image: tests-image
+        attempts: 2
+        timeout: 15m
+        config:
+          platform: linux
+          params:
+            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            STUB_IDP_USER: "stub-idp-demo-one"
+            SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
+            ZDD: true
           run:
             path: /bin/bash
             args:

--- a/ci/build/zdd-pipeline.yaml
+++ b/ci/build/zdd-pipeline.yaml
@@ -154,6 +154,8 @@ groups:
     jobs: [build, package, roll-test, test, release]
   - name: base-images
     jobs: [build-base-images]
+  - name: test
+    jobs: [roll-test, test]
   - name: all
     jobs: [build-base-images, build, package, roll-test, test, release]
 
@@ -536,7 +538,7 @@ jobs:
 
   - name: release
     serial: true
-    serial_groups: ["package"]
+    serial_groups: ["test"]
     plan:
 
       - get: chart

--- a/ci/build/zdd-pipeline.yaml
+++ b/ci/build/zdd-pipeline.yaml
@@ -1,0 +1,542 @@
+github_source: &github_source
+  uri: https://github.com/alphagov/verify-proxy-node.git
+  organization: alphagov
+  owner: alphagov
+  repository: verify-proxy-node
+  github_api_token: ((github.api-token))
+  access_token: ((github.api-token))
+  approvers: ((trusted-developers.github-accounts))
+  required_approval_count: 2
+  commit_verification_keys: ((trusted-developers.gpg-keys))
+
+harbor_source: &harbor_source
+  username: ((harbor.harbor_username))
+  password: ((harbor.harbor_password))
+  harbor:
+    url: ((harbor.harbor_url))
+    prevent_vul: "false"
+  notary:
+    url: ((harbor.notary_url))
+    root_key: ((harbor.root_key))
+    delegate_key: ((harbor.ci_key))
+    passphrase:
+      root: ((harbor.notary_root_passphrase))
+      snapshot: ((harbor.notary_snapshot_passphrase))
+      targets: ((harbor.notary_targets_passphrase))
+      delegation: ((harbor.notary_delegation_passphrase))
+
+task_toolbox: &task_toolbox
+  type: docker-image
+  source:
+    repository: govsvc/task-toolbox
+    tag: "1.2.0"
+
+resource_types:
+
+  - name: github
+    type: registry-image
+    source:
+      repository: "govsvc/concourse-github-resource"
+      tag: "v0.0.1"
+
+  - name: harbor
+    type: docker-image
+    privileged: true
+    source:
+      repository: govsvc/gsp-harbor-docker-image-resource
+      tag: "0.0.1553882420"
+
+resources:
+
+  - name: src
+    type: github
+    icon: github-circle
+    source:
+      <<: *github_source
+      ignore_paths: [cloudhsm, proxy-node-vsp-config, ci/sandbox]
+      branch: master
+
+  - name: vsp-src
+    icon: github-circle
+    type: git
+    source:
+      uri: https://github.com/alphagov/verify-service-provider.git
+      branch: master
+
+  - name: vsp-config
+    icon: check-outline
+    type: github
+    source:
+      <<: *github_source
+      paths: [proxy-node-vsp-config]
+      branch: master
+
+  - name: cloudhsm-config
+    type: github
+    icon: folder-key-network-outline
+    source:
+      <<: *github_source
+      paths: [cloudhsm]
+      branch: master
+
+  - name: chart
+    type: github-release
+    icon: file-document
+    source:
+      <<: *github_source
+      pre_release: true
+      release: false
+
+  - name: release
+    type: github-release
+    icon: tag
+    source:
+      <<: *github_source
+
+  - name: tests-image
+    type: harbor
+    icon: code-tags-check
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/acceptance-tests
+
+  - name: gateway-image
+    type: harbor
+    icon: gate
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/gateway
+
+  - name: translator-image
+    type: harbor
+    icon: file-xml
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/translator
+
+  - name: parser-image
+    type: harbor
+    icon: page-next
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/parser
+
+  - name: stub-connector-image
+    type: harbor
+    icon: power-plug
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/stub-connector
+
+  - name: cloudhsm-client-image
+    type: harbor
+    icon: folder-key-network
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/cloudhsm-client
+
+  - name: cloudhsm-jce-image
+    type: harbor
+    icon: puzzle
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/cloudhsm-jce-gradle
+
+  - name: verify-service-provider-image
+    type: harbor
+    icon: marker-check
+    source:
+      <<: *harbor_source
+      repository: registry.((cluster.domain))/eidas/verify-service-provider
+
+groups:
+  - name: proxy-node
+    jobs: [build, package, test, release]
+  - name: base-images
+    jobs: [build-base-images]
+  - name: all
+    jobs: [build-base-images, build, package, test, release]
+
+jobs:
+
+  - name: build-base-images
+    serial: true
+    serial_groups: [build-base-images]
+    plan:
+      - in_parallel:
+          - get: src
+          - get: vsp-src
+            trigger: true
+          - get: cloudhsm-config
+            trigger: true
+          - get: vsp-config
+            trigger: true
+      - in_parallel:
+          - put: cloudhsm-client-image
+            get_params: {skip_download: true}
+            params:
+              build: src/cloudhsm
+              tag_file: src/.git/short_ref
+              tag_as_latest: true
+              tag_prefix: v
+          - put: cloudhsm-jce-image
+            get_params: {skip_download: true}
+            params:
+              build: src/cloudhsm/base-images/jdk11-jce-gradle
+              tag_file: src/.git/short_ref
+              tag_as_latest: true
+              tag_prefix: v
+          - put: verify-service-provider-image
+            get_params: {skip_download: true}
+            params:
+              build: vsp-src
+              build_args: {VERIFY_USE_PUBLIC_BINARIES: "false"}
+              dockerfile: vsp-config/proxy-node-vsp-config/Dockerfile
+              tag_file: src/.git/short_ref
+              tag_as_latest: true
+              tag_prefix: v
+
+  - name: build
+    serial: true
+    serial_groups: [build-base-images]
+    plan:
+      - in_parallel:
+          - get: src
+            trigger: true
+          - get: cloudhsm-jce-image
+            passed: ["build-base-images"]
+            trigger: true
+            params: {skip_download: true}
+      - in_parallel:
+          limit: 3
+          fail_fast: true
+          steps:
+            - put: gateway-image
+              get_params: {skip_download: true}
+              params:
+                cache: true
+                build: src
+                build_args:
+                  component: proxy-node-gateway
+                tag_file: src/.git/short_ref
+                tag_as_latest: true
+                tag_prefix: v
+            - put: translator-image
+              get_params: {skip_download: true}
+              params:
+                cache: true
+                build: src
+                dockerfile: src/cloudhsm/base-images/jdk11-jre/Dockerfile
+                build_args:
+                  component: proxy-node-translator
+                tag_file: src/.git/short_ref
+                tag_as_latest: true
+                tag_prefix: v
+            - put: parser-image
+              get_params: {skip_download: true}
+              params:
+                cache: true
+                build: src
+                build_args:
+                  component: eidas-saml-parser
+                tag_file: src/.git/short_ref
+                tag_as_latest: true
+                tag_prefix: v
+            - put: stub-connector-image
+              get_params: {skip_download: true}
+              params:
+                cache: true
+                build: src
+                dockerfile: src/cloudhsm/base-images/jdk11-jre/Dockerfile
+                build_args:
+                  component: stub-connector
+                tag_file: src/.git/short_ref
+                tag_as_latest: true
+                tag_prefix: v
+            - put: tests-image
+              get_params: {skip_download: true}
+              params:
+                cache: true
+                build: src/proxy-node-acceptance-tests
+                tag_file: src/.git/short_ref
+                tag_as_latest: true
+                tag_prefix: v
+
+  - name: package
+    serial: true
+    serial_groups: ["package"]
+    plan:
+      - in_parallel:
+          - get: src
+            passed: ["build"]
+            trigger: true
+          - get: gateway-image
+            passed: ["build"]
+            trigger: true
+            params: {skip_download: true}
+          - get: translator-image
+            passed: ["build"]
+            trigger: true
+            params: {skip_download: true}
+          - get: parser-image
+            passed: ["build"]
+            trigger: true
+            params: {skip_download: true}
+          - get: stub-connector-image
+            passed: ["build"]
+            trigger: true
+            params: {skip_download: true}
+          - get: cloudhsm-client-image
+            passed: ["build-base-images"]
+            trigger: true
+            params: {skip_download: true}
+          - get: verify-service-provider-image
+            passed: ["build-base-images"]
+            trigger: true
+            params: {skip_download: true}
+          - get: release
+
+      - task: generate-chart-values
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: src
+            - name: gateway-image
+            - name: translator-image
+            - name: parser-image
+            - name: stub-connector-image
+            - name: cloudhsm-client-image
+            - name: verify-service-provider-image
+          outputs:
+            - name: chart-values
+          run:
+            path: /bin/bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "generating helm values for latest image versions..."
+                mkdir -p chart-values
+                cat << EOF > ./overrides.yaml
+                esp:
+                  image:
+                    repository: $(cat parser-image/repository)@$(cat parser-image/digest | cut -d ':' -f 1)
+                    tag: $(cat parser-image/digest | cut -d ':' -f 2)
+                gateway:
+                  image:
+                    repository: $(cat gateway-image/repository)@$(cat gateway-image/digest | cut -d ':' -f 1)
+                    tag: $(cat gateway-image/digest | cut -d ':' -f 2)
+                translator:
+                  image:
+                    repository: $(cat translator-image/repository)@$(cat translator-image/digest | cut -d ':' -f 1)
+                    tag: $(cat translator-image/digest | cut -d ':' -f 2)
+                hsm:
+                  image:
+                    repository: $(cat cloudhsm-client-image/repository)@$(cat cloudhsm-client-image/digest | cut -d ':' -f 1)
+                    tag: $(cat cloudhsm-client-image/digest | cut -d ':' -f 2)
+                vsp:
+                  image:
+                    repository: $(cat verify-service-provider-image/repository)@$(cat verify-service-provider-image/digest | cut -d ':' -f 1)
+                    tag: $(cat verify-service-provider-image/digest | cut -d ':' -f 2)
+                stubConnector:
+                  image:
+                    repository: $(cat stub-connector-image/repository)@$(cat stub-connector-image/digest | cut -d ':' -f 1)
+                    tag: $(cat stub-connector-image/digest | cut -d ':' -f 2)
+                EOF
+                echo "merging with chart values..."
+                spruce merge ./src/chart/values.yaml ./overrides.yaml | tee -a chart-values/values.yaml
+
+      - task: generate-chart-version
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: release
+          outputs:
+            - name: chart-version
+          params:
+            CLUSTER_DOMAIN: ((cluster.domain))
+          run:
+            path: /bin/bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "bumping release number..."
+                CURRENT_TAG=$(cat release/tag)
+                awk -F. '/[0-9]+\./{$NF++;print}' OFS=. <<< "${CURRENT_TAG}" > chart-version/tag
+                NEW_TAG=$(cat chart-version/tag)
+                echo "${NEW_TAG}" > chart-version/name
+                cat chart-version/name
+
+      - task: generate-chart-package
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: src
+            - name: chart-version
+            - name: chart-values
+          outputs:
+            - name: chart-package
+          params:
+            CLUSTER_PRIVATE_KEY: ((cluster.privateKey))
+          run:
+            path: /bin/bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "preparing keyring..."
+                echo "${CLUSTER_PRIVATE_KEY}" > key
+                gpg --import key
+                gpg --export-secret-keys > ~/.gnupg/pubring.gpg
+                KEY_ID="$(gpg --list-secret-keys --with-colons  | awk -F: '/uid:/ {print $10}' | head -n1)"
+                echo "building chart with release values..."
+                CHART_NAME=$(yq . < ./src/chart/Chart.yaml | jq -r .name)
+                cp -r "./src/chart" "./${CHART_NAME}"
+                cp "./chart-values/values.yaml" "./${CHART_NAME}/values.yaml"
+                mkdir -p chart-package
+                APP_VERSION=$(cat ./src/.git/short_ref)
+                CHART_VERSION=$(cat ./chart-version/tag)
+                echo "generating signed (${KEY_ID}) helm package for ${CHART_NAME} at app-version: '${APP_VERSION}' chart-version: '${CHART_VERSION}'..."
+                helm package \
+                  --app-version "${APP_VERSION}" \
+                  --version "${CHART_VERSION}" \
+                  --destination "./chart-package/" \
+                  --save=false \
+                  --sign \
+                  --key "${KEY_ID}" \
+                  "./${CHART_NAME}"
+
+      - put: chart
+        params:
+          name: chart-version/name
+          tag: chart-version/tag
+          globs:
+            - chart-package/*
+
+  - name: test
+    serial: true
+    serial_groups: ["package"]
+    plan:
+
+      - get: chart
+        passed: ["package"]
+        trigger: true
+
+      - task: render-chart-package
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: chart
+          outputs:
+            - name: manifests
+          params:
+            CLUSTER_NAME: ((cluster.name))
+            CLUSTER_DOMAIN: ((cluster.domain))
+            CLUSTER_PRIVATE_KEY: ((cluster.privateKey))
+            RELEASE_NAMESPACE: ((namespace-deployer.namespace))
+            RELEASE_NAME: test
+            CLOUDHSM_IP: ((cluster.cloudHsmIp))
+          run:
+            path: /bin/bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "preparing keyring..."
+                echo "${CLUSTER_PRIVATE_KEY}" > key
+                gpg --import key
+                gpg --export-secret-keys > ~/.gnupg/pubring.gpg
+                KEY_ID="$(gpg --list-secret-keys --with-colons  | awk -F: '/uid:/ {print $10}' | head -n1)"
+                echo "verifying package signature..."
+                helm verify ./chart/*.tgz
+                echo "OK!"
+                echo "rendering chart with release name '${RELEASE_NAME}' and namespace '${RELEASE_NAMESPACE}'..."
+                helm template \
+                  --name "${RELEASE_NAME}" \
+                  --namespace "${RELEASE_NAMESPACE}" \
+                  --set "global.cluster.name=${CLUSTER_NAME}" \
+                  --set "global.cluster.domain=${CLUSTER_DOMAIN}" \
+                  --set "global.cloudHsm.ip=${CLOUDHSM_IP}" \
+                  --set "stubConnector.enabled=true" \
+                  --set "vsp.secretName=vsp" \
+                  --output-dir "./manifests/" \
+                  ./chart/*.tgz
+
+      - task: deploy-chart-package
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: manifests
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            KUBERNETES_API: kubernetes.default.svc
+            RELEASE_NAMESPACE: ((namespace-deployer.namespace))
+            RELEASE_NAME: test
+            APP_NAME: proxy-node
+          run:
+            path: /bin/bash
+            args:
+              - -eu
+              - -c
+              - |
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "applying chart to ${RELEASE_NAMESPACE} namespace..."
+                kapp deploy \
+                  -y \
+                  --namespace "${RELEASE_NAMESPACE}" \
+                  --allow-ns "${RELEASE_NAMESPACE}" \
+                  --app "${RELEASE_NAME}-${APP_NAME}" \
+                  --diff-changes \
+                  -f ./manifests/
+
+      - get: tests-image
+        passed: ["build"]
+
+      - task: test-chart-package
+        image: tests-image
+        attempts: 2
+        timeout: 15m
+        config:
+          platform: linux
+          params:
+            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            STUB_IDP_USER: "stub-idp-demo-one"
+            SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
+          run:
+            path: /bin/bash
+            args:
+              - -c
+              - |
+                set -euo pipefail
+                cd /
+                bundle exec cucumber --strict --tags "not @ignore"
+
+  - name: release
+    serial: true
+    serial_groups: ["package"]
+    plan:
+
+      - get: chart
+        passed: ["test"]
+        trigger: true
+
+      - put: release
+        params:
+          name: chart/tag
+          tag: chart/tag
+          globs:
+            - chart/*.tgz*

--- a/ci/build/zdd-pipeline.yaml
+++ b/ci/build/zdd-pipeline.yaml
@@ -253,14 +253,6 @@ jobs:
                 tag_file: src/.git/short_ref
                 tag_as_latest: true
                 tag_prefix: v
-            - put: tests-image
-              get_params: {skip_download: true}
-              params:
-                cache: true
-                build: src/proxy-node-acceptance-tests
-                tag_file: src/.git/short_ref
-                tag_as_latest: true
-                tag_prefix: v
 
   - name: package
     serial: true
@@ -416,6 +408,14 @@ jobs:
           tag: chart-version/tag
           globs:
             - chart-package/*
+      - put: tests-image
+        get_params: {skip_download: true}
+        params:
+          cache: true
+          build: src/proxy-node-acceptance-tests
+          tag_file: src/.git/short_ref
+          tag_as_latest: true
+          tag_prefix: v
 
   - name: test
     serial: true
@@ -503,7 +503,7 @@ jobs:
                   -f ./manifests/
 
       - get: tests-image
-        passed: ["build"]
+        passed: ["package"]
 
       - task: test-chart-package
         image: tests-image

--- a/ci/build/zdd-pipeline.yaml
+++ b/ci/build/zdd-pipeline.yaml
@@ -151,11 +151,11 @@ resources:
 
 groups:
   - name: proxy-node
-    jobs: [build, package, test, release]
+    jobs: [build, package, roll-test, test, release]
   - name: base-images
     jobs: [build-base-images]
   - name: all
-    jobs: [build-base-images, build, package, test, release]
+    jobs: [build-base-images, build, package, roll-test, test, release]
 
 jobs:
 
@@ -408,16 +408,8 @@ jobs:
           tag: chart-version/tag
           globs:
             - chart-package/*
-      - put: tests-image
-        get_params: {skip_download: true}
-        params:
-          cache: true
-          build: src/proxy-node-acceptance-tests
-          tag_file: src/.git/short_ref
-          tag_as_latest: true
-          tag_prefix: v
-
-  - name: test
+            -
+  - name: roll-test
     serial: true
     serial_groups: ["package"]
     plan:
@@ -501,9 +493,25 @@ jobs:
                   --app "${RELEASE_NAME}-${APP_NAME}" \
                   --diff-changes \
                   -f ./manifests/
+      - put: tests-image
+        get_params: {skip_download: true}
+        params:
+          cache: true
+          build: src/proxy-node-acceptance-tests
+          tag_file: src/.git/short_ref
+          tag_as_latest: true
+          tag_prefix: v
+      - put: chart
+
+  - name: test
+    serial: true
+    serial_groups: ["package"]
+    plan:
 
       - get: tests-image
-        passed: ["package"]
+        passed: ["roll-test"]
+      - get: chart
+        passed: ["roll-test"]
 
       - task: test-chart-package
         image: tests-image
@@ -524,6 +532,7 @@ jobs:
                 set -euo pipefail
                 cd /
                 bundle exec cucumber --strict --tags "not @ignore"
+
 
   - name: release
     serial: true


### PR DESCRIPTION
This is a draft PR to record how the build pipeline should be updated to handle ZDD.

This is a zdd-pipepline.yaml which can be deployed directly to local concourse for testing.
One the shape of the pipeline is correct, we can deploy into into a GSP cluster.

Changes are:
* restarting of the test instance has been separated from the actual acceptance tests, `roll-test` is now separate from `test`
* a new `zdd` job after `package` that starts ZDD tests against the current test instance before and during the `roll-test` job.

Before:
<img width="1036" alt="Screen Shot 2019-08-12 at 17 52 13" src="https://user-images.githubusercontent.com/137389/62882564-162f8580-bd2a-11e9-93d3-92808d3a6e77.png">

After:
<img width="610" alt="Screen Shot 2019-08-12 at 22 47 21" src="https://user-images.githubusercontent.com/137389/62900857-29a31680-bd53-11e9-8ebc-d60d4fc1a490.png">



What it missing is that the new ZDD job and test job need to agree when they are both happy, before release.
