### PR TITLE
BAU: build with latest java 11 on amazonlinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,7 @@
-# Base AWS Java app image
-
-ARG JAVA_HOME=/usr/local/openjdk-11
-FROM openjdk:11-jre-slim AS jre
-
-FROM amazonlinux:2.0.20190508
-WORKDIR /app
+FROM amazonlinux:2.0.20191016.0
 
 # Install Java
-ARG JAVA_HOME
-ENV JAVA_HOME $JAVA_HOME
-ENV PATH=$PATH:$JAVA_HOME/bin
-COPY --from=jre $JAVA_HOME $JAVA_HOME
+RUN yum install -y java-11-amazon-corretto
 
 # Install AWS CloudHSM Java library if needed
 ARG TALKS_TO_HSM=false

--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -1,6 +1,6 @@
 # AWS CloudHSM client
 
-FROM amazonlinux:2.0.20190508
+FROM amazonlinux:2.0.20191016.0
 WORKDIR /cloudhsm
 
 # Install AWS CloudHSM client

--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -1,9 +1,8 @@
 # Base builder image to build apps that need to talk to the HSM cient
+FROM amazonlinux:2.0.20191016.0
 
-FROM amazonlinux:2.0.20190508
-
-# Install JDK
-RUN amazon-linux-extras install java-openjdk11
+# Install Java
+RUN yum install -y java-11-amazon-corretto
 
 # Install AWS CloudHSM client and libs
 ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .

--- a/proxy-node-vsp-config/Dockerfile
+++ b/proxy-node-vsp-config/Dockerfile
@@ -1,14 +1,8 @@
-ARG JAVA_HOME=/usr/local/openjdk-11
-FROM openjdk:11-jre-slim AS jre
-
-FROM amazonlinux:2.0.20190508
+FROM amazonlinux:2.0.20191016.0
 WORKDIR /verify-service-provider
 
 # Install Java
-ARG JAVA_HOME
-ENV JAVA_HOME $JAVA_HOME
-ENV PATH=$PATH:$JAVA_HOME/bin
-COPY --from=jre $JAVA_HOME $JAVA_HOME
+RUN yum install -y java-11-amazon-corretto
 
 # Instal VSP app
 COPY build/install/verify-service-provider .


### PR DESCRIPTION
Install `java-11-amazon-corretto` on the container against latest `amazonlinux`.

This fixes the `javax.net.ssl.SSLPeerUnverifiedException: peer not authenticated` error we were getting when connecting to https://plugins.gradle.org:443 using TLS 1.3.

A failed example build that this PR fixes is https://ci.london.sandbox.govsvc.uk/teams/proxy-node-dev/pipelines/build-release/jobs/build-proxy-node/builds/60