### PR TITLE
Invalidate session after saml response to gateway

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -120,6 +120,15 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
     }
 
     private void setResponseServletFilter(Environment environment) {
+
+        InvalidateSessionServletFilter invalidateSessionServletFilter = new InvalidateSessionServletFilter();
+        environment.servlets()
+                .addFilter(invalidateSessionServletFilter.getClass().getSimpleName(), invalidateSessionServletFilter)
+                .addMappingForUrlPatterns(
+                        EnumSet.of(DispatcherType.REQUEST),
+                        true,
+                        Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE);
+
         JourneyIdHubResponseServletFilter responseFilter = new JourneyIdHubResponseServletFilter();
         environment.servlets()
                 .addFilter(responseFilter.getClass().getSimpleName(), responseFilter)

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/InvalidateSessionServletFilter.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/InvalidateSessionServletFilter.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.notification;
+
+import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+public class InvalidateSessionServletFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        chain.doFilter(servletRequest, servletResponse);
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            ProxyNodeLogger.info("Invalidating session " + session.getId());
+            session.invalidate();
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+
+    }
+}

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -65,7 +65,6 @@ public class HubResponseResource {
         String eidasResponse = translatorProxy.getTranslatedHubResponse(translatorRequest, session.getId());
         ProxyNodeLogger.info("Received eIDAS response from Translator");
 
-        session.invalidate();
         return samlFormViewBuilder.buildResponse(
             sessionData.getEidasDestination(),
             eidasResponse,

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/InvalidateSessionServletFilterTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/InvalidateSessionServletFilterTest.java
@@ -1,0 +1,46 @@
+package uk.gov.ida.notification;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InvalidateSessionServletFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpSession session;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Test
+    public void filterChainShouldRunBeforeSessionInvalidated() throws IOException, ServletException {
+        when(request.getSession(false)).thenReturn(session);
+        new InvalidateSessionServletFilter().doFilter(request, response, filterChain);
+        InOrder inOrder = inOrder(request, filterChain, session);
+        inOrder.verify(filterChain).doFilter(request, response);
+        inOrder.verify(request).getSession(false);
+        inOrder.verify(session).invalidate();
+        inOrder.verifyNoMoreInteractions();
+        verifyZeroInteractions(response);
+    }
+}

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -210,7 +210,6 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
     @Test
     public void testThatABadResponseFromTranslatorProducingSAMLErrorResponseClearsSession() throws Exception {
-
         NewCookie samlRequestWithCookie = postSAMLRequest(proxyNodeServerErrorAppRule);
         Response response = proxyNodeServerErrorAppRule
                 .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -142,7 +142,6 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
                 .post(Entity.form(POST_FORM));
         assertLogsIngressEgress();
         assertSuccessfulResponse(response);
-        return;
     }
 
     @Test

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -131,7 +131,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
 
     @Test
     public void hubResponseReturnsHtmlFormWithSamlBlob() throws Exception {
-        NewCookie sessionCookie = getSessionCookie(proxyNodeAppRule);
+        NewCookie sessionCookie = postSAMLRequest(proxyNodeAppRule);
         Logger logger = (Logger) LoggerFactory.getLogger(ProxyNodeLogger.class);
         logger.addAppender(appender);
 
@@ -140,23 +140,9 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
                 .request()
                 .cookie(sessionCookie)
                 .post(Entity.form(POST_FORM));
-
-        assertThat(response.getStatus()).isEqualTo(200);
         assertLogsIngressEgress();
-
-        final String htmlString = response.readEntity(String.class);
-        HtmlHelpers.assertXPath(
-                htmlString,
-                String.format(
-                        "//form[@action='%s']/input[@name='SAMLResponse'][@value='%s']",
-                        SAMPLE_DESTINATION_URL,
-                        TestTranslatorResource.SAML_SUCCESS_BLOB));
-
-        HtmlHelpers.assertXPath(
-                htmlString,
-                String.format(
-                        "//form[@action='%s']/input[@name='RelayState'][@value='relay-state']",
-                        SAMPLE_DESTINATION_URL));
+        assertSuccessfulResponse(response);
+        return;
     }
 
     @Test
@@ -164,7 +150,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         Response response = proxyNodeAppRuleEmbeddedRedis
                 .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
                 .request()
-                .cookie(getSessionCookie(proxyNodeAppRuleEmbeddedRedis))
+                .cookie(postSAMLRequest(proxyNodeAppRuleEmbeddedRedis))
                 .post(Entity.form(POST_FORM));
 
         assertThat(response.getStatus()).isEqualTo(200);
@@ -181,8 +167,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
                 .request()
                 .post(Entity.form(POST_FORM));
 
-        assertThat(response.getStatus()).isEqualTo(Response.Status.SEE_OTHER.getStatusCode());
-        assertThat(response.getHeaderString("Location")).isEqualTo(ERROR_PAGE_REDIRECT_URL);
+        assertShowProxyNodeErrorPage(response);
     }
 
     @Test
@@ -190,7 +175,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         Response response = proxyNodeServerErrorAppRule
                 .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
                 .request()
