### PR TITLE
🍒EID-1822: Set UTF8 encoding for all Amazon Corretto images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Base AWS Java app image
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 WORKDIR /app
 
 # Install AWS CloudHSM Java library if needed

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -267,9 +267,9 @@ spec:
 
       - task: run-tests
         attempts: 2
+        image: cloudhsm-jce-image
         config:
           platform: linux
-          image_resource: *openjdk_image
           inputs:
           - name: src
           outputs:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -4,7 +4,7 @@ kind: Pipeline
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: build-release
+  name: build-test-sandbox
 spec:
   exposed: true
   config:
@@ -72,7 +72,7 @@ spec:
     resources:
 
     - name: src
-      type: github
+      type: git
       icon: github-circle
       source:
         <<: *github_source
@@ -88,14 +88,14 @@ spec:
 
     - name: vsp-config
       icon: check-outline
-      type: github
+      type: git
       source:
         <<: *github_source
         paths: [proxy-node-vsp-config]
         branch: sandbox
 
     - name: cloudhsm-config
-      type: github
+      type: git
       icon: folder-key-network-outline
       source:
         <<: *github_source
@@ -263,9 +263,9 @@ spec:
 
       - task: run-tests
         attempts: 2
+        image: cloudhsm-jce-image
         config:
           platform: linux
-          image_resource: *openjdk_image
           inputs:
           - name: src
           outputs:

--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -1,6 +1,7 @@
 # Base builder image to build apps that need to talk to the HSM cient
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 
 # Install AWS CloudHSM client and libs
 ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .

--- a/proxy-node-vsp-config/Dockerfile
+++ b/proxy-node-vsp-config/Dockerfile
@@ -1,6 +1,7 @@
 # Custom VSP image using Amazon JDK
 
 FROM amazoncorretto:11
+ENV LANG C.UTF-8
 WORKDIR /verify-service-provider
 
 # Instal VSP app


### PR DESCRIPTION
Corretto doesn't use UTF8 by default so we need to set an environment variable.

Also use the same image to test abd build the Proxy Node apps.

Apply changes to the Sandbox pipeline from the Sandbox branch to reduce diff drift.

(cherry picked from commit 5875271ce548ebadff1c494a86ef0ecaba543c24)