### PR TITLE
BAU: Publish test report on failure when running in Concourse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,10 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.gradle.build-scan' version '2.4.1'
+}
+
 apply plugin: 'java'
 apply plugin: 'com.github.ben-manes.versions'
 
@@ -208,7 +212,7 @@ subprojects {
 
 task jacocoMerge(type: JacocoMerge) {
     destinationFile = file("$buildDir/jacoco/allTestCoverage.exec")
-    executionData = project.fileTree(dir: '.', include:'**/build/jacoco/*est.exec')
+    executionData = project.fileTree(dir: '.', include: '**/build/jacoco/*est.exec')
     jacocoClasspath = project.files(project.configurations.jacocoAnt)
 }
 
@@ -227,6 +231,12 @@ task jacocoRootReport(type: JacocoReport) {
     doFirst {
         executionData files(executionData.findAll { it.exists() })
     }
+}
+
+buildScan {
+    publishOnFailureIf(project.hasProperty('CI'))
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 defaultTasks 'clean', 'test'

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -273,7 +273,7 @@ spec:
               - |
                 cd src
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
-                ./gradlew --console verbose --parallel test -x createPoms
+                ./gradlew --console verbose --parallel -PCI test -x createPoms
 
       - task: build-apps
         image: cloudhsm-jce-image
@@ -294,7 +294,7 @@ spec:
               - |
                 cd src
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
-                ./gradlew --console verbose --parallel -Pcloudhsm installDist
+                ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 
       - in_parallel:
           limit: 3


### PR DESCRIPTION
If the tests fail in Concourse, we have no way of knowing why. This will enable gradle to publish test reports on failure.