### PR TITLE
EID-1822: Set UTF8 encoding for all Amazon Corretto🍦images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Base AWS Java app image
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 WORKDIR /app
 
 # Install AWS CloudHSM Java library if needed

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -219,7 +219,6 @@ spec:
               - |
                 cd vsp-src
                 rm -f .dockerignore
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose test installDist
 
@@ -270,9 +269,9 @@ spec:
 
       - task: run-tests
         attempts: 2
+        image: cloudhsm-jce-image
         config:
           platform: linux
-          image_resource: *openjdk_image
           inputs:
           - name: src
           outputs:
@@ -286,7 +285,6 @@ spec:
               - -euc
               - |
                 cd src
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -PCI test
 
@@ -308,7 +306,6 @@ spec:
               - -elc
               - |
                 cd src
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: build-release
+  name: build-test-sandbox
 spec:
   exposed: true
   config:
@@ -72,7 +72,7 @@ spec:
     resources:
 
     - name: src
-      type: github
+      type: git
       icon: github-circle
       source:
         <<: *github_source
@@ -88,14 +88,14 @@ spec:
 
     - name: vsp-config
       icon: check-outline
-      type: github
+      type: git
       source:
         <<: *github_source
         paths: [proxy-node-vsp-config]
         branch: sandbox
 
     - name: cloudhsm-config
-      type: github
+      type: git
       icon: folder-key-network-outline
       source:
         <<: *github_source
@@ -213,7 +213,6 @@ spec:
               - |
                 cd vsp-src
                 rm -f .dockerignore
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose test installDist
 
@@ -264,9 +263,9 @@ spec:
 
       - task: run-tests
         attempts: 2
+        image: cloudhsm-jce-image
         config:
           platform: linux
-          image_resource: *openjdk_image
           inputs:
           - name: src
           outputs:
@@ -280,7 +279,6 @@ spec:
               - -euc
               - |
                 cd src
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -PCI test
 
@@ -302,7 +300,6 @@ spec:
               - -elc
               - |
                 cd src
-                export GRADLE_OPTS="-Dfile.encoding=utf-8"
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 

--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -1,6 +1,7 @@
 # Base builder image to build apps that need to talk to the HSM cient
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 
 # Install AWS CloudHSM client and libs
 ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .

--- a/eidas-saml-parser/build.gradle
+++ b/eidas-saml-parser/build.gradle
@@ -11,7 +11,6 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.eidassaml.EidasSamlApplication'
-applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/proxy-node-gateway/build.gradle
+++ b/proxy-node-gateway/build.gradle
@@ -18,7 +18,6 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.GatewayApplication'
-applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -36,7 +36,6 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.translator.TranslatorApplication'
-applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'

--- a/proxy-node-vsp-config/Dockerfile
+++ b/proxy-node-vsp-config/Dockerfile
@@ -1,6 +1,7 @@
 # Custom VSP image using Amazon JDK
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 WORKDIR /verify-service-provider
 
 # Instal VSP app

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -26,7 +26,6 @@ version = "${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 
 apply plugin: 'application'
 mainClassName = 'uk.gov.ida.notification.stubconnector.StubConnectorApplication'
-applicationDefaultJvmArgs = ["-Dfile.encoding=utf-8"]
 
 run {
     args 'server', './src/dist/config.yml'


### PR DESCRIPTION
Corretto doesn't use UTF8 by default so we need to set an environment variable.

Also use the same image to test and build the Proxy Node apps.

Apply changes to the Sandbox pipeline from the Sandbox branch to reduce diff drift.