### PR TITLE
[DO NOT MERGE] ZDD: Add a proxy node journey ID cookie

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdGeneratingServletFilter.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdGeneratingServletFilter.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.notification;
 
 import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
+import uk.gov.ida.notification.shared.Urls;
 import uk.gov.ida.notification.shared.logging.ProxyNodeMDCKey;
 
 import javax.servlet.Filter;
@@ -9,8 +10,11 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class JourneyIdGeneratingServletFilter implements Filter {
 
@@ -28,6 +32,13 @@ public class JourneyIdGeneratingServletFilter implements Filter {
         String journeyId = idGenerationStrategy.generateIdentifier();
         request.getSession().setAttribute(JOURNEY_ID_KEY, journeyId);
         servletRequest.setAttribute(JOURNEY_ID_KEY, journeyId);
+        Cookie cookie = new Cookie(JOURNEY_ID_KEY.toLowerCase(), journeyId);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge((int) TimeUnit.MINUTES.toSeconds(90));
+        cookie.setDomain(request.getServerName());
+        cookie.setPath(Urls.GatewayUrls.GATEWAY_ROOT);
+        ((HttpServletResponse) servletResponse).addCookie(cookie);
         chain.doFilter(servletRequest, servletResponse);
     }
 

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilter.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilter.java
@@ -23,8 +23,11 @@ public class JourneyIdHubResponseServletFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         final String journeyId = (String) request.getSession().getAttribute(JOURNEY_ID_KEY);
         servletRequest.setAttribute(JOURNEY_ID_KEY, journeyId);
+        expireJourneyIdCookie(request, (HttpServletResponse) servletResponse);
         chain.doFilter(servletRequest, servletResponse);
-        HttpServletResponse response = (HttpServletResponse) servletResponse;
+    }
+
+    private void expireJourneyIdCookie(HttpServletRequest request, HttpServletResponse response) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             Arrays.stream(cookies)

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilter.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilter.java
@@ -8,8 +8,11 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 
 public class JourneyIdHubResponseServletFilter implements Filter {
 
@@ -21,6 +24,16 @@ public class JourneyIdHubResponseServletFilter implements Filter {
         final String journeyId = (String) request.getSession().getAttribute(JOURNEY_ID_KEY);
         servletRequest.setAttribute(JOURNEY_ID_KEY, journeyId);
         chain.doFilter(servletRequest, servletResponse);
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            Arrays.stream(cookies)
+                    .filter(c -> JOURNEY_ID_KEY.toLowerCase().equals(c.getName()))
+                    .forEach(c -> {
+                        c.setMaxAge(0);
+                        response.addCookie(c);
+                    });
+        }
     }
 
     @Override

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/JourneyIdGeneratingServletFilterTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/JourneyIdGeneratingServletFilterTest.java
@@ -3,16 +3,22 @@ package uk.gov.ida.notification;
 import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.ida.notification.shared.Urls;
 
 import javax.servlet.FilterChain;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -40,18 +46,33 @@ public class JourneyIdGeneratingServletFilterTest {
     @Mock
     private FilterChain chain;
 
+    @Captor
+    private ArgumentCaptor<Cookie> captorCookie;
+
     @Test
     public void setAJourneyIdInSessionAndRequest() throws Exception {
         String journeyId = UUID.randomUUID().toString();
         when(idGenerationStrategy.generateIdentifier()).thenReturn(journeyId);
         when(request.getSession()).thenReturn(session);
+        when(request.getServerName()).thenReturn("proxy-node");
         filter.doFilter(request, response, chain);
         verify(idGenerationStrategy).generateIdentifier();
         verify(request).getSession();
         verify(session).setAttribute(JOURNEY_ID_KEY, journeyId);
         verify(request).setAttribute(JOURNEY_ID_KEY, journeyId);
+        verify(request).getServerName();
+        verify(response).addCookie(captorCookie.capture());
         verify(chain).doFilter(request, response);
         verifyNoMoreInteractions(chain, request, session, idGenerationStrategy);
         verifyZeroInteractions(response);
+        Cookie cookie = captorCookie.getValue();
+        assertThat(cookie.getName()).isEqualTo(JOURNEY_ID_KEY.toLowerCase());
+        assertThat(cookie.getValue()).isEqualTo(journeyId);
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getSecure()).isTrue();
+        assertThat(cookie.getMaxAge()).isEqualTo(TimeUnit.MINUTES.toSeconds(90));
+        assertThat(cookie.getDomain()).isEqualTo("proxy-node");
+        assertThat(cookie.getPath()).isEqualTo(Urls.GatewayUrls.GATEWAY_ROOT);
+
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilterTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/JourneyIdHubResponseServletFilterTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.servlet.FilterChain;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -35,15 +36,24 @@ public class JourneyIdHubResponseServletFilterTest {
     @Mock
     private FilterChain chain;
 
+    @Mock
+    private Cookie cookie;
+
     @Test
     public void shouldGetJourneyIdFromSessionAndSetAsRequestAttribute() throws Exception {
         when(request.getSession()).thenReturn(session);
         when(session.getAttribute(JOURNEY_ID_KEY)).thenReturn("a journey id");
+        when(request.getCookies()).thenReturn(new Cookie[]{cookie});
+        when(cookie.getName()).thenReturn(JOURNEY_ID_KEY.toLowerCase());
         filter.doFilter(request, response, chain);
         verify(request).getSession();
+        verify(request).getCookies();
         verify(session).getAttribute(JOURNEY_ID_KEY);
         verify(request).setAttribute(JOURNEY_ID_KEY, "a journey id");
         verify(chain).doFilter(request, response);
+        verify(cookie).getName();
+        verify(cookie).setMaxAge(0);
+        verify(response).addCookie(cookie);
         verifyNoMoreInteractions(request, session);
         verifyZeroInteractions(response);
     }


### PR DESCRIPTION
Create a new cookie, named `proxy_node_journey_id` when making an eIDAS request to gateway, and delete the cookie on gateway egress after hub response.

The cookie value will be used in future as a key to gateway data stored in redis.
This PR will not remove the current gateway session cookie.

It has the attributes:
* secure
* httpOnly
* path `/SAML2/SSO`
* domain of the current FQDN
* value of the current `journeyId` variable set in `JourneyIdGeneratingServletFilter`.
* expiry of 90 minutes

## Why
As part of ZDD, `gateway` will be scaled to at least two replicas. Each of these replicas currently has a distinct value for its `gateway_session` cookie, set by [Jersey](https://jersey.github.io/). This value is used as a key to gateway redis, so the value should not be distinct per replica.

## To consider
* is the cookie name ok?
