### PR TITLE
Initialise prometheus counters correctly

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/MetricsUtils.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/MetricsUtils.java
@@ -1,29 +1,5 @@
 package uk.gov.ida.notification;
 
-import io.prometheus.client.Counter;
-
 public class MetricsUtils {
-
-    private static final String LABEL_PREFIX = "verify_proxy_node";
-
-    public static final Counter REQUESTS = Counter.build(
-            LABEL_PREFIX + "_requests_total",
-            "Number of eIDAS SAML requests to Verify Proxy Node ")
-            .register();
-
-    public static final Counter REQUESTS_SUCCESSFUL = Counter.build(
-            LABEL_PREFIX + "_successful_requests_total",
-            "Number of successful eIDAS SAML requests to Verify Proxy Node")
-            .register();
-
-    public static final Counter RESPONSES = Counter.build(
-            LABEL_PREFIX + "_responses_total",
-            "Number of eIDAS SAML responses to Verify Proxy Node")
-            .register();
-
-    public static final Counter RESPONSES_SUCCESSFUL = Counter.build(
-            LABEL_PREFIX + "_successful_responses_total",
-            "Number of successful eIDAS SAML responses To Verify Proxy Node")
-            .register();
-
+    public static final String LABEL_PREFIX = "verify_proxy_node";
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -2,6 +2,7 @@ package uk.gov.ida.notification.resources;
 
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
+import io.prometheus.client.Counter;
 import uk.gov.ida.notification.MetricsUtils;
 import uk.gov.ida.notification.SamlFormViewBuilder;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
@@ -27,6 +28,14 @@ import javax.ws.rs.core.UriBuilder;
 @Path(Urls.GatewayUrls.GATEWAY_ROOT)
 public class HubResponseResource {
 
+    private static final Counter RESPONSES = Counter.build(
+            MetricsUtils.LABEL_PREFIX + "_responses_total",
+            "Number of eIDAS SAML responses to Verify Proxy Node")
+            .register();
+    private static final Counter RESPONSES_SUCCESSFUL = Counter.build(
+            MetricsUtils.LABEL_PREFIX + "_successful_responses_total",
+            "Number of successful eIDAS SAML responses To Verify Proxy Node")
+            .register();
     static final String LEVEL_OF_ASSURANCE = "LEVEL_2";
 
     private final SamlFormViewBuilder samlFormViewBuilder;
@@ -49,7 +58,7 @@ public class HubResponseResource {
         @FormParam(SamlFormMessageType.SAML_RESPONSE) @ValidBase64Xml String hubResponse,
         @FormParam("RelayState") String relayState,
         @Session HttpSession session) {
-        MetricsUtils.RESPONSES.inc();
+        RESPONSES.inc();
         GatewaySessionData sessionData = sessionStorage.getSession(session.getId());
 
         ProxyNodeLogger.info("Retrieved GatewaySessionData");
@@ -71,7 +80,7 @@ public class HubResponseResource {
                 eidasResponse,
                 sessionData.getEidasRelayState()
         );
-        MetricsUtils.RESPONSES_SUCCESSFUL.inc();
+        RESPONSES_SUCCESSFUL.inc();
         return samlFormView;
     }
 }


### PR DESCRIPTION
Currently, the prometheus counters aren't getting initialised
correctly.  If you look at `verify_proxy_node_requests_total` in
Grafana's explore view, you see that counters start from 1, when the
first request happens, not 0, when the app starts.  This means that we
will be missing requests from our count of requests (and of successful
requests).

The problem is less pressing for the response counters, because the
first time *any* counter is accessed, they *all* get initialised.

I think this is because the counters are being created in static
initialisers in MetricUtils.  When do static initialisers run?  It's
complicated, but section 12.4 of the standard is the authority [1].
In particular, static initialisers run when the class is initialised,
which can happen when:

 - a static field is accessed
 - an instance of the class is created

This commit fixes that by moving the counters out of MetricUtils and
into the classes that use them.  This means that the static
initialisers will be run during app startup in the
GatewayApplication.run() method, because this is where instances of
the Resource classes are created.  This means that the Counters should
be initialised to 0 at app startup correctly.

This is similar to the common pattern of putting loggers in the
consuming class with static initialisers.

At this point the MetricUtils class is not terribly useful but I
wasn't sure whether we preferred to keep the code DRY or to inline the
METRIC_PREFIX constant to remove the MetricUtils class.

[1]: https://docs.oracle.com/javase/specs/jls/se11/html/jls-12.html#jls-12.4