### PR TITLE
hsm-incident: switch java security provider during InvalidSignature test

### DIFF
--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -5,6 +5,7 @@ import io.dropwizard.views.View;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
 import net.shibboleth.utilities.java.support.velocity.VelocityEngine;
+import org.apache.xml.security.algorithms.JCEMapper;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.messaging.encoder.MessageEncodingException;
 import org.opensaml.messaging.handler.MessageHandlerException;
@@ -114,13 +115,19 @@ public class SendAuthnRequestResource {
         @Session HttpSession session,
         @Context HttpServletResponse httpServletResponse
     ) throws Throwable {
+        JCEMapper.setProviderId("BC");
+
         KeyFileCredentialConfiguration invalidCredentialConfiguration = new KeyFileCredentialConfiguration(
-                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
-                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
+            new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+            new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
         );
         MessageContext context = generateAuthnRequestContext(session, EidasLoaEnum.LOA_SUBSTANTIAL, invalidCredentialConfiguration);
         encode(httpServletResponse, context);
-        return Response.ok().build();
+
+        Response response = Response.ok().build();
+
+        JCEMapper.setProviderId("Cavium");
+        return response;
     }
 
     @GET


### PR DESCRIPTION
A quick summary of the investigation:

- Cyber alert `I003 Security State/A003_hsm_alert_p2` in `GDS-003 Verify eIDAS Notification` is triggered when the following op code is generated on the HSM: `CN_NIST_AES_WRAP (0x1e)`
- This op code is often accompanied by: `CN_UNWRAP_KEY (0x1b)`
- The unexpected op codes found on the HSM are caused by our proxy-node acceptance tests.
- Our acceptance tests include error scenarios, and one of those triggers the effect we're seeing.
- It's a side effect of the fact that the Integration environment shares the HSM with Production, and so the alerts are triggered when these things happen.
- Of the acceptance tests, scenario "Stub connector generates an Authn request with an invalid signature" causes the unexpected op codes to appear.
- This scenario makes a call to the `/InvalidSignature` endpoint on `SendAuthnRequestResource`.
- InvalidSignature uses a cert and private key taken from a file (not the HSM to sign) so on initial inspection it shouldn't invoke the HSM.
- Java Security Providers enact the actual signing/encryption operations used by supported libraries.
- `BouncyCastle` is an example of of a Security Provider, as is `Cavium` (provided by AWS for accessing the HSM).
- **Java Security Providers remain resident, even when they are not being used.**
- **In fact, the `Cavium` provider is already the preferred Java Security Provider at this time, and so the HSM _is_ still used.**
- In doing so, the SAML signing library has to pass the private key in to the HSM in order to use it to sign, and we believe this leads to the unexpected op codes.
- The solution is to switch off `Cavium` for the duration of _this call only_.
- Tested and verified on sandbox: It's possible to disable `Cavium` (and switch to `BouncyCastle`) for the duration of a single call.

This PR switches the preferred Security provider to `BouncyCastle` for the duration of the InvalidSignature call, and then restores `Cavium`.