### PR TITLE
EID-1822: Use SHA1 as the release commitish value

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: concourse.k8s.io/v1beta1
 kind: Pipeline
 metadata:
@@ -14,6 +13,7 @@ spec:
       organization: alphagov
       owner: alphagov
       repository: verify-proxy-node
+      branch: master
       github_api_token: ((github.api-token))
       access_token: ((github.api-token))
       approvers: ((trusted-developers.github-accounts))
@@ -77,7 +77,6 @@ spec:
       source:
         <<: *github_source
         ignore_paths: [cloudhsm, proxy-node-vsp-config, ci]
-        branch: master
 
     - name: vsp-src
       icon: github-circle
@@ -92,7 +91,6 @@ spec:
       source:
         <<: *github_source
         paths: [proxy-node-vsp-config]
-        branch: master
 
     - name: cloudhsm-config
       type: github
@@ -100,7 +98,6 @@ spec:
       source:
         <<: *github_source
         paths: [cloudhsm]
-        branch: master
 
     - name: release
       type: github-release
@@ -495,7 +492,7 @@ spec:
                 --key "${KEY_ID}" \
                 "./${CHART_NAME}"
               cp chart-version/tag proxy-node-chart-package/
-              cp ./src/.git/short_ref proxy-node-chart-package/
+              cp ./src/.git/ref proxy-node-chart-package/
               tar -rf alpine-image/rootfs.tar proxy-node-chart-package/
 
       - put: chart
@@ -652,6 +649,6 @@ spec:
         params:
           name: chart/tag
           tag: chart/tag
-          commitish: chart/short_ref
+          commitish: chart/ref
           globs:
           - chart/*.tgz*


### PR DESCRIPTION
The github release Concourse resource requires the commit SHA for the commitish value, which is provided by the ref value from the git resource.

Cherry picked from e0672c45214b5212fd34c8f7aec2c48ee43482ec