### PR TITLE
EID-1823 Update urls for multi-country build release

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 
 {{- define "gateway.host" -}}
-{{- printf "%s-%s.%s" .Release.Name .Chart.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s-%s-%s.%s" "eidas" .Chart.Name .Release.Name  (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "gateway.entityID" -}}
@@ -9,7 +9,7 @@
 
 {{- define "stubConnector.host" -}}
 {{- if .Values.stubConnector.enabled -}}
-{{- printf "%s-%s.%s" .Release.Name "connector" (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s-%s.%s" "eidas-stub-connector" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.stubConnector.host -}}
 {{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 
 {{- define "gateway.host" -}}
-{{- printf "%s-%s-%s.%s" "eidas" .Chart.Name .Release.Name  (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s.%s.%s.%s" .Chart.Name "eidas" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "gateway.entityID" -}}
@@ -9,7 +9,7 @@
 
 {{- define "stubConnector.host" -}}
 {{- if .Values.stubConnector.enabled -}}
-{{- printf "%s-%s.%s" "eidas-stub-connector" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s.%s.%s" "stub-connector.eidas" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.stubConnector.host -}}
 {{- end -}}

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -610,8 +610,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -124,28 +124,28 @@ spec:
       icon: code-tags-check
       source:
         <<: *harbor_source
-        repository: registry.((cluster.domain))/eidas/acceptance-tests
+        repository: registry.((cluster.domain))/eidas/proxy-node-acceptance-tests
 
     - name: gateway-image
       type: harbor
       icon: gate
       source:
         <<: *harbor_source
-        repository: registry.((cluster.domain))/eidas/gateway
+        repository: registry.((cluster.domain))/eidas/proxy-node-gateway
 
     - name: translator-image
       type: harbor
       icon: file-xml
       source:
         <<: *harbor_source
-        repository: registry.((cluster.domain))/eidas/translator
+        repository: registry.((cluster.domain))/eidas/proxy-node-translator
 
     - name: parser-image
       type: harbor
       icon: page-next
       source:
         <<: *harbor_source
-        repository: registry.((cluster.domain))/eidas/parser
+        repository: registry.((cluster.domain))/eidas/proxy-node-saml-parser
 
     - name: stub-connector-image
       type: harbor

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -610,8 +610,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
+            PROXY_NODE_URL: "https://proxy-node.eidas.test.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://stub-connector.eidas.test.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/ci/build/vsp-secret.yaml
+++ b/ci/build/vsp-secret.yaml
@@ -3,7 +3,7 @@ kind: SealedSecret
 metadata:
   name: vsp
   creationTimestamp: null
-  namespace: verify-proxy-node-build
+  namespace: verify-eidas-proxy-node-build
 spec:
   encryptedData:
     VERIFY_ENVIRONMENT: AgBJrAciwL7NLfIlyk0Q4FraCCUUz/cpFdRsmuBJJHRG/uE2sQhnlPebZYVXMnvgzjNlpoY3+klGXjkzbhxhMaQVO4jNa+M7R211oGE7yKUD3GxZ2otimMa9oxPrFEhO7jsCIXPZcrfsPOAz99ZjR/rf0UKnhyAavBWQZaa+xdEpWwPF9Pw5PwmYrKbX7d1YnPiIFODorJQQCRcQ4DXJva8qJ4a0Q300BzBzxqFOtyxUYHR/ErwyJGbEvDU/U1XGjfCAAlWNs8wKfgyoVzaM25dMqtxsAhBNQPy1MA0tgzjkVOLtgBbn4pL6+YOAMfpQ46to6NxaXevEsHKQ4XSA4flbTDGqmuancNIOaKzBg0udj4AmIuO+F0LWct++rQpwJA7DnaCU4FK9Ra7b7BB9t3KGgU/kXklVkLc9DekCgR9XAWNcu2iPx+2m+IUsQfBe9lNCT8aYYHYp9Ef2VX5qKSCcmn8SgpXJlxNyZd65x3RiqMHKfBxlspioj7/XGpv9A6p8QBaP5VDk8VIvGEFq19G8AeIThYKkuJGBnu1MOdG7awFzvpO/+8tIAS2Ry1PPP2/+ljp8nBRIuWvtXz6/kiDqAFaJ+diPeSxBlMl0mBEjv9Dm+CTzK6nSJxcxQEy4ZMl+34f2/Ybie/YkxBZfmRYW7q+DjWHVEjRzLxvfGrW4zQJI4oyseWQTB7YWTD7z5gKiQAm2+ONtGqteJA==

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -599,8 +599,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
+            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -600,8 +600,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://test-proxy-node.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://test-connector.((cluster.domain))"
+            PROXY_NODE_URL: "https://eidas-proxy-node-test.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://eidas-stub-connector-test.((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -231,7 +231,6 @@ spec:
       - get: cloudhsm-config
         trigger: true
       - in_parallel:
-          limit: 3
           fail_fast: true
           steps:
           - put: cloudhsm-client-image

--- a/proxy-node-acceptance-tests/run-staging-tests.sh
+++ b/proxy-node-acceptance-tests/run-staging-tests.sh
@@ -4,8 +4,8 @@ set -eu
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-export PROXY_NODE_URL="https://test-proxy-node.london.verify.govsvc.uk"
-export STUB_CONNECTOR_URL="https://test-connector.london.verify.govsvc.uk"
+export PROXY_NODE_URL="https://eidas-proxy-node-test.london.verify.govsvc.uk"
+export STUB_CONNECTOR_URL="https://eidas-stub-connector-test.london.verify.govsvc.uk"
 export STUB_IDP_USER="stub-idp-demo-one"
 docker-compose up --abort-on-container-exit | grep acceptance-tests_1 --colour=never
 docker cp $(docker ps -a -q -f name="acceptance-tests"):/testreport .

--- a/proxy-node-acceptance-tests/run-staging-tests.sh
+++ b/proxy-node-acceptance-tests/run-staging-tests.sh
@@ -4,8 +4,8 @@ set -eu
 echo "Before Docker compose build"
 docker-compose build
 echo "Docker compose build"
-export PROXY_NODE_URL="https://eidas-proxy-node-test.london.verify.govsvc.uk"
-export STUB_CONNECTOR_URL="https://eidas-stub-connector-test.london.verify.govsvc.uk"
+export PROXY_NODE_URL="https://proxy-node.eidas.test.london.verify.govsvc.uk"
+export STUB_CONNECTOR_URL="https://stub-connector.eidas.test.london.verify.govsvc.uk"
 export STUB_IDP_USER="stub-idp-demo-one"
 docker-compose up --abort-on-container-exit | grep acceptance-tests_1 --colour=never
 docker cp $(docker ps -a -q -f name="acceptance-tests"):/testreport .

--- a/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
+++ b/proxy-node-gateway/src/test/resources/metadata/test-proxy-node-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
+++ b/proxy-node-shared/src/test/resources/metadata/test-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>

--- a/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
+++ b/stub-connector/src/test/resources/metadata/test-stub-connector-metadata.xml
@@ -19,9 +19,9 @@
     </md:Extensions>
     <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <md:NameIDFormat xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://test-proxy-node.london.verify.govsvc.uk/SAML2/SSO/POST" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://proxy-node.invalid/SAML2/SSO/POST"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
-        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://test-proxy-node.london.verify.govsvc.uk/Redirect" 
+        <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://proxy-node.invalid/Redirect"
             xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"/>
         <saml2:Attribute FriendlyName="PersonIdentifier" Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" 
             xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"/>


### PR DESCRIPTION
Reverts alphagov/verify-proxy-node#375, reapplying PR https://github.com/alphagov/verify-proxy-node/pull/371

**TL;DR**
set Gateway hostname to https://proxy-node.eidas.test.london.verify.govsvc.uk/
set Stub Connector hostname to https://stub-connector.eidas.test.london.verify.govsvc.uk/