### PR TITLE
EID-1822 Refer to release branch on build and release pipeline

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -13,6 +13,7 @@ spec:
       organization: alphagov
       owner: alphagov
       repository: verify-proxy-node
+      branch: release/single-country-legacy
       github_api_token: ((github.api-token))
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
@@ -77,7 +78,6 @@ spec:
       source:
         <<: *github_source
         ignore_paths: [cloudhsm, proxy-node-vsp-config, ci]
-        branch: release/single-country-legacy
 
     - name: vsp-src
       icon: github-circle
@@ -92,7 +92,6 @@ spec:
       source:
         <<: *github_source
         paths: [proxy-node-vsp-config]
-        branch: release/single-country-legacy
 
     - name: cloudhsm-config
       type: github
@@ -100,7 +99,6 @@ spec:
       source:
         <<: *github_source
         paths: [cloudhsm]
-        branch: release/single-country-legacy
 
     - name: release
       type: github-release


### PR DESCRIPTION
Refer to the release branch when building and releasing on the "legacy" build pipeline.