### PR TITLE
Trigger package after VSP build step

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -369,9 +369,11 @@ spec:
           params: {skip_download: true}
         - get: cloudhsm-client-image
           passed: [build-base-images]
+          trigger: true
           params: {skip_download: true}
         - get: verify-service-provider-image
           passed: [build-base-images]
+          trigger: true
           params: {skip_download: true}
         - get: alpine-image
           params: {rootfs: true}

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -354,9 +354,11 @@ spec:
           params: {skip_download: true}
         - get: cloudhsm-client-image
           passed: [build-base-images]
+          trigger: true
           params: {skip_download: true}
         - get: verify-service-provider-image
           passed: [build-base-images]
+          trigger: true
           params: {skip_download: true}
         - get: alpine-image
           params: {rootfs: true}


### PR DESCRIPTION
Since you can't run any image other than the latest from Harbor, if we build a new image we need to ensure it gets deployed.