### PR TITLE
EID-1542: Make the no-js "Continue" button the same as in the Hub

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./gradlew clean test
+./gradlew --parallel clean test

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -44,7 +44,7 @@ public class EidasAuthnRequestResource {
             MetricsUtils.LABEL_PREFIX + "_successful_requests_total",
             "Number of successful eIDAS SAML requests to Verify Proxy Node")
             .register();
-    public static final String SUBMIT_BUTTON_TEXT = "Post Verify Authn Request to Hub";
+
     private final EidasSamlParserProxy eidasSamlParserService;
     private final VerifyServiceProviderProxy vspProxy;
     private final SamlFormViewBuilder samlFormViewBuilder;
@@ -123,6 +123,6 @@ public class EidasAuthnRequestResource {
     private SamlFormView buildSamlFormView(AuthnRequestResponse vspResponse, String relayState) {
         URI hubUrl = vspResponse.getSsoLocation();
         String samlRequest = vspResponse.getSamlRequest();
-        return samlFormViewBuilder.buildRequest(hubUrl.toString(), samlRequest, SUBMIT_BUTTON_TEXT, relayState);
+        return samlFormViewBuilder.buildRequest(hubUrl.toString(), samlRequest, relayState);
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
@@ -44,9 +44,8 @@ public class SamlResponseExceptionMapperResourceRuleTest {
                 new SamlFormView("postUrl",
                                  "samlMessageType",
                                  "encodedSamlMessage",
-                                 "submitText"));
+                                 "relayState"));
     }
-
 
     @Test
     public void shouldMapSessionAlreadyExistsExceptionToExceptionToSamlErrorResponseMapper() {

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/EidasAuthnRequestResourceTest.java
@@ -43,7 +43,6 @@ import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_EID
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_HUB_SAML_AUTHN_REQUEST;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_ISSUER;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_REQUEST_ID;
-import static uk.gov.ida.notification.resources.EidasAuthnRequestResource.SUBMIT_BUTTON_TEXT;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EidasAuthnRequestResourceTest {
@@ -138,7 +137,7 @@ public class EidasAuthnRequestResourceTest {
 
         verify(eidasSamlParserService).parse(captorEidasSamlParserRequest.capture(), any(String.class));
         verify(vspProxy).generateAuthnRequest(any(String.class));
-        verify(samlFormViewBuilder).buildRequest("http://hub.bub", SAMPLE_HUB_SAML_AUTHN_REQUEST, SUBMIT_BUTTON_TEXT, "journey id");
+        verify(samlFormViewBuilder).buildRequest("http://hub.bub", SAMPLE_HUB_SAML_AUTHN_REQUEST, "journey id");
         verify(session).getAttribute(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name());
         verifyNoMoreInteractions(vspProxy, eidasSamlParserService, appender, samlFormViewBuilder, session);
         verifyNoMoreInteractions(sessionStore);

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/SamlFormViewBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/SamlFormViewBuilder.java
@@ -10,13 +10,13 @@ import uk.gov.ida.notification.views.SamlFormView;
 public class SamlFormViewBuilder {
     private SamlObjectMarshaller marshaller = new SamlObjectMarshaller();
 
-    public SamlFormView buildRequest(String url, AuthnRequest authnRequest, String submitText, String relayState) {
+    public SamlFormView buildRequest(String url, AuthnRequest authnRequest, String relayState) {
         String samlMessage = marshaller.transformToString(authnRequest);
         String encodedSamlMessage = Base64.encodeAsString(samlMessage);
-        return buildRequest(url, encodedSamlMessage, submitText, relayState);
+        return buildRequest(url, encodedSamlMessage, relayState);
     }
 
-    public SamlFormView buildRequest(String url, String encodedSamlMessage, String submitText, String relayState) {
+    public SamlFormView buildRequest(String url, String encodedSamlMessage, String relayState) {
         return new SamlFormView(url, SamlFormMessageType.SAML_REQUEST, encodedSamlMessage, relayState);
     }
 

--- a/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
+++ b/proxy-node-shared/src/main/resources/uk/gov/ida/notification/views/saml-form.mustache
@@ -89,7 +89,7 @@
     </div>
     <input type=hidden name={{samlMessageType}} value={{encodedSamlMessage}}>
     <input type=hidden name=RelayState value={{relayState}}>
-    <input type=submit name=submitBtn value=Submit class="button">
+    <input type=submit name=submitBtn value=Continue class="button">
 </form>
 </body>
 </html>

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/SamlFormViewBuilderTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/SamlFormViewBuilderTest.java
@@ -22,7 +22,7 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
 
         String encodedAuthnRequest = Base64.encodeAsString(MARSHALLER.transformToString(authnRequest));
 
-        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildRequest("url", authnRequest, "submit", "relay");
+        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildRequest("url", authnRequest, "relay");
 
         assertThat(SamlFormMessageType.SAML_REQUEST).isEqualTo(view.getSamlMessageType());
         assertThat(encodedAuthnRequest).isEqualTo(view.getEncodedSamlMessage());
@@ -33,7 +33,7 @@ public class SamlFormViewBuilderTest extends SamlInitializedTest {
     @Test
     public void shouldGenerateSAMLRequestFormFromEncodedSAMLMessage() {
         String encodedAuthnRequest = Base64.encodeAsString("a saml blob");
-        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildRequest("url", encodedAuthnRequest, "submit", "relay");
+        SamlFormView view = SAML_FORM_VIEW_BUILDER.buildRequest("url", encodedAuthnRequest, "relay");
         assertThat(SamlFormMessageType.SAML_REQUEST).isEqualTo(view.getSamlMessageType());
         assertThat(encodedAuthnRequest).isEqualTo(view.getEncodedSamlMessage());
         assertThat("url").isEqualTo(view.getPostUrl());


### PR DESCRIPTION
The Hub button says "Continue", not "Submit".
Also clean up the unnecessary args as the button text is no longer customisable.