### PR TITLE
EID-1822 Amend regex to remove quotes

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -104,7 +104,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
-        tag_filter: "^v1\.\d+$"
+        tag_filter: ^v1\.\d+$
 
     - name: alpine-image
       type: docker-image

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -40,7 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
-        tag_filter: "^v1\.\d+$"
+        tag_filter: ^v1\.\d+$
 
     - name: daily
       type: time

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -40,7 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
-        tag_filter: "^v1\.\d+$"
+        tag_filter: ^v1\.\d+$
 
     - name: nightly
       type: time


### PR DESCRIPTION
The quotes in the regex were causing an "found unknown escape character" message in configure namespace pipelines.

This is a fix to https://github.com/alphagov/verify-proxy-node/pull/385

Other examples that do not use quotes are: https://github.com/alphagov/gsp/search?q=tag_filter&unscoped_q=tag_filter