### PR TITLE
2nd acceptance test for stub-connector calling HSM

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -135,7 +135,21 @@ public class SendAuthnRequestResource {
         );
         MessageContext context = generateAuthnRequestContext(session, EidasLoaEnum.LOA_SUBSTANTIAL, invalidCredentialConfiguration);
 
-        return "ok";
+        return "test1";
+    }
+
+    @GET
+    @Path("/test2") // Same as above but does not call generateAuthnRequestContext
+    public String test2(
+            @Session HttpSession session,
+            @Context HttpServletResponse httpServletResponse
+    ) throws Throwable {
+        KeyFileCredentialConfiguration invalidCredentialConfiguration = new KeyFileCredentialConfiguration(
+                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
+        );
+
+        return "test2";
     }
 
     private MessageContext generateAuthnRequestContext(


### PR DESCRIPTION
The /InvalidSignature endpoint on stub-connector seems to create an HSM CN_NIST_AES_WRAP event.

We want to check whether the stub-connector or esp is generating this event.
This PR creates a new endpoint, /test2, that is same as '/test1' except it does not call `generateAuthnRequestContext`.
We are trying to figure out which slice of code calls the HSM.

This PR is related to https://github.com/alphagov/verify-proxy-node/pull/334
