### PR TITLE
EID-1822 build and run with utf8 file encoding

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -219,6 +219,7 @@ spec:
               - |
                 cd vsp-src
                 rm -f .dockerignore
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose test installDist
 
@@ -285,6 +286,7 @@ spec:
               - -euc
               - |
                 cd src
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -PCI test
 
@@ -306,6 +308,7 @@ spec:
               - -elc
               - |
                 cd src
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -213,6 +213,7 @@ spec:
               - |
                 cd vsp-src
                 rm -f .dockerignore
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose test installDist
 
@@ -279,6 +280,7 @@ spec:
               - -euc
               - |
                 cd src
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -PCI test
 
@@ -300,6 +302,7 @@ spec:
               - -elc
               - |
                 cd src
+                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 

--- a/eidas-saml-parser/build.gradle
+++ b/eidas-saml-parser/build.gradle
@@ -11,6 +11,7 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.eidassaml.EidasSamlApplication'
+applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/proxy-node-gateway/build.gradle
+++ b/proxy-node-gateway/build.gradle
@@ -18,6 +18,7 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.GatewayApplication'
+applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -36,6 +36,7 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.translator.TranslatorApplication'
+applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -26,6 +26,7 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.stubconnector.StubConnectorApplication'
+applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'


### PR DESCRIPTION
### Why
[Integration tests are failing](https://ci.london.verify.govsvc.uk/teams/proxy-node-build/pipelines/build-release/jobs/build-proxy-node/builds/32) to correctly compare the string contents of a `favicon.ico` to expected output.

The Amazon Coretto Docker image is not setting file-encoding to utf-8, which presumably was set in openjdk images.

### What
* Set the file encoding to utf-8 in `GRADLE_OPTS` to allow the tests to pass
* Also set the file-encoding of the built applications to use utf-8

This fix has been tested in sandbox, and fixes the pipeline in that cluster.

-----------
This was a useful test failure as it surfaced an encoding issue that might cause issues in production.