### PR TITLE
A simple Grafana dashboard for the Proxy Node

### DIFF
--- a/ci/prod/dashboard.yaml
+++ b/ci/prod/dashboard.yaml
@@ -1,0 +1,219 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboard
+  namespace: verify-proxy-node-prod
+  labels:
+    grafana_dashboard: "1"
+data:
+  verify_proxy_node_prod_dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 22,
+      "links": [],
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "links": [],
+          "options": {
+            "displayMode": "gradient",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "max": 10,
+                "min": 0,
+                "thresholds": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal"
+          },
+          "pluginVersion": "6.3.5",
+          "targets": [
+            {
+              "expr": "sum(increase(verify_proxy_node_successful_responses_total{namespace=\"verify-proxy-node-prod\"}[24h])) by (release)",
+              "legendFormat": "{{release}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "eIDAS Responses (last 24h)",
+          "type": "bargauge"
+        },
+        {
+          "cacheTimeout": null,
+          "description": "Errors where the user could not be sent back to the eIDAS connector node, i.e. their journey ended in failure on a Verify error page.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 6,
+          "links": [],
+          "options": {
+            "displayMode": "lcd",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "max": 2,
+                "min": 0,
+                "thresholds": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.05
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 8
+                  }
+                ]
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal"
+          },
+          "pluginVersion": "6.3.5",
+          "targets": [
+            {
+              "expr": "increase(verify_proxy_node_failure_error_page{namespace=\"verify-proxy-node-prod\"}[1h])",
+              "instant": false,
+              "legendFormat": "{{release}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Errors pages (1h)",
+          "type": "bargauge"
+        },
+        {
+          "cacheTimeout": null,
+          "description": "Errors where the user was sent back to the eIDAS connector node due to a failure to register or sign in.",
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 8,
+          "links": [],
+          "options": {
+            "displayMode": "lcd",
+            "fieldOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "defaults": {
+                "mappings": [],
+                "max": 5,
+                "min": 0,
+                "thresholds": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.05
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 4
+                  }
+                ]
+              },
+              "override": {},
+              "values": false
+            },
+            "orientation": "horizontal"
+          },
+          "pluginVersion": "6.3.5",
+          "targets": [
+            {
+              "expr": "\nincrease(verify_proxy_node_failure_saml_error_responses_total{namespace=\"verify-proxy-node-prod\"}[1h])",
+              "instant": false,
+              "legendFormat": "{{release}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Error responses (1h)",
+          "type": "bargauge"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 19,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-24h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "eIDAS Proxy Node Monitoring",
+      "uid": "0F-KUN1Wk",
+      "version": 1
+    }


### PR DESCRIPTION
Dashboards created in [GSP Verify Grafana](https://grafana.london.verify.govsvc.uk) are ephemeral. Defining a dashboard as kubeyaml persists them.

This PR is step 1 in proving this persistence.

We want a single dashboard for the `verify-proxy-node-prod` namespace, so this`ConfigMap` deployment is defined in `ci/prod` only. As a result there is no helm templating.

The name of the dash definition, `verify_proxy_node_prod_dashboard.json` must be global to the cluster.

Also, please don't consider the dashboard json in this PR - this will be updated susequently.
