### PR TITLE
A test endpoint for testing out HSM alerts

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -123,6 +123,21 @@ public class SendAuthnRequestResource {
         return Response.ok().build();
     }
 
+    @GET
+    @Path("/test1") // Same as above but does not call pn gateway
+    public String test1(
+            @Session HttpSession session,
+            @Context HttpServletResponse httpServletResponse
+    ) throws Throwable {
+        KeyFileCredentialConfiguration invalidCredentialConfiguration = new KeyFileCredentialConfiguration(
+                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
+        );
+        MessageContext context = generateAuthnRequestContext(session, EidasLoaEnum.LOA_SUBSTANTIAL, invalidCredentialConfiguration);
+
+        return "ok";
+    }
+
     private MessageContext generateAuthnRequestContext(
         HttpSession session,
         EidasLoaEnum loaType,


### PR DESCRIPTION
The `/InvalidSignature` endpoint on stub-connector seems to create an HSM `CN_NIST_AES_WRAP` event.

We want to check whether the `stub-connector` or `esp` is generating this event.
This PR creates a new endpoint, `/test1`, that is same as `/InvalidSignature` except it does not call gateway.

If event still occurs then the stub-connector must be generating it, which would be nuts!