-                .cookie(getSessionCookie(proxyNodeServerErrorAppRule))
+                .cookie(postSAMLRequest(proxyNodeServerErrorAppRule))
                 .post(Entity.form(POST_FORM));
 
         assertGoodSamlErrorResponse(response);
@@ -201,10 +186,70 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         Response response = proxyNodeClientErrorAppRule
                 .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
                 .request()
-                .cookie(getSessionCookie(proxyNodeClientErrorAppRule))
+                .cookie(postSAMLRequest(proxyNodeClientErrorAppRule))
                 .post(Entity.form(POST_FORM));
 
         assertGoodSamlErrorResponse(response);
+    }
+
+    @Test
+    public void testThatASuccessfulJourneyClearsSession() throws Exception {
+        NewCookie samlRequestWithCookie = postSAMLRequest(proxyNodeAppRule);
+        Response response = proxyNodeAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertSuccessfulResponse(response);
+        Response samlResponseAgain = proxyNodeAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertThatASAMLResponseCannotBeReplayed(samlRequestWithCookie, samlResponseAgain);
+    }
+
+    @Test
+    public void testThatABadResponseFromTranslatorProducingSAMLErrorResponseClearsSession() throws Exception {
+
+        NewCookie samlRequestWithCookie = postSAMLRequest(proxyNodeServerErrorAppRule);
+        Response response = proxyNodeServerErrorAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertGoodSamlErrorResponse(response);
+        Response samlResponseAgain = proxyNodeAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertThatASAMLResponseCannotBeReplayed(samlRequestWithCookie, samlResponseAgain);
+    }
+
+    @Test
+    public void testThatABadResponseResultingInProxyNodeErrorPageClearsSession() throws Exception {
+        NewCookie samlRequestWithCookie = postSAMLRequest(proxyNodeServerErrorAppRule);
+        Response response = proxyNodeClientErrorAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertShowProxyNodeErrorPage(response);
+        Response samlResponseAgain = proxyNodeAppRule
+                .target(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_RESOURCE)
+                .request()
+                .cookie(samlRequestWithCookie)
+                .post(Entity.form(POST_FORM));
+        assertThatASAMLResponseCannotBeReplayed(samlRequestWithCookie, samlResponseAgain);
+    }
+
+    private void assertThatASAMLResponseCannotBeReplayed(NewCookie requestCookie, Response response) {
+        assertThat(requestCookie.getValue()).isNotNull();
+        assertShowProxyNodeErrorPage(response);
+        NewCookie responseCookie = response.getCookies().get("gateway-session");
+        assertThat(responseCookie.getValue()).isNotNull();
+        assertThat(responseCookie.getValue()).isNotEqualTo(requestCookie.getValue());
     }
 
     private void assertLogsIngressEgress() {
@@ -215,7 +260,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         assertThat(logEvents).filteredOn(e -> e.getMessage().equals(MESSAGE_EGRESS)).hasSizeGreaterThanOrEqualTo(1);
     }
 
-    private NewCookie getSessionCookie(GatewayAppRule appRule) throws Exception {
+    private NewCookie postSAMLRequest(GatewayAppRule appRule) throws Exception {
         return postEidasAuthnRequest(buildAuthnRequest(), appRule).getCookies().get("gateway-session");
     }
 
@@ -233,5 +278,27 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
                 htmlString,
                 String.format("//form[@action='%s']/input[@name='RelayState'][@value='relay-state']", SAMPLE_DESTINATION_URL)
         );
+    }
+
+    private void assertShowProxyNodeErrorPage(Response response) {
+        assertThat(response.getStatus()).isEqualTo(Response.Status.SEE_OTHER.getStatusCode());
+        assertThat(response.getHeaderString("Location")).isEqualTo(ERROR_PAGE_REDIRECT_URL);
+    }
+
+    private void assertSuccessfulResponse(Response response) throws XPathExpressionException, ParserConfigurationException {
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String htmlString = response.readEntity(String.class);
+        HtmlHelpers.assertXPath(
+                htmlString,
+                String.format(
+                        "//form[@action='%s']/input[@name='SAMLResponse'][@value='%s']",
+                        SAMPLE_DESTINATION_URL,
+                        TestTranslatorResource.SAML_SUCCESS_BLOB));
+
+        HtmlHelpers.assertXPath(
+                htmlString,
+                String.format(
+                        "//form[@action='%s']/input[@name='RelayState'][@value='relay-state']",
+                        SAMPLE_DESTINATION_URL));
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -89,7 +89,6 @@ public class HubResponseResourceTest {
         assertThat("translated_eidas_response").isEqualTo(response.getEncodedSamlMessage());
         assertThat(HubResponseResource.SUBMIT_TEXT).isEqualTo(response.getSubmitText());
         assertThat("eidas_relay_state_in_session").isEqualTo(response.getRelayState());
-        verify(session).invalidate();
 
     }
 


### PR DESCRIPTION
Ensure that the http session is cleared after the the Proxy Node SAML Response has been processed.

If the same gateway-session cookie is used in a subsequent response, that session will not be found and a new gateway-session cookie will be assigned.