### PR TITLE
EID-1542 Apply GOV.UK style and wording to the JavaScript disabled 'Continue' page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,15 @@ repositories {
 
 ext {
     opensaml_version = '3.4.3'
+<<<<<<< HEAD
     dropwizard_version = '1.3.14'
     utils_version = '2.0.0-371'
     saml_lib_version = "${opensaml_version}-210"
+=======
+    dropwizard_version = '1.3.16'
+    utils_version = '2.0.0-371'
+    saml_lib_version = "${opensaml_version}-225"
+>>>>>>> Upgrade some libs because snyk upsets Travis
     build_version = "$opensaml_version-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 }
 

--- a/libs/eidas-saml-parser/pom.xml
+++ b/libs/eidas-saml-parser/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-gateway/pom.xml
+++ b/libs/proxy-node-gateway/pom.xml
@@ -273,7 +273,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-shared/pom.xml
+++ b/libs/proxy-node-shared/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-test/pom.xml
+++ b/libs/proxy-node-test/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/proxy-node-translator/pom.xml
+++ b/libs/proxy-node-translator/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/libs/stub-connector/pom.xml
+++ b/libs/stub-connector/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>io.dropwizard</groupId>
       <artifactId>dropwizard-testing</artifactId>
-      <version>1.3.14</version>
+      <version>1.3.16</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/exceptions/mappers/ExceptionToSamlErrorResponseMapper.java
@@ -21,8 +21,6 @@ import static java.text.MessageFormat.format;
 
 public class ExceptionToSamlErrorResponseMapper implements ExceptionMapper<FailureSamlResponseException> {
 
-    private static final String SUBMIT_TEXT = "Continue";
-
     private final SamlFormViewBuilder samlFormViewBuilder;
     private final TranslatorProxy translatorProxy;
     private final SessionStore sessionStorage;
@@ -64,7 +62,6 @@ public class ExceptionToSamlErrorResponseMapper implements ExceptionMapper<Failu
         final SamlFormView samlFormView = samlFormViewBuilder.buildResponse(
                 sessionData.getEidasDestination(),
                 samlErrorResponse,
-                SUBMIT_TEXT,
                 sessionData.getEidasRelayState());
 
         return Response.ok().entity(samlFormView).build();

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -26,7 +26,6 @@ import javax.ws.rs.core.UriBuilder;
 public class HubResponseResource {
 
     static final String LEVEL_OF_ASSURANCE = "LEVEL_2";
-    static final String SUBMIT_TEXT = "Post eIDAS Response SAML to Connector Node";
 
     private final SamlFormViewBuilder samlFormViewBuilder;
     private final TranslatorProxy translatorProxy;
@@ -68,7 +67,6 @@ public class HubResponseResource {
         return samlFormViewBuilder.buildResponse(
             sessionData.getEidasDestination(),
             eidasResponse,
-            SUBMIT_TEXT,
             sessionData.getEidasRelayState()
         );
     }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
@@ -37,12 +37,14 @@ public class SamlResponseExceptionMapperResourceRuleTest {
 
     @Before
     public void before() {
-        when(sessionStore.getSession(any(String.class))).thenReturn(
-                new GatewaySessionData("HubRequestId", "EidasRequestId", "EidasDestination",
-                        "EidasConnectorPublicKey", "EidasRelayState"));
-
-        when(samlFormViewBuilder.buildResponse("EidasDestination", (String) null, "Continue", "EidasRelayState"))
-                .thenReturn(new SamlFormView("postUrl", "samlMessageType", "encodedSamlMessage", "submitText"));
+        when(sessionStore.getSession(any(String.class))).thenReturn(new GatewaySessionData("HubRequestId","EidasRequestId","EidasDestination","EidasConnectorPublicKey","EidasRelayState"));
+        String nullString = null;
+        when(samlFormViewBuilder.buildResponse("EidasDestination", nullString, "EidasRelayState"))
+                .thenReturn(
+                new SamlFormView("postUrl",
+                                 "samlMessageType",
+                                 "encodedSamlMessage",
+                                 "submitText"));
     }
 
 
@@ -79,7 +81,7 @@ public class SamlResponseExceptionMapperResourceRuleTest {
     private boolean checkResponseEntityIsSamlFormResponse(String responseEntity) {
         // The actual application returns a web page with a form but this stripped down version, returns some JSON
         // As long as it matches, we can be confident that the correct exception mapper has been used
-        Pattern pattern = Pattern.compile("\\{\"postUrl\":\"postUrl\",\"samlMessageType\":\"samlMessageType\",\"encodedSamlMessage\":\"encodedSamlMessage\",\"submitText\":\"submitText\",\"relayState\":.*\"}");
+        Pattern pattern = Pattern.compile("\\{\"postUrl\":\"postUrl\",\"samlMessageType\":\"samlMessageType\",\"encodedSamlMessage\":\"encodedSamlMessage\",\"relayState\":.*\"}");
         Matcher matcher = pattern.matcher(responseEntity);
         return matcher.matches();
     }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -87,7 +87,6 @@ public class HubResponseResourceTest {
         assertThat("http://connector.node").isEqualTo(response.getPostUrl());
         assertThat("SAMLResponse").isEqualTo(response.getSamlMessageType());
         assertThat("translated_eidas_response").isEqualTo(response.getEncodedSamlMessage());
-        assertThat(HubResponseResource.SUBMIT_TEXT).isEqualTo(response.getSubmitText());
         assertThat("eidas_relay_state_in_session").isEqualTo(response.getRelayState());
 
     }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/SamlFormViewBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/SamlFormViewBuilder.java
@@ -17,16 +17,16 @@ public class SamlFormViewBuilder {
     }
 
     public SamlFormView buildRequest(String url, String encodedSamlMessage, String submitText, String relayState) {
-        return new SamlFormView(url, SamlFormMessageType.SAML_REQUEST, encodedSamlMessage, submitText, relayState);
+        return new SamlFormView(url, SamlFormMessageType.SAML_REQUEST, encodedSamlMessage, relayState);
     }
 
-    public SamlFormView buildResponse(String url, Response response, String submitText, String relayState) {
+    public SamlFormView buildResponse(String url, Response response, String relayState) {
         String samlMessage = marshaller.transformToString(response);
         String encodedSamlMessage = Base64.encodeAsString(samlMessage);
-        return buildResponse(url, encodedSamlMessage, submitText, relayState);
+        return buildResponse(url, encodedSamlMessage, relayState);
     }
 
-    public SamlFormView buildResponse(String url, String encodedSamlMessage, String submitText, String relayState) {
-        return new SamlFormView(url, SamlFormMessageType.SAML_RESPONSE, encodedSamlMessage, submitText, relayState);
+    public SamlFormView buildResponse(String url, String encodedSamlMessage, String relayState) {
+        return new SamlFormView(url, SamlFormMessageType.SAML_RESPONSE, encodedSamlMessage, relayState);
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/views/SamlFormView.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/views/SamlFormView.java
@@ -8,19 +8,17 @@ public class SamlFormView extends View {
     private final String postUrl;
     private final String samlMessageType;
     private final String encodedSamlMessage;
-    private final String submitText;
     private final String relayState;
 
-    public SamlFormView(String postUrl, String samlMessageType, String encodedSamlMessage, String submitText) {
-        this(postUrl, samlMessageType, encodedSamlMessage, submitText, UUID.randomUUID().toString());
+    public SamlFormView(String postUrl, String samlMessageType, String encodedSamlMessage) {
+        this(postUrl, samlMessageType, encodedSamlMessage, UUID.randomUUID().toString());
     }
 
-    public SamlFormView(String postUrl, String samlMessageType, String encodedSamlMessage, String submitText, String relayState) {
+    public SamlFormView(String postUrl, String samlMessageType, String encodedSamlMessage, String relayState) {
         super("saml-form.mustache");
         this.postUrl = postUrl;
         this.samlMessageType = samlMessageType;
         this.encodedSamlMessage = encodedSamlMessage;
-        this.submitText = submitText;
         this.relayState = relayState;
     }
 
@@ -34,10 +32,6 @@ public class SamlFormView extends View {
 
     public String getEncodedSamlMessage() {
         return encodedSamlMessage;
-    }
-
-    public String getSubmitText() {
-        return submitText;
     }
 
     public String getRelayState() {

--- a/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
+++ b/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
@@ -19,11 +19,11 @@
             padding-top: 2em;
             padding-left: 2em;
             background-color: white;
-            font-family: "nta", Arial, sans-serif;
+            font-family: Arial, sans-serif;
         }
 
         .heading-large {
-            font-family: "nta", Arial, sans-serif;
+            font-family: Arial, sans-serif;
             font-weight: 700;
             text-transform: none;
             font-size: 24px;
@@ -84,7 +84,7 @@
 <body onload="init()">
 <form action={{postUrl}} method=post name=saml-form>
     <h1 class="heading-large">Continue to next step</h1>
-    <div class="application notice info-notice">
+    <div class="application-notice info-notice">
         <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
     </div>
     <input type=hidden name={{samlMessageType}} value={{encodedSamlMessage}}>

--- a/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
+++ b/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
@@ -15,40 +15,81 @@
         }
     </script>
     <style type='text/css'>
-      body {
-        padding-top: 2em;
-        padding-left: 2em;
-        background-color: white;
-      }
-      .saml-form {
-        font-family: Arial, sans-serif;
-      }
-      .submitBtn {
-        background-color: #00823b;
-        color: #fff;
-        padding: 10px;
-        font-size: 1em;
-        line-height: 1.25;
-        border: none;
-        box-shadow: 0 2px 0 #003618;
-        cursor: pointer;
-      }
-      .submitBtn:hover, .submitBtn:focus {
-        background-color: #00692f;
-      }
+        body {
+            padding-top: 2em;
+            padding-left: 2em;
+            background-color: white;
+            font-family: "nta", Arial, sans-serif;
+        }
+
+        .heading-large {
+            font-family: "nta", Arial, sans-serif;
+            font-weight: 700;
+            text-transform: none;
+            font-size: 24px;
+            line-height: 1.0416666667;
+            display: block;
+            margin-top: 1.0416666667em;
+            margin-bottom: 0.4166666667em;
+        }
+        @media (min-width: 641px) {
+            .heading-large {
+            font-size: 36px;
+            line-height: 1.1111111111; }
+        }
+        @media (min-width: 641px) {
+            .heading-large {
+            margin-top: 1.25em;
+            margin-bottom: 0.5555555556em; }
+        }
+
+        .button {
+            background-color: #00823b;
+            position: relative;
+            display: -moz-inline-stack;
+            display: inline-block;
+            padding: .526315em .789473em .263157em;
+            border: none;
+            border-radius: 0;
+            outline: 1px solid transparent;
+            outline-offset: -1px;
+            -webkit-appearance: none;
+            -webkit-box-shadow: 0 2px 0 #003618;
+            box-shadow: 0 2px 0 #003618;
+            font-size: 1em;
+            line-height: 1.25;
+            text-decoration: none;
+            -webkit-font-smoothing: antialiased;
+            cursor: pointer;
+            color: #fff;
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+            vertical-align: top;
+        }
+        .button:visited {
+            background-color: #00823b;
+        }
+        .button:hover, .button:focus {
+            background-color: #00692f;
+        }
+        .button:active {
+            top: 2px;
+            -webkit-box-shadow: 0 0 0 #00823b;
+            box-shadow: 0 0 0 #00823b;
+        }
+
     </style>
 </head>
 
 <body onload="init()">
 <form action={{postUrl}} method=post name=saml-form>
-    <h1>Continue to next step</h1>
-    <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
+    <h1 class="heading-large">Continue to next step</h1>
+    <div class="application notice info-notice">
+        <p>Because Javascript is not enabled on your browser, you must press the continue button</p>
+    </div>
     <input type=hidden name={{samlMessageType}} value={{encodedSamlMessage}}>
     <input type=hidden name=RelayState value={{relayState}}>
-    <label>
-        {{submitText}}:
-        <input type=submit name=submitBtn value=Submit>
-    </label>
+    <input type=submit name=submitBtn value=Submit class="button">
 </form>
 </body>
 </html>

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/SamlFormViewBuilderTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/SamlFormViewBuilderTest.java
@@ -27,7 +27,6 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
         assertThat(SamlFormMessageType.SAML_REQUEST).isEqualTo(view.getSamlMessageType());
         assertThat(encodedAuthnRequest).isEqualTo(view.getEncodedSamlMessage());
         assertThat("url").isEqualTo(view.getPostUrl());
-        assertThat("submit").isEqualTo(view.getSubmitText());
         assertThat("relay").isEqualTo(view.getRelayState());
     }
 
@@ -38,7 +37,6 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
         assertThat(SamlFormMessageType.SAML_REQUEST).isEqualTo(view.getSamlMessageType());
         assertThat(encodedAuthnRequest).isEqualTo(view.getEncodedSamlMessage());
         assertThat("url").isEqualTo(view.getPostUrl());
-        assertThat("submit").isEqualTo(view.getSubmitText());
         assertThat("relay").isEqualTo(view.getRelayState());
     }
 
@@ -48,12 +46,11 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
 
         String encodedResponse = Base64.encodeAsString(MARSHALLER.transformToString(response));
 
-        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildResponse("url", response, "submit", "relay");
+        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildResponse("url", response, "relay");
 
         assertThat(SamlFormMessageType.SAML_RESPONSE).isEqualTo(view.getSamlMessageType());
         assertThat(encodedResponse).isEqualTo(view.getEncodedSamlMessage());
         assertThat("url").isEqualTo(view.getPostUrl());
-        assertThat("submit").isEqualTo(view.getSubmitText());
         assertThat("relay").isEqualTo(view.getRelayState());
     }
 
@@ -61,12 +58,11 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
     public void shouldGenerateSAMLResponseFormFromEncodedSAMLMessage() {
         String encodedResponse = Base64.encodeAsString("a response saml blob");
 
-        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildResponse("url", encodedResponse, "submit", "relay");
+        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildResponse("url", encodedResponse, "relay");
 
         assertThat(SamlFormMessageType.SAML_RESPONSE).isEqualTo(view.getSamlMessageType());
         assertThat(encodedResponse).isEqualTo(view.getEncodedSamlMessage());
         assertThat("url").isEqualTo(view.getPostUrl());
-        assertThat("submit").isEqualTo(view.getSubmitText());
         assertThat("relay").isEqualTo(view.getRelayState());
     }
 }


### PR DESCRIPTION
Copy and paste the required styles from the Verify version of these pages.

Remove the 'submitText' parameter from the template, the view that uses the template and anything else affected by the demise of the 'submitText' parameter.

Actually using the full stylesheets would require all sorts of extra work for a page that nobody is going to see unless they've disabled JavaScript so we can use inline styles here because rules need to be applied sensibly.