### PR TITLE
EID-1761 Improve Proxy Node error logging

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -247,7 +247,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         postEidasAuthnRequest(eidasSamlParserAppRule, authnRequest);
 
         ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
-        verify(appender, times(6)).doAppend(loggingEventArgumentCaptor.capture());
+        verify(appender, times(5)).doAppend(loggingEventArgumentCaptor.capture());
 
         final List<ILoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
         final Map<String, String> mdcPropertyMap = logEvents.stream()

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+./gradlew clean test

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-set -e
 ./gradlew clean test

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/istio/IstioHeaderMapperFilter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/istio/IstioHeaderMapperFilter.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.notification.shared.istio;
 
 import uk.gov.ida.notification.shared.logging.IngressEgressLogging;
-import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -25,8 +24,6 @@ public class IstioHeaderMapperFilter implements ContainerResponseFilter, Contain
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         istioHeaderStorage.appendIstioHeadersToResponseContextHeaders(responseContext);
-        // TODO: remove once istio tracing works
-        ProxyNodeLogger.info(istioHeaderStorage.toString());
         istioHeaderStorage.clear();
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLogger.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLogger.java
@@ -1,10 +1,7 @@
 package uk.gov.ida.notification.shared.logging;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.MDC;
 
-import java.util.Optional;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -35,42 +32,19 @@ public class ProxyNodeLogger {
     }
 
     public static void logException(Throwable exception, Level level, String message) {
-        addExceptionContext(exception);
-        log(level, message, exception);
+        logInternal(level, message, exception);
     }
 
     private static void log(Level level, String message) {
-        logWithCallingFrame(level, () -> message, null);
+        logInternal(level, message, null);
     }
 
