### PR TITLE
EID-1822: Use the Amazon Corretto🍦image in all the places

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -51,8 +51,8 @@ spec:
     openjdk_image: &openjdk_image
       type: docker-image
       source:
-        repository: openjdk
-        tag: 11-jdk-slim
+        repository: amazoncorretto
+        tag: 11
 
     resource_types:
 

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -51,8 +51,8 @@ spec:
     openjdk_image: &openjdk_image
       type: docker-image
       source:
-        repository: openjdk
-        tag: 11-jdk-slim
+        repository: amazoncorretto
+        tag: 11
 
     resource_types:
 

--- a/proxy-node-vsp-config/Dockerfile
+++ b/proxy-node-vsp-config/Dockerfile
@@ -1,14 +1,7 @@
-ARG JAVA_HOME=/usr/local/openjdk-11
-FROM openjdk:11-jre-slim AS jre
+# Custom VSP image using Amazon JDK
 
-FROM amazonlinux:2.0.20190508
+FROM amazoncorretto:11
 WORKDIR /verify-service-provider
-
-# Install Java
-ARG JAVA_HOME
-ENV JAVA_HOME $JAVA_HOME
-ENV PATH=$PATH:$JAVA_HOME/bin
-COPY --from=jre $JAVA_HOME $JAVA_HOME
 
 # Instal VSP app
 COPY build/install/verify-service-provider .


### PR DESCRIPTION
This image is provided by Amazon and has JDK 11 installed with some Java patches.
The logic to install Java has been removed from the VSP as the new image comes with Java pre-installed.
Build apps and run tests in the pipeline also using the Corretto image instead of the vanilla `openjdk11`.