### PR TITLE
🍒SNYK cherry-pick of snyk updates from master to release

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2019-11-30T19:21:05.816Z
+        expires: 2019-12-15T00:00:00.000Z
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617:
     - '*':
         reason: Fix not yet available in Dropwizard

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ ext {
 
 subprojects {
 
+    task allDeps(type: DependencyReportTask) {} // run `./gradlew allDeps` for a dep report across all modules
+
     apply plugin: 'java'
     apply plugin: 'maven'
 
@@ -116,6 +118,7 @@ subprojects {
                 substitute module("com.fasterxml.jackson.core:jackson-databind") because "https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-467014" with module("com.fasterxml.jackson.core:jackson-databind:2.10.0.pr3")
                 substitute module("ca.juliusdavies:not-yet-commons-ssl:0.3.9") because "https://snyk.io/vuln/SNYK-JAVA-CAJULIUSDAVIES-30073" with module("ca.juliusdavies:not-yet-commons-ssl:0.3.11")
                 substitute module("org.apache.santuario:xmlsec") because "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281" with module("org.apache.santuario:xmlsec:2.1.4")
+                substitute module("com.nimbusds:nimbus-jose-jwt") because "https://snyk.io/vuln/SNYK-JAVA-COMNIMBUSDS-536068" with module("com.nimbusds:nimbus-jose-jwt:8.2.1")
                 exclude group: "commons-beanutils", module: "commons-beanutils"
             }
         }

--- a/proxy-node-acceptance-tests/Gemfile
+++ b/proxy-node-acceptance-tests/Gemfile
@@ -2,8 +2,8 @@ ruby '2.5.3'
 
 source 'https://rubygems.org'
 
-gem 'capybara'
+gem 'capybara', '>= 3.18.0'
 gem 'cucumber'
 gem 'selenium-webdriver'
 gem 'geckodriver-helper'
-gem 'capybara-screenshot'
+gem 'capybara-screenshot', '>= 1.0.22'

--- a/proxy-node-acceptance-tests/Gemfile.lock
+++ b/proxy-node-acceptance-tests/Gemfile.lock
@@ -66,8 +66,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
-  capybara-screenshot
+  capybara (>= 3.18.0)
+  capybara-screenshot (>= 1.0.22)
   cucumber
   geckodriver-helper
   selenium-webdriver


### PR DESCRIPTION
* Fix for https://snyk.io/vuln/SNYK-JAVA-COMNIMBUSDS-536068.
* Ignore the vulnerability https://snyk.io/vuln/SNYK-JAVA-CAJULIUSDAVIES-30073 until Dec 15, as there is no release yet that addresses it.
* Patch Gemfile & proxy-node-acceptance-tests/Gemfile.lock to reduce vulnerabilities