### PR TITLE
Update build namespace to refer to release branch

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -78,7 +78,7 @@ spec:
       source:
         <<: *github_source
         ignore_paths: [cloudhsm, proxy-node-vsp-config, ci]
-        branch: master
+        branch: release/single-country-legacy
 
     - name: vsp-src
       icon: github-circle
@@ -93,7 +93,7 @@ spec:
       source:
         <<: *github_source
         paths: [proxy-node-vsp-config]
-        branch: master
+        branch: release/single-country-legacy
 
     - name: cloudhsm-config
       type: github
@@ -101,7 +101,7 @@ spec:
       source:
         <<: *github_source
         paths: [cloudhsm]
-        branch: master
+        branch: release/single-country-legacy
 
     - name: release
       type: github-release

--- a/proxy-node-vsp-config/Dockerfile
+++ b/proxy-node-vsp-config/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=jre $JAVA_HOME $JAVA_HOME
 COPY build/install/verify-service-provider .
 
 RUN rm verify-service-provider.yml
-ADD https://raw.githubusercontent.com/alphagov/verify-proxy-node/master/proxy-node-vsp-config/verify-service-provider.yml verify-service-provider.yml
+ADD https://raw.githubusercontent.com/alphagov/verify-proxy-node/release/single-country-legacy/proxy-node-vsp-config/verify-service-provider.yml verify-service-provider.yml
 
 ENTRYPOINT ["bin/verify-service-provider"]
 CMD ["server", "verify-service-provider.yml"]


### PR DESCRIPTION
We want to update our build pipeline to refer to the new release branch.

We did this before but didn't branch off the release branch and then merge onto it using the GSP process. This is a take 2.