### PR TITLE
EID-1822: Use SHA1 as commitish

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -493,7 +493,7 @@ spec:
                 --key "${KEY_ID}" \
                 "./${CHART_NAME}"
               cp chart-version/tag proxy-node-chart-package/
-              cp ./src/.git/short_ref proxy-node-chart-package/
+              cp ./src/.git/ref proxy-node-chart-package/
               tar -rf alpine-image/rootfs.tar proxy-node-chart-package/
 
       - put: chart
@@ -650,6 +650,6 @@ spec:
         params:
           name: chart/tag
           tag: chart/tag
-          commitish: chart/short_ref
+          commitish: chart/ref
           globs:
           - chart/*.tgz*


### PR DESCRIPTION
The [github release Concourse resource](https://github.com/concourse/github-release-resource) requires the commit SHA for the `commitish` value, which is provided by the `ref` value from the [git resource](https://github.com/concourse/git-resource).