### PR TITLE
Update the api groups of certificate resources.

### DIFF
--- a/chart/templates/gateway-ingress-certificate.yaml
+++ b/chart/templates/gateway-ingress-certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-gateway-ingress

--- a/chart/templates/stub-connector-ingress-certificate.yaml
+++ b/chart/templates/stub-connector-ingress-certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.stubConnector.enabled -}}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-connector-ingress


### PR DESCRIPTION
Following the upgrade of cert-manager to 0.11 the api groups changed. This
brings them into alignment.

## Before merge

- [x] https://github.com/alphagov/gsp/pull/716 needs to be rolled out to the Verify cluster