-    private static void log(Level level, String message, Throwable exception) {
-        logWithCallingFrame(level, () -> message, exception);
+    private static void logInternal(Level level, String message, Throwable exception) {
+        if (exception != null) {
+            LOG.log(level, message, exception);
+        } else {
+            LOG.log(level, message);
+        }
     }
 
-    private static void log(Level level, Supplier<String> message) {
-        logWithCallingFrame(level, message, null);
-    }
-
-    private static void addExceptionContext(Throwable exception) {
-        addContext(ProxyNodeMDCKey.EXCEPTION_MESSAGE, exception.getMessage());
-        addContext(ProxyNodeMDCKey.EXCEPTION_STACKTRACE, ExceptionUtils.getStackTrace(exception));
-    }
-
-    private static void logWithCallingFrame(Level level, Supplier<String> message, Throwable exception) {
-        Optional<StackWalker.StackFrame> callingFrame = getCallingStackFrame();
-        callingFrame.ifPresent(f -> {
-            addContext(ProxyNodeMDCKey.LOG_LOCATION, String.format("%s.%s", f.getClassName(), f.getMethodName()));
-            if (exception != null) {
-                LOG.log(level, message.get(), exception);
-            } else {
-                LOG.log(level, message);
-            }
-            MDC.remove(ProxyNodeMDCKey.LOG_LOCATION.name());
-        });
-    }
-
-    private static Optional<StackWalker.StackFrame> getCallingStackFrame() {
-        return StackWalker.getInstance().walk(
-                s -> s.dropWhile(f -> f.getClassName().startsWith(ProxyNodeLogger.class.getName())).findFirst());
-    }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLogger.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLogger.java
@@ -32,14 +32,14 @@ public class ProxyNodeLogger {
     }
 
     public static void logException(Throwable exception, Level level, String message) {
-        logInternal(level, message, exception);
+        log(level, message, exception);
     }
 
     private static void log(Level level, String message) {
-        logInternal(level, message, null);
+        log(level, message, null);
     }
 
-    private static void logInternal(Level level, String message, Throwable exception) {
+    private static void log(Level level, String message, Throwable exception) {
         if (exception != null) {
             LOG.log(level, message, exception);
         } else {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLoggingFilter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeLoggingFilter.java
@@ -35,7 +35,7 @@ public class ProxyNodeLoggingFilter implements ContainerRequestFilter, Container
         }
 
         ProxyNodeLogger.addContext(PROXY_NODE_JOURNEY_ID, getJourneyId(requestContext));
-        ProxyNodeLogger.addContext(REFERER, requestContext.getHeaderString(HttpHeaders.REFERER));
+        ProxyNodeLogger.addContext(REFERER, Optional.ofNullable(requestContext.getHeaderString(HttpHeaders.REFERER)).orElse(""));
         Optional.ofNullable(requestContext.getUriInfo()).ifPresent(u -> ProxyNodeLogger.addContext(RESOURCE_PATH, u.getAbsolutePath().toString()));
         Optional.ofNullable(requestContext.getMediaType()).ifPresent(m -> ProxyNodeLogger.addContext(INGRESS_MEDIA_TYPE, m.toString()));
         ProxyNodeLogger.info(MESSAGE_INGRESS);

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeMDCKey.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/shared/logging/ProxyNodeMDCKey.java
@@ -1,7 +1,6 @@
 package uk.gov.ida.notification.shared.logging;
 
 public enum ProxyNodeMDCKey {
-    LOG_LOCATION,
     HUB_REQUEST_ID,
     HUB_URL,
     EIDAS_REQUEST_ID,
@@ -11,8 +10,6 @@ public enum ProxyNodeMDCKey {
     CONNECTOR_PUBLIC_ENC_CERT_SUFFIX,
     SIGNING_PROVIDER,
     EIDAS_LOA,
-    EXCEPTION_STACKTRACE,
-    EXCEPTION_MESSAGE,
     SESSION_ID,
     REFERER,
     RESOURCE_PATH,

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/ProxyNodeLoggerTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/shared/ProxyNodeLoggerTest.java
@@ -14,9 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
-import uk.gov.ida.notification.shared.logging.ProxyNodeMDCKey;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -39,35 +36,6 @@ public class ProxyNodeLoggerTest {
     @Before
     public void setUp() {
         LOGGER.addAppender(appender);
-    }
-
-    @Test
-    public void shouldNotLogProxyNodeLoggerAsTheLogLocation() {
-        ProxyNodeLogger.info("test");
-
-        verify(appender).doAppend(loggingEventCaptor.capture());
-
-        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
-        assertThat(logEvent.getMDCPropertyMap().get(ProxyNodeMDCKey.LOG_LOCATION.name())).doesNotContain(ProxyNodeLogger.class.getName());
-        assertThat(logEvent.getMDCPropertyMap().get(ProxyNodeMDCKey.LOG_LOCATION.name())).contains("ProxyNodeLoggerTest.shouldNotLogProxyNodeLoggerAsTheLogLocation");
-    }
-
-    @Test
-    public void shouldAddExceptionContext() {
-        Exception cause = new Exception("cause-message");
-        Exception exception = new Exception("exception-message", cause);
-
-        ProxyNodeLogger.logException(exception, java.util.logging.Level.SEVERE, "log-message");
-
-        verify(appender).doAppend(loggingEventCaptor.capture());
-
-        final ILoggingEvent logEvent = loggingEventCaptor.getValue();
-        assertThat(logEvent.getLevel()).isEqualTo(Level.ERROR);
-        assertThat(logEvent.getMessage()).isEqualTo("log-message");
-
-        final Map<String, String> mdc = logEvent.getMDCPropertyMap();
-        assertThat(mdc.get(ProxyNodeMDCKey.EXCEPTION_MESSAGE.name())).isEqualTo("exception-message");
-        assertThat(mdc.get(ProxyNodeMDCKey.EXCEPTION_STACKTRACE.name())).contains("java.lang.Exception: exception-message");
     }
 
     @Test

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -187,7 +187,7 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
 
         Response eidasResponse = extractEidasResponseFromTranslator(buildSignedHubResponse());
 
-        verify(appender, Mockito.times(5)).doAppend(loggingEventArgumentCaptor.capture());
+        verify(appender, Mockito.times(4)).doAppend(loggingEventArgumentCaptor.capture());
 
         final List<ILoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
         final Map<String, String> mdcPropertyMap = logEvents.stream()


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/EID-1761

Tidy up Proxy Node error logging, to remove fields `EXCEPTION_STACKTRACE`, `EXCEPTION_MESSAGE` and `LOG_LOCATION`, to produce an error event like:

````
{
  "exception": "error message and stack trace ...",
  "level": "WARN",
  "logger": "uk.gov.ida.notification.shared.logging.ProxyNodeLogger",
  "thread": "dw-74 - POST /SAML2/SSO/Response/POST",
  "message": "Error whilst contacting URI [http://localhost:51529/SAML2/SSO/Response/POST]",
  "HUB_REQUEST_ID": "a hub request id",
  "PROXY_NODE_JOURNEY_ID": "_af111e686076206535861fc6c6d2597d",
  "RESOURCE_PATH": "http://localhost:51529/SAML2/SSO/Response/POST",
  "SESSION_ID": "node05yd8shxs9kck1c55vwpih391b2",
  "REFERER": "",
  "EIDAS_REQUEST_ID": "_95338268-84ae-427b-89cf-55b81bcb4181",
  "timestamp": 1573223548800
}

````
The changes are:
* Remove duplication of exception stack trace, message in logs by removing the `EXCEPTION_STACKTRACE`, `EXCEPTION_MESSAGE` attributes - these are retained by the `exception` and `message` attributes which are hoisted onto the MDC by Dropwizard
* Do not continue to log exception on the current thread
* Remove logging the class and method that produced the logging - we can figure this out
* Remove istio header logging, it's not being used
* Log referer as `""` if null

Note that the issue of Splunk timestamps not matching the timestamp fields from the log events is not addressed.
