### PR TITLE
EID-1823 Update urls for multi-country build release

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 
 {{- define "gateway.host" -}}
-{{- printf "%s-%s.%s" .Release.Name .Chart.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s-%s-%s.%s" "eidas" .Chart.Name .Release.Name  (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "gateway.entityID" -}}
@@ -9,7 +9,7 @@
 
 {{- define "stubConnector.host" -}}
 {{- if .Values.stubConnector.enabled -}}
-{{- printf "%s-%s.%s" .Release.Name "connector" (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s-%s.%s" "eidas-stub-connector" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.stubConnector.host -}}
 {{- end -}}

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -613,8 +613,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -601,8 +601,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/proxy-node-acceptance-tests/run-staging-tests.sh
+++ b/proxy-node-acceptance-tests/run-staging-tests.sh
@@ -4,8 +4,8 @@ set -eu
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-export PROXY_NODE_URL="https://test-proxy-node.london.verify.govsvc.uk"
-export STUB_CONNECTOR_URL="https://test-connector.london.verify.govsvc.uk"
+export PROXY_NODE_URL="https://eidas-proxy-node-test.london.verify.govsvc.uk"
+export STUB_CONNECTOR_URL="https://eidas-stub-connector-test.london.verify.govsvc.uk"
 export STUB_IDP_USER="stub-idp-demo-one"
 docker-compose up --abort-on-container-exit | grep acceptance-tests_1 --colour=never
 docker cp $(docker ps -a -q -f name="acceptance-tests"):/testreport .

--- a/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
+++ b/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
+++ b/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
+++ b/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
+++ b/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
+++ b/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
+++ b/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="/SAML2/SSO/POST"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="/Redirect"
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/EID-1823

Update subdomains of stub-connector and gateway for the build release on the new multi-country build namespace.

Required as we are still running a test release on the BAU `release/single-country-legacy` branch, and we need a unique subdomain on the cluster.

The agreed urls are:
Stub Connector: https://eidas-stub-connector-test.london.verify.govsvc.uk
Gateway: https://eidas-proxy-node-test.london.verify.govsvc.uk