### PR TITLE
Present pipelines as proper YAML instead of a string

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -7,7 +7,7 @@ metadata:
   name: build-release
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     github_source: &github_source
       uri: https://github.com/alphagov/verify-proxy-node.git
@@ -197,10 +197,11 @@ spec:
       serial_groups: [build-vsp]
       plan:
       - in_parallel:
-        - get: vsp-src
-          trigger: true
-        - get: vsp-config
-          trigger: true
+          steps:
+          - get: vsp-src
+            trigger: true
+          - get: vsp-config
+            trigger: true
 
       - task: build-and-test-vsp
         attempts: 2
@@ -261,11 +262,12 @@ spec:
       serial_groups: [build-proxy-node]
       plan:
       - in_parallel:
-        - get: src
-          trigger: true
-        - get: cloudhsm-jce-image
-          passed: [build-cloudhsm]
-          trigger: true
+          steps:
+          - get: src
+            trigger: true
+          - get: cloudhsm-jce-image
+            passed: [build-cloudhsm]
+            trigger: true
 
       - task: run-tests
         attempts: 2
@@ -354,35 +356,36 @@ spec:
       serial_groups: [package, build-vsp, build-proxy-node]
       plan:
       - in_parallel:
-        - get: src
-          passed: [build-proxy-node]
-          trigger: true
-        - get: gateway-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: translator-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: parser-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: stub-connector-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: verify-service-provider-image
-          passed: [build-vsp-image]
-          trigger: true
-          params: {skip_download: true}
-        - get: cloudhsm-client-image
-          passed: [build-cloudhsm]
-          params: {skip_download: true}
-        - get: alpine-image
-          params: {rootfs: true}
-        - get: release
+          steps:
+          - get: src
+            passed: [build-proxy-node]
+            trigger: true
+          - get: gateway-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: translator-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: parser-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: stub-connector-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: verify-service-provider-image
+            passed: [build-vsp-image]
+            trigger: true
+            params: {skip_download: true}
+          - get: cloudhsm-client-image
+            passed: [build-cloudhsm]
+            params: {skip_download: true}
+          - get: alpine-image
+            params: {rootfs: true}
+          - get: release
 
       - task: generate-chart-values
         config:
@@ -508,11 +511,12 @@ spec:
       plan:
 
       - in_parallel:
-        - get: chart
-          passed: [package]
-          trigger: true
-        - get: tests-image
-          passed: [build-proxy-node]
+          steps:
+          - get: chart
+            passed: [package]
+            trigger: true
+          - get: tests-image
+            passed: [build-proxy-node]
 
       - task: extract-chart
         image: chart

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deploy
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     github_source: &github_source
       uri: https://github.com/alphagov/verify-proxy-node.git

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deploy
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     github_source: &github_source
       uri: https://github.com/alphagov/verify-proxy-node.git

--- a/ci/prod/killswitch-pipeline.yaml
+++ b/ci/prod/killswitch-pipeline.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   exposed: false
   paused: true
-  pipelineString: |
+  config:
 
     task_toolbox: &task_toolbox
       type: docker-image

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -7,7 +7,7 @@ metadata:
   name: build-release
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     github_source: &github_source
       uri: https://github.com/alphagov/verify-proxy-node.git
@@ -191,10 +191,11 @@ spec:
       serial_groups: [build-vsp]
       plan:
       - in_parallel:
-        - get: vsp-src
-          trigger: true
-        - get: vsp-config
-          trigger: true
+          steps:
+          - get: vsp-src
+            trigger: true
+          - get: vsp-config
+            trigger: true
 
       - task: build-and-test-vsp
         attempts: 2
@@ -222,9 +223,8 @@ spec:
         params:
           build: vsp-src
           dockerfile: vsp-config/proxy-node-vsp-config/Dockerfile
+          <<: *image_tag
           tag_file: vsp-config/.git/short_ref
-          tag_as_latest: true
-          tag_prefix: v
 
     - name: build-cloudhsm
       serial: true
@@ -241,28 +241,27 @@ spec:
             params:
               cache: true
               build: cloudhsm-config/cloudhsm
+              <<: *image_tag
               tag_file: cloudhsm-config/.git/short_ref
-              tag_as_latest: true
-              tag_prefix: v
           - put: cloudhsm-jce-image
             get_params: {skip_download: true}
             params:
               cache: true
               build: cloudhsm-config/cloudhsm/jdk-jce-image
+              <<: *image_tag
               tag_file: cloudhsm-config/.git/short_ref
-              tag_as_latest: true
-              tag_prefix: v
 
     - name: build-proxy-node
       serial: true
       serial_groups: [build-proxy-node]
       plan:
       - in_parallel:
-        - get: src
-          trigger: true
-        - get: cloudhsm-jce-image
-          passed: [build-cloudhsm]
-          trigger: true
+          steps:
+          - get: src
+            trigger: true
+          - get: cloudhsm-jce-image
+            passed: [build-cloudhsm]
+            trigger: true
 
       - task: run-tests
         attempts: 2
@@ -351,34 +350,35 @@ spec:
       serial_groups: [package, build-vsp, build-proxy-node]
       plan:
       - in_parallel:
-        - get: src
-          passed: [build-proxy-node]
-          trigger: true
-        - get: gateway-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: translator-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: parser-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: stub-connector-image
-          passed: [build-proxy-node]
-          trigger: true
-          params: {skip_download: true}
-        - get: verify-service-provider-image
-          passed: [build-vsp-image]
-          trigger: true
-          params: {skip_download: true}
-        - get: cloudhsm-client-image
-          passed: [build-cloudhsm]
-          params: {skip_download: true}
-        - get: alpine-image
-          params: {rootfs: true}
+          steps:
+          - get: src
+            passed: [build-proxy-node]
+            trigger: true
+          - get: gateway-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: translator-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: parser-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: stub-connector-image
+            passed: [build-proxy-node]
+            trigger: true
+            params: {skip_download: true}
+          - get: verify-service-provider-image
+            passed: [build-vsp-image]
+            trigger: true
+            params: {skip_download: true}
+          - get: cloudhsm-client-image
+            passed: [build-cloudhsm]
+            params: {skip_download: true}
+          - get: alpine-image
+            params: {rootfs: true}
 
       - task: generate-chart-values
         config:
@@ -499,11 +499,12 @@ spec:
       plan:
 
       - in_parallel:
-        - get: chart
-          passed: [package]
-          trigger: true
-        - get: tests-image
-          passed: [build-proxy-node]
+          steps:
+          - get: chart
+            passed: [package]
+            trigger: true
+          - get: tests-image
+            passed: [build-proxy-node]
 
       - task: extract-chart
         image: chart

--- a/ci/sandbox/deploy-pipeline.yaml
+++ b/ci/sandbox/deploy-pipeline.yaml
@@ -7,7 +7,7 @@ metadata:
   name: deploy
 spec:
   exposed: true
-  pipelineString: |
+  config:
 
     github_source: &github_source
       uri: https://github.com/alphagov/verify-proxy-node.git

--- a/ci/sandbox/killswitch-pipeline.yaml
+++ b/ci/sandbox/killswitch-pipeline.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   exposed: false
   paused: true
-  pipelineString: |
+  config:
 
     task_toolbox: &task_toolbox
       type: docker-image


### PR DESCRIPTION
The `config` option is now supported instead of `pipelineString: |`. This allows the pipelines to be proper YAML which means we get validation, syntax highlighting and less errors due to stray whitespaces.
