### PR TITLE
EID-1687 Improve handling of missing first name attribute in Translator

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.notification.contracts.verifyserviceprovider;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
@@ -54,13 +55,23 @@ public class Attribute<T> {
         return to;
     }
 
-
-    public boolean isValid() {
+    public boolean isVerifiedAndCurrent() {
         return this.verified && this.isCurrent() && this.value != null;
     }
 
     public boolean isCurrent() {
-        return (this.from != null && this.from.isBeforeNow()) &&
+        return (this.from == null || this.from.isBeforeNow()) &&
                 (this.to == null || this.to.isAfterNow());
+    }
+
+    @Override
+    @JsonIgnore
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Attribute{");
+        sb.append("verified=").append(verified);
+        sb.append(", has from=").append(from != null);
+        sb.append(", has to=").append(to != null);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attribute.java
@@ -55,10 +55,6 @@ public class Attribute<T> {
         return to;
     }
 
-    public boolean isVerifiedAndCurrent() {
-        return this.verified && this.isCurrent() && this.value != null;
-    }
-
     public boolean isCurrent() {
         return (this.from == null || this.from.isBeforeNow()) &&
                 (this.to == null || this.to.isAfterNow());

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -106,16 +106,20 @@ public class Attributes {
 
         public List<Attribute<T>> getValidAttributes() {
 
-            var valid = getAllAttributes().stream()
-                    .filter(Attribute::isVerifiedAndCurrent)
+            var current = getAllAttributes().stream()
+                    .filter(Attribute::isCurrent)
                     .collect(Collectors.toList());
-            if (valid.isEmpty()) {
+
+            var verifiedAndCurrent = current.stream()
+                    .filter(Attribute::isVerified)
+                    .collect(Collectors.toList());
+
+            if (verifiedAndCurrent.isEmpty()) {
                 ProxyNodeLogger.info("No verified and current attributes: " + createAttributesMessage());
-                valid = getAllAttributes().stream()
-                        .filter(Attribute::isCurrent)
-                        .collect(Collectors.toList());
+                return current;
+            } else {
+                return verifiedAndCurrent;
             }
-            return valid;
         }
 
         public List<Attribute<T>> getAllAttributes() {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -1,14 +1,16 @@
 package uk.gov.ida.notification.contracts.verifyserviceprovider;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.ISODateTimeFormat;
+import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class Attributes {
@@ -53,40 +55,78 @@ public class Attributes {
         this.addresses = addresses;
     }
 
-    public List<Attribute<String>> getFirstNames() {
-        return firstNames != null ? firstNames : new ArrayList<>();
+    @JsonIgnore
+    public AttributesList<String> getFirstNames() {
+        return new AttributesList(firstNames, "firstName");
     }
 
-    public List<Attribute<String>> getMiddleNames() {
-        return middleNames != null ? middleNames : new ArrayList<>();
+    @JsonIgnore
+    public AttributesList<String> getMiddleNames() {
+        return new AttributesList(middleNames, "middleName");
     }
 
-    public List<Attribute<String>> getSurnames() {
-        return surnames != null ? surnames : new ArrayList<>();
+    @JsonIgnore
+    public AttributesList<String> getSurnames() {
+        return new AttributesList(surnames, "surname");
     }
 
-    public List<Attribute<DateTime>> getDatesOfBirth() {
-        return datesOfBirth != null ? datesOfBirth : new ArrayList<>();
+    @JsonIgnore
+    public AttributesList<DateTime> getDatesOfBirth() {
+        return new AttributesList(datesOfBirth, "dateOfBirth");
     }
 
+    @JsonIgnore
     public Attribute<String> getGender() {
         return gender;
     }
 
-    public List<Attribute<Address>> getAddresses() {
-        return addresses;
-    }
-
-    public static String combineAttributeValues(List<Attribute<String>> attributes) {
-        return attributes.stream()
-                .filter(Objects::nonNull)
-                .map(Attribute::getValue)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.joining(" "));
+    @JsonIgnore
+    public AttributesList<Address> getAddresses() {
+        return new AttributesList(datesOfBirth, "dateOfBirth");
     }
 
     // Prints date in EIDAS format YYYY-MM-dd
     public static String getFormattedDate(DateTime date) {
         return ISODateTimeFormat.date().withChronology(ISOChronology.getInstanceUTC()).print(date);
+    }
+
+    public class AttributesList<T> {
+
+        private final List<Attribute<T>> attributes;
+        private final String type;
+
+        AttributesList(List<Attribute<T>> attributes, String type) {
+            this.attributes = Optional.ofNullable(attributes).orElse(Collections.emptyList());
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public List<Attribute<T>> getValidAttributes() {
+
+            var valid = getAllAttributes().stream()
+                    .filter(Attribute::isVerifiedAndCurrent)
+                    .collect(Collectors.toList());
+            if (valid.isEmpty()) {
+                ProxyNodeLogger.info("No verified and current attributes: " + createAttributesMessage());
+                valid = getAllAttributes().stream()
+                        .filter(Attribute::isCurrent)
+                        .collect(Collectors.toList());
+            }
+            return valid;
+        }
+
+        public List<Attribute<T>> getAllAttributes() {
+            return Collections.unmodifiableList(attributes);
+        }
+
+        public String createAttributesMessage() {
+            return "[ " + type + " " + attributes.stream()
+                    .map(Attribute::toString)
+                    .collect(Collectors.joining(", ")) + " ]";
+        }
+
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -82,7 +82,7 @@ public class Attributes {
 
     @JsonIgnore
     public AttributesList<Address> getAddresses() {
-        return new AttributesList(datesOfBirth, "dateOfBirth");
+        return new AttributesList(addresses, "address");
     }
 
     // Prints date in EIDAS format YYYY-MM-dd

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -86,7 +86,7 @@ public class Attributes {
     }
 
     // Prints date in EIDAS format YYYY-MM-dd
-    public static String getFormattedDate(DateTime date) {
+    public static String getDateInEidasFormat(DateTime date) {
         return ISODateTimeFormat.date().withChronology(ISOChronology.getInstanceUTC()).print(date);
     }
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/verifyserviceprovider/Attributes.java
@@ -114,12 +114,12 @@ public class Attributes {
                     .filter(Attribute::isVerified)
                     .collect(Collectors.toList());
 
-            if (verifiedAndCurrent.isEmpty()) {
-                ProxyNodeLogger.info("No verified and current attributes: " + createAttributesMessage());
-                return current;
-            } else {
+            if (!verifiedAndCurrent.isEmpty()) {
                 return verifiedAndCurrent;
             }
+
+            ProxyNodeLogger.info("No verified and current attributes: " + createAttributesMessage());
+            return current;
         }
 
         public List<Attribute<T>> getAllAttributes() {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseAttributesHashLogger.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/logging/HubResponseAttributesHashLogger.java
@@ -21,20 +21,20 @@ public class HubResponseAttributesHashLogger {
             return;
         }
 
-        attributes.getFirstNames().stream()
+        attributes.getFirstNames().getAllAttributes().stream()
                 .filter(Attribute::isVerified)
                 .findFirst()
                 .ifPresent(firstName -> logger.setFirstName(firstName.getValue()));
 
-        attributes.getMiddleNames().forEach(
+        attributes.getMiddleNames().getAllAttributes().forEach(
                 middleName -> logger.addMiddleName(middleName.getValue())
         );
 
-        attributes.getSurnames().forEach(
+        attributes.getSurnames().getAllAttributes().forEach(
                 surname -> logger.addSurname(surname.getValue())
         );
 
-        attributes.getDatesOfBirth().stream()
+        attributes.getDatesOfBirth().getAllAttributes().stream()
                 .filter(Attribute::isVerified)
                 .findFirst()
                 .ifPresent(dateOfBirth -> logger.setDateOfBirth(dateOfBirth.getValue()));

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -143,7 +143,7 @@ public class HubResponseTranslator {
         return validDatesOfBirth.stream()
                 .map(Attribute::getValue)
                 .reduce(BinaryOperator.maxBy(DateTimeComparator.getDateOnlyInstance()))
-                .map(Attributes::getFormattedDate).get();
+                .map(Attributes::getDateInEidasFormat).get();
     }
 
     private static String combineStringAttributeValues(List<Attribute<String>> attributeStream) {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -19,14 +19,10 @@ import uk.gov.ida.notification.saml.EidasAttributeBuilder;
 import uk.gov.ida.notification.saml.EidasResponseBuilder;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes.combineAttributeValues;
 
 public class HubResponseTranslator {
 
@@ -119,39 +115,38 @@ public class HubResponseTranslator {
     }
 
     private static String getCombineFirstAndMiddleNames(HubResponseContainer hubResponseContainer) {
-        final List<Attribute<String>> firstNames = hubResponseContainer.getAttributes().getFirstNames();
-        final List<Attribute<String>> middleNames = hubResponseContainer.getAttributes().getMiddleNames();
-
-        final String firstNamesCombined = combineAttributeValues(getValidAttributes(firstNames));
-
-        if (firstNamesCombined.isEmpty()) {
-            throw new HubResponseTranslationException("No verified current first name present");
+        var firstNames = hubResponseContainer.getAttributes().getFirstNames();
+        var validFirstNames = firstNames.getValidAttributes();
+        if (validFirstNames.isEmpty()) {
+            throw new HubResponseTranslationException("No verified current first name present: " + firstNames.createAttributesMessage());
         }
-
-        final String middleNamesCombined = combineAttributeValues(getValidAttributes(middleNames));
-
-        return middleNamesCombined.isEmpty() ? firstNamesCombined : firstNamesCombined + " " + middleNamesCombined;
+        List<Attribute<String>> validMiddleNames = hubResponseContainer.getAttributes().getMiddleNames().getValidAttributes();
+        validFirstNames.addAll(validMiddleNames);
+        return combineStringAttributeValues(validFirstNames);
     }
 
     private static String getCombinedSurnames(HubResponseContainer hubResponseContainer) {
-        return Optional.of(combineAttributeValues(getValidAttributes(hubResponseContainer.getAttributes().getSurnames())))
-                .filter(s -> !s.isEmpty())
-                .orElseThrow(() -> new HubResponseTranslationException("No verified current surname present"));
+        var surnames = hubResponseContainer.getAttributes().getSurnames();
+        var validSurnames = surnames.getValidAttributes();
+        if (validSurnames.isEmpty()) {
+            throw new HubResponseTranslationException("No verified current surname present: " + surnames.createAttributesMessage());
+        }
+        return combineStringAttributeValues(surnames.getValidAttributes());
     }
 
     private static String getLatestValidDateOfBirth(HubResponseContainer hubResponseContainer) {
-        return getValidAttributes(hubResponseContainer.getAttributes().getDatesOfBirth())
-                .stream()
+        var datesOfBirth = hubResponseContainer.getAttributes().getDatesOfBirth();
+        var validDatesOfBirth = datesOfBirth.getValidAttributes();
+        if (validDatesOfBirth.isEmpty()) {
+            throw new HubResponseTranslationException("No verified current date of birth present: " + datesOfBirth.createAttributesMessage());
+        }
+        return validDatesOfBirth.stream()
                 .map(Attribute::getValue)
                 .reduce(BinaryOperator.maxBy(DateTimeComparator.getDateOnlyInstance()))
-                .map(Attributes::getFormattedDate)
-                .orElseThrow(() -> new HubResponseTranslationException("No verified current date of birth present"));
+                .map(Attributes::getFormattedDate).get();
     }
 
-    private static <T> List<Attribute<T>> getValidAttributes(List<Attribute<T>> attributes) {
-        return Optional.ofNullable(attributes).orElse(Collections.emptyList())
-                .stream()
-                .filter(Attribute::isValid)
-                .collect(Collectors.toList());
+    private static String combineStringAttributeValues(List<Attribute<String>> attributeStream) {
+        return attributeStream.stream().map(Attribute::getValue).filter(s -> !s.isEmpty()).collect(Collectors.joining(" "));
     }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/logging/EidasResponseAttributesHashLoggerTest.java
@@ -12,6 +12,7 @@ import uk.gov.ida.saml.core.transformers.EidasResponseAttributesHashLogger;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -31,23 +32,30 @@ public class EidasResponseAttributesHashLoggerTest {
     private Attributes attributes;
 
     @Mock
+    private Attributes.AttributesList<String> attributesList;
+
+    @Mock
+    private Attributes.AttributesList<DateTime> attributesListDateTime;
+
+    @Mock
     private EidasResponseAttributesHashLogger attributesHashLogger;
 
     @Test
     public void shouldOnlyIncludeFirstVerifiedFirstNameInHash() {
-        when(attributes.getFirstNames()).thenReturn(List.of(
-                new Attribute<>("FirstNameA", false, null, null),
+        when(attributes.getFirstNames()).thenReturn(attributesList);
+        when(attributes.getMiddleNames()).thenReturn(attributesList);
+        when(attributes.getSurnames()).thenReturn(attributesList);
+        when(attributes.getDatesOfBirth()).thenReturn(attributesListDateTime);
+        when(attributesList.getAllAttributes()).thenReturn(List.of(
                 new Attribute<>("FirstNameV1", true, null, null),
-                new Attribute<>("FirstNameB", false, null, null),
                 new Attribute<>("FirstNameV2", true, null, null)
-        ));
+                ))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Collections.emptyList());
 
         applyAttributesToLogger();
 
         verify(attributesHashLogger).setPid(PID);
-        verify(attributesHashLogger, times(1)).setFirstName(any());
-        verify(attributesHashLogger, never()).setFirstName("FirstNameA");
-        verify(attributesHashLogger, never()).setFirstName("FirstNameB");
         verify(attributesHashLogger).setFirstName("FirstNameV1");
         verify(attributesHashLogger, never()).setFirstName("FirstNameV2");
 
@@ -58,12 +66,20 @@ public class EidasResponseAttributesHashLoggerTest {
 
     @Test
     public void shouldIncludeAllMiddleNamesInHash() {
-        when(attributes.getMiddleNames()).thenReturn(List.of(
+        when(attributes.getFirstNames()).thenReturn(attributesList);
+        when(attributes.getMiddleNames()).thenReturn(attributesList);
+        when(attributes.getSurnames()).thenReturn(attributesList);
+        when(attributes.getDatesOfBirth()).thenReturn(attributesListDateTime);
+        when(attributesList.getAllAttributes())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(
                 new Attribute<>("MiddleNameA", false, null, null),
                 new Attribute<>("MiddleNameV1", true, null, null),
                 new Attribute<>("MiddleNameC", false, null, null),
                 new Attribute<>("MiddleNameV2", true, null, null)
-        ));
+                ))
+                .thenReturn(Collections.emptyList());
+        when(attributesListDateTime.getAllAttributes()).thenReturn(Collections.emptyList());
 
         applyAttributesToLogger();
 
@@ -83,13 +99,20 @@ public class EidasResponseAttributesHashLoggerTest {
 
     @Test
     public void shouldIncludeAllSurnamesInHash() {
-        when(attributes.getSurnames()).thenReturn(List.of(
+        when(attributes.getFirstNames()).thenReturn(attributesList);
+        when(attributes.getMiddleNames()).thenReturn(attributesList);
+        when(attributes.getSurnames()).thenReturn(attributesList);
+        when(attributes.getDatesOfBirth()).thenReturn(attributesListDateTime);
+        when(attributesList.getAllAttributes())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(List.of(
                 new Attribute<>("SurnameV1", true, null, null),
                 new Attribute<>("SurnameA", false, null, null),
                 new Attribute<>("SurnameV2", true, null, null),
                 new Attribute<>("SurnameB", false, null, null)
         ));
-
+        when(attributesListDateTime.getAllAttributes()).thenReturn(Collections.emptyList());
         applyAttributesToLogger();
 
         verify(attributesHashLogger).setPid(PID);
@@ -109,27 +132,30 @@ public class EidasResponseAttributesHashLoggerTest {
     @Test
     public void shouldOnlyIncludeFirstVerifiedDateOfBirthInHash() {
         final DateTime[] datesOfBirth = new DateTime[]{
-                new DateTime(1990, 1, 1, 0, 0),
                 new DateTime(1985, 9, 7, 14, 0),
-                new DateTime(1984, 10, 1, 0, 0),
                 new DateTime(1977, 12, 6, 12, 0)
         };
 
-        when(attributes.getDatesOfBirth()).thenReturn(List.of(
-                new Attribute<>(datesOfBirth[0], false, null, null),
-                new Attribute<>(datesOfBirth[1], true, null, null),
-                new Attribute<>(datesOfBirth[2], false, null, null),
-                new Attribute<>(datesOfBirth[3], true, null, null)
+        when(attributes.getFirstNames()).thenReturn(attributesList);
+        when(attributes.getMiddleNames()).thenReturn(attributesList);
+        when(attributes.getSurnames()).thenReturn(attributesList);
+        when(attributes.getDatesOfBirth()).thenReturn(attributesListDateTime);
+
+        when(attributesList.getAllAttributes())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Collections.emptyList());
+
+        when(attributesListDateTime.getAllAttributes()).thenReturn(List.of(
+                new Attribute<>(datesOfBirth[0], true, null, null),
+                new Attribute<>(datesOfBirth[1], true, null, null)
         ));
 
         applyAttributesToLogger();
 
         verify(attributesHashLogger).setPid(PID);
-        verify(attributesHashLogger, times(1)).setDateOfBirth(any());
-        verify(attributesHashLogger, never()).setDateOfBirth(datesOfBirth[0]);
-        verify(attributesHashLogger).setDateOfBirth(datesOfBirth[1]);
-        verify(attributesHashLogger, never()).setDateOfBirth(datesOfBirth[2]);
-        verify(attributesHashLogger, never()).setDateOfBirth(datesOfBirth[3]);
+        verify(attributesHashLogger).setDateOfBirth(datesOfBirth[0]);
+        verify(attributesHashLogger, never()).setDateOfBirth(datesOfBirth[1]);
 
         verify(attributesHashLogger, never()).addMiddleName(any());
         verify(attributesHashLogger, never()).addSurname(any());

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -20,6 +20,7 @@ import uk.gov.ida.saml.core.test.builders.ResponseBuilder;
 
 import java.net.URI;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createAttribute;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createDateTime;
@@ -121,13 +122,29 @@ public class HubResponseTranslatorTest {
     }
 
     @Test
-    public void translateShouldThrowWhenCurrentFirstNameNotValid() {
+    public void translateShouldReturnResponseWhenCurrentFirstNameNotVerifiedButNoFromOrToMakesItCurrent() {
+        final Attribute<String> firstName = createAttribute(AttributesBuilder.FIRST_NAME, false, null, null);
+        final HubResponseContainer hubResponseContainer = buildHubResponseContainer(attributesBuilder.withFirstName(firstName).build());
+        Attributes attributes = hubResponseContainer.getAttributes();
+        assertThat(attributes.getFirstNames().getValidAttributes().size()).isEqualTo(1);
+    }
+
+
+
+    @Test
+    public void translateShouldReturnResponseWhenCurrentFirstNameNotValidButCurrentFrom() {
         final Attribute<String> firstName = createAttribute(AttributesBuilder.FIRST_NAME, false, AttributesBuilder.VALID_FROM, null);
         final HubResponseContainer hubResponseContainer = buildHubResponseContainer(attributesBuilder.withFirstName(firstName).build());
+        Attributes attributes = hubResponseContainer.getAttributes();
+        assertThat(attributes.getFirstNames().getValidAttributes().size()).isEqualTo(1);
+    }
 
-        assertThatThrownBy(() -> TRANSLATOR.getTranslatedHubResponse(hubResponseContainer))
-                .isInstanceOf(HubResponseTranslationException.class)
-                .hasMessageContaining("No verified current first name present");
+    @Test
+    public void translateShouldReturnResponseWhenCurrentFirstNameNotValidButCurrentTo() {
+        final Attribute<String> firstName = createAttribute(AttributesBuilder.FIRST_NAME, false, null, DateTime.now().plusDays(1));
+        final HubResponseContainer hubResponseContainer = buildHubResponseContainer(attributesBuilder.withFirstName(firstName).build());
+        Attributes attributes = hubResponseContainer.getAttributes();
+        assertThat(attributes.getFirstNames().getValidAttributes().size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/EID-1687

There have been instances of the Proxy Node throwing “Error whilst handling Hub response. No verified current first name present”.

An attribute can be provided to a Member State if it is verified and valid for the present time, or if it is valid for the present time.

Currently an attribute is only provided in the former case.

1. Relax logic in the Attribute class to allow
    * the from date to be null,
    * allow no from and to date to be valid for the present time
2. Change translator logic to accept attributes in this order:
    * current and verified
    * If no attributes satisfying a), look for current (without
requiring verified)
3. Log when b) happens so we can track how many times this occurs
4. Log when no current with verified or unverified so we can track which scenarios we have to deal with

The attribute data to be logged is:
- 	the attribute type: first name, last name etc.
- 	is verified
- 	is validFrom not null
- 	is validTo not null
The attribute value will not be logged.

Note the use of the `var` keyword.