### PR TITLE
EID-1822 Add short_ref of commit to release to associate with branch

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -652,6 +652,6 @@ spec:
         params:
           name: chart/tag
           tag: chart/tag
-          commitsh: chart/short_ref
+          commitish: chart/short_ref
           globs:
           - chart/*.tgz*

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -495,6 +495,7 @@ spec:
                 --key "${KEY_ID}" \
                 "./${CHART_NAME}"
               cp chart-version/tag proxy-node-chart-package/
+              cp ./src/.git/short_ref proxy-node-chart-package/
               tar -rf alpine-image/rootfs.tar proxy-node-chart-package/
 
       - put: chart
@@ -651,5 +652,6 @@ spec:
         params:
           name: chart/tag
           tag: chart/tag
+          commitsh: chart/short_ref
           globs:
           - chart/*.tgz*


### PR DESCRIPTION
Adds the build-triggering git commit short_ref to the [github release](https://github.com/alphagov/verify-proxy-node/releases).

This will indicate the **branch** that the release should be associated with.

**Why:**
The latest release, https://github.com/alphagov/verify-proxy-node/releases/tag/v1.119, from the release branch, picked a short ref by default from master. The short ref should be [this commit from the branch](https://github.com/alphagov/verify-proxy-node/commit/d0ff6d95ac390314d64c1a07cd304787758e09f7).

Co-authored-by: George Lund <george.lund@digital.cabinet-office.gov.uk>