### PR TITLE
fix istio metrics to actually work

### DIFF
--- a/chart/templates/metrics.yaml
+++ b/chart/templates/metrics.yaml
@@ -39,9 +39,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   actions:
-  - handler: prometheusbypath
+  - handler: {{ .Release.Name }}-prometheus-by-path-handler
     instances:
-    - requestcountbypath.metric
+    - {{ .Release.Name }}-metrics-request-count-by-path.metric
   match: (context.protocol == "http") && (match((request.useragent | "-"), "kube-probe*") == false)
 ---
 apiVersion: config.istio.io/v1alpha2
@@ -55,7 +55,7 @@ spec:
   compiledAdapter: prometheus
   params:
     metrics:
-    - instance_name: requestcountbypath.metric.{{ .Release.Namespace }}
+    - instance_name: {{ .Release.Name }}-metrics-request-count-by-path.metric.{{ .Release.Namespace }}
       kind: COUNTER
       label_names:
       - reporter
@@ -76,6 +76,6 @@ spec:
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
-      name: {{ .Release.Namespace | replace "-" "_" }}_requests_by_path_total
+      name: {{ .Release.Namespace | replace "-" "_" }}_{{ .Release.Name | replace "-" "_" }}_requests_by_path_total
     metricsExpirationPolicy:
       metricsExpiryDuration: 10m


### PR DESCRIPTION
These istio metrics were originally created in #310 and worked
provided you only had a single helm release per namespace.  However
because it didn't include appropriate `{{ .Release.Name }}` scoping in
the resource names, it completely blocked the ability to deploy
multiple instances per namespace.

That problem was fixed in #322, which changed the resource names to
include `{{ .Release.Name }}` as appropriate.  However it didn't
update references to those resource names, nor did it update the name
of the underlying prometheus metric.  This means that the istio
metrics from #310 aren't currently being recorded at all.

This commit fixes the resource references to actually point at each
other, and also adds the `{{ .Release.Name }}` to the prometheus
metric name.  Hopefully, once this is merged we'll be able to see
metrics like `verify_proxy_node_prod_nl_requests_by_path_total` for
each release of the proxy node in each namespace.