### PR TITLE
Invalidate a http session on a successful response from Hub

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -65,6 +65,7 @@ public class HubResponseResource {
         String eidasResponse = translatorProxy.getTranslatedHubResponse(translatorRequest, session.getId());
         ProxyNodeLogger.info("Received eIDAS response from Translator");
 
+        session.invalidate();
         return samlFormViewBuilder.buildResponse(
             sessionData.getEidasDestination(),
             eidasResponse,

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -89,6 +89,7 @@ public class HubResponseResourceTest {
         assertThat("translated_eidas_response").isEqualTo(response.getEncodedSamlMessage());
         assertThat(HubResponseResource.SUBMIT_TEXT).isEqualTo(response.getSubmitText());
         assertThat("eidas_relay_state_in_session").isEqualTo(response.getRelayState());
+        verify(session).invalidate();
 
     }
 


### PR DESCRIPTION
Invalidate the http session after a successful egress from Gateway to the Government Service.