### PR TITLE
BAU: Update travis curl script to download jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jdk:
 
 before_install:
   - sudo apt-get install jq
-  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({content_type, browser_download_url} | select(.content_type | contains("java-archive"))) | .[0].browser_download_url') -o codacy-coverage-reporter-assembly.jar
+  - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
 
 install:
   - npm install -g snyk@1.146.0


### PR DESCRIPTION
Cherry pick: the travis release metadata json at https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest no longer contains a `java-archive` key,  so obtain the browser download url from the first asset map that contains key `codacy-coverage-reporter-assembly`.

This script worked on release branch PR https://github.com/alphagov/verify-proxy-node/pull/400.
This PR should also exercise the travis script, obvs.