### PR TITLE
BAU Update proxy-node saml signing cert validity to 12 months

### DIFF
--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -24,7 +24,7 @@ spec:
   samlSigningCertRequest:
     countryCode: GB
     commonName: Verify Proxy Node SAML Signing
-    expiryMonths: 3
+    expiryMonths: 12
     organization: Cabinet Office
     organizationUnit: GDS
     location: London


### PR DESCRIPTION
There is currently no agreed mechanism within eIDAS to rotate SAML
signing keys/certs.

We've pushed this back to 12 months to allow for more time for a
solution to become apparent, and so the connections with countries don't
break in the mean time.