### PR TITLE
EID-1823 Filter release to produce a v2 major version

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -107,6 +107,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: ^v2\.\d+$
 
     - name: alpine-image
       type: docker-image

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -40,6 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: ^v2\.\d+$
 
     - name: daily
       type: time

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -40,6 +40,7 @@ spec:
       icon: tag
       source:
         <<: *github_source
+        tag_filter: ^v2\.\d+$
 
     - name: nightly
       type: time


### PR DESCRIPTION
Ensure that the build pipeline only produces a release with the v2 major version, and the integration and prod pipelines only get releases tagged with v2 major.