### PR TITLE
BAU Remove xml tag check from validation

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -106,11 +106,8 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
     }
 
     @Test
-    public void shouldReturnHTTP400WhenAuthnRequestIsMalformedBase64() throws Exception {
-        AuthnRequest request = this.request.withRandomRequestId().build();
-        SAML_OBJECT_SIGNER.sign(request, null);
-
-        Response response = postMalformedEidasAuthnRequest(eidasSamlParserAppRule, request);
+    public void shouldReturnHTTP400WhenAuthnRequestIsBlankBase64() throws Exception {
+        Response response = postBlankEidasAuthnRequest(eidasSamlParserAppRule);
         assertErrorResponse(response);
     }
 

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
@@ -30,8 +30,8 @@ public class EidasSamlParserAppRuleTestBase extends AbstractSamlAppRuleTestBase 
                 .post(Entity.entity(createEspRequest(authnRequest), MediaType.APPLICATION_JSON_TYPE));
     }
 
-    protected Response postMalformedEidasAuthnRequest(EidasSamlParserAppRule eidasSamlParserAppRule, AuthnRequest authnRequest) throws URISyntaxException {
-        final String eidasAuthnRequest = "not-a-base-64-encoded-xml-start-tag" + createSamlBase64EncodedRequest(authnRequest);
+    protected Response postBlankEidasAuthnRequest(EidasSamlParserAppRule eidasSamlParserAppRule) throws URISyntaxException {
+        final String eidasAuthnRequest = Base64.getEncoder().encodeToString("".getBytes());
         final EidasSamlParserRequest request = new EidasSamlParserRequest(eidasAuthnRequest);
 
         return eidasSamlParserAppRule.target("/eidasAuthnRequest")

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/Base64NotBlankValidator.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/Base64NotBlankValidator.java
@@ -6,7 +6,7 @@ import org.glassfish.jersey.internal.util.Base64;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-public class Base64XmlValidator implements ConstraintValidator<ValidBase64Xml, String> {
+public class Base64NotBlankValidator implements ConstraintValidator<ValidBase64Xml, String> {
 
     @Override
     public void initialize(ValidBase64Xml constraint) { /* intentionally blank */ }
@@ -19,8 +19,7 @@ public class Base64XmlValidator implements ConstraintValidator<ValidBase64Xml, S
 
         try {
             String decoded = Base64.decodeAsString(potentialBase64);
-            if (StringUtils.isBlank(decoded)) { return false; }
-            return decoded.trim().startsWith("<?xml version=");
+            return StringUtils.isNotBlank(decoded);
 
         } catch (RuntimeException e) {
             context.buildConstraintViolationWithTemplate("Exception: " + e.getMessage()).addConstraintViolation();

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/ValidBase64Xml.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/validations/ValidBase64Xml.java
@@ -11,7 +11,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Documented
-@Constraint(validatedBy = { Base64XmlValidator.class })
+@Constraint(validatedBy = { Base64NotBlankValidator.class })
 @Target({ FIELD, PARAMETER })
 @Retention(RUNTIME)
 public @interface ValidBase64Xml {

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/validation/EidasSamlParserRequestValidationTests.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/validation/EidasSamlParserRequestValidationTests.java
@@ -44,8 +44,8 @@ public class EidasSamlParserRequestValidationTests extends AbstractDtoValidation
     }
 
     @Test
-    public void shouldFailValidationWithInvalidRequest() {
-        EidasSamlParserRequest badRequest = new EidasSamlParserRequest("not base 64 SAML");
+    public void shouldFailValidationWithBlankRequest() {
+        EidasSamlParserRequest badRequest = new EidasSamlParserRequest("");
 
         Map<String,List<ConstraintViolation<EidasSamlParserRequest>>> badViolationsMap = validateAndMap(badRequest);
 

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -210,7 +210,7 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
     }
 
     private javax.ws.rs.core.Response postMalformedHubResponseToTranslator(Response hubResponse) throws Exception {
-        String encodedResponse = "not-a-base64-encoded-xml-start-tag" + Base64.encodeAsString(MARSHALLER.transformToString(hubResponse));
+        String encodedResponse = Base64.encodeAsString("");
 
         HubResponseTranslatorRequest hubResponseTranslatorRequest =
             new HubResponseTranslatorRequest(

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
@@ -63,7 +63,7 @@ public class HubResponseTranslatorRequestValidationTests extends AbstractDtoVali
     @Test
     public void shouldFailValidationWithInvalidParameters() {
         HubResponseTranslatorRequest badRequest = new HubResponseTranslatorRequest(
-                "not base 64 SAML",
+                "",
                 "1_should_fail_because_of_the_first_numeric_character",
                 "_2_is_too_short",
                 "LEVEL_7",


### PR DESCRIPTION
Countries using CEF reference connector don't include an XML declaration
at the beginning of Authn requests. This causes requests to fail
validation in the gateway.

This changes the validator to not check for the declaration, and instead
does the minimum of checking the decoded Base64 is not blank. If the XML
is actually not valid we'll find out later as it works its way through
the system.