### PR TITLE
EID-1822: Use the Amazon Corretto🍦image as the base image for apps that need Java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,7 @@
 # Base AWS Java app image
 
-ARG JAVA_HOME=/usr/local/openjdk-11
-FROM openjdk:11-jre-slim AS jre
-
-FROM amazonlinux:2.0.20190508
+FROM amazoncorretto:11
 WORKDIR /app
-
-# Install Java
-ARG JAVA_HOME
-ENV JAVA_HOME $JAVA_HOME
-ENV PATH=$PATH:$JAVA_HOME/bin
-COPY --from=jre $JAVA_HOME $JAVA_HOME
 
 # Install AWS CloudHSM Java library if needed
 ARG TALKS_TO_HSM=false

--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -1,6 +1,6 @@
 # AWS CloudHSM client
 
-FROM amazonlinux:2.0.20190508
+FROM amazonlinux:2
 WORKDIR /cloudhsm
 
 # Install AWS CloudHSM client

--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -1,9 +1,6 @@
 # Base builder image to build apps that need to talk to the HSM cient
 
-FROM amazonlinux:2.0.20190508
-
-# Install JDK
-RUN amazon-linux-extras install java-openjdk11
+FROM amazoncorretto:11
 
 # Install AWS CloudHSM client and libs
 ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .
@@ -12,7 +9,3 @@ ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-cli
 RUN yum install -y ./cloudhsm-client-*.rpm \
  && rm ./cloudhsm-client-*.rpm \
  && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
-
-RUN echo export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep "java.home" | awk '{print $3}') \
-    >> /etc/profile.d/sh.local
-


### PR DESCRIPTION
This image is provided by Amazon and has JDK 11 installed with some Java patches.
The logic to install Java has been removed as the new image comes with Java pre-installed.

This replaces #376

**Also see #390 for more Corretto🍦goodness**