### PR TITLE
EID-1822 Only deploy to prod & int on a "v1." release

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -106,6 +106,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: "^v1\.\d+$"
 
     - name: alpine-image
       type: docker-image

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -40,6 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: "^v1\.\d+$"
 
     - name: daily
       type: time

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -40,6 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: "^v1\.\d+$"
 
     - name: nightly
       type: time


### PR DESCRIPTION
Applies the `tag_filter` regex `^v1\.\d+$` to the [concourse github-release resource](https://github.com/concourse/github-release-resource).

As there are no capturing groups in the regex, the full match will be expected.

The regex with test cases can be evaluated here: https://regex101.com/r/RZ8jwP/1

I believe this will enforce that this **release branch** will only support creating release tags in this regex format, and will only accept releases in this format for deployment to integration and production.

Following this PR, we will enforce that releases on the **master branch** are aligned with a `v2.` release tag.