### PR TITLE
remove commit_verification_keys

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -18,7 +18,6 @@ spec:
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
       required_approval_count: 2
-      commit_verification_keys: ((trusted-developers.gpg-keys))
 
     harbor_source: &harbor_source
       username: ((harbor.harbor_username))
@@ -38,8 +37,8 @@ spec:
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     image_tag: &image_tag
       tag_file: src/.git/short_ref
@@ -60,8 +59,8 @@ spec:
     - name: github
       type: registry-image
       source:
-        repository: govsvc/concourse-github-resource
-        tag: v0.0.1
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     - name: harbor
       type: docker-image

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -18,21 +18,20 @@ spec:
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
       required_approval_count: 2
-      commit_verification_keys: ((trusted-developers.gpg-keys))
 
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     resource_types:
 
     - name: github
       type: registry-image
       source:
-        repository: govsvc/concourse-github-resource
-        tag: v0.0.3
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     resources:
 

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -18,21 +18,20 @@ spec:
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
       required_approval_count: 2
-      commit_verification_keys: ((trusted-developers.gpg-keys))
 
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     resource_types:
 
     - name: github
       type: registry-image
       source:
-        repository: govsvc/concourse-github-resource
-        tag: v0.0.3
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     resources:
 

--- a/ci/prod/killswitch-pipeline.yaml
+++ b/ci/prod/killswitch-pipeline.yaml
@@ -13,8 +13,8 @@ spec:
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     jobs:
 

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -18,7 +18,6 @@ spec:
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
       required_approval_count: 0
-      commit_verification_keys: ((trusted-developers.gpg-keys))
 
     harbor_source: &harbor_source
       username: ((harbor.harbor_username))
@@ -38,8 +37,8 @@ spec:
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     image_tag: &image_tag
       tag_file: src/.git/short_ref
@@ -60,8 +59,8 @@ spec:
     - name: github
       type: registry-image
       source:
-        repository: govsvc/concourse-github-resource
-        tag: v0.0.1
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     - name: harbor
       type: docker-image

--- a/ci/sandbox/deploy-pipeline.yaml
+++ b/ci/sandbox/deploy-pipeline.yaml
@@ -18,21 +18,20 @@ spec:
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
       required_approval_count: 0
-      commit_verification_keys: ((trusted-developers.gpg-keys))
 
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     resource_types:
 
     - name: github
       type: registry-image
       source:
-        repository: govsvc/concourse-github-resource
-        tag: v0.0.3
+        repository: ((concourse.github-resource-image))
+        tag: ((concourse.github-resource-tag))
 
     resources:
 

--- a/ci/sandbox/killswitch-pipeline.yaml
+++ b/ci/sandbox/killswitch-pipeline.yaml
@@ -13,8 +13,8 @@ spec:
     task_toolbox: &task_toolbox
       type: docker-image
       source:
-        repository: govsvc/task-toolbox
-        tag: 1.5.0
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
 
     jobs:
 


### PR DESCRIPTION
The latest version of the github resource doesn't need this (since
alphagov/gsp#378).  Instead the process is to add your GPG key to
GitHub and get GitHub to verify the signature; we only need to
validate the signature on the GitHub merge commit against the GitHub
web flow key.

Note that if we can get rid of commit_verification_keys from all our
pipelines, we can also merge alphagov/gds-trusted-developers#111 so
that we no longer have to faff with GPG keys in that repository when
people join teams that commit to GSP projects.

This also bumps the task-toolbox and github-resource references to use
the tag provided by GSP in the `concourse` secret.