### PR TITLE
EID-1848 Deploy countries configMap

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -541,8 +541,7 @@ spec:
               - -euc
               - |
                 cd eidas-config/tools
-                ./gradlew run --args="--mode=config --environment=TEST"
-                mv config.yml countriesConfig.yml
+                ./gradlew run --args="generate-config --environment=test"
 
       - task: create-config-map
         config:
@@ -571,9 +570,9 @@ spec:
                 kubectl config use-context deployer
 
                 echo "generating configMap resource definition from file"
-                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yml -o yaml --dry-run \
+                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yaml -o yaml --dry-run \
                   | yq -y '.metadata += {"annotations": {"kapp.k14s.io/versioned": "", "kapp.k14s.io/num-versions":"5"}}' \
-                  | tee ../../manifests/countriesConfigMap.yml
+                  | tee ../../manifests/countriesConfigMap.yaml
 
       - task: extract-chart
         image: chart

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -536,12 +536,11 @@ spec:
           outputs:
             - name: eidas-config
           run:
-            path: /bin/sh
+            dir: eidas-config/tools
+            path: gradlew
             args:
-              - -euc
-              - |
-                cd eidas-config/tools
-                ./gradlew run --args="generate-config --environment=test"
+              - run
+              - --args="generate-config --environment=test"
 
       - task: create-config-map
         config:

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -92,6 +92,16 @@ spec:
         <<: *github_source
         paths: [proxy-node-vsp-config]
 
+    - name: eidas-config
+      type: git
+      icon: bugle
+      source:
+        uri: https://github.com/alphagov/verify-eidas-config.git
+        branch: master
+        paths: [test]
+        username: "re-autom8-ci"
+        password: ((github.api-token))
+
     - name: cloudhsm-config
       type: github
       icon: folder-key-network-outline
@@ -514,6 +524,56 @@ spec:
             trigger: true
           - get: tests-image
             passed: [build-proxy-node]
+          - get: eidas-config
+            trigger: true
+
+      - task: generate-config
+        config:
+          platform: linux
+          image_resource: *openjdk_image
+          inputs:
+            - name: eidas-config
+          outputs:
+            - name: eidas-config
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                cd eidas-config/tools
+                ./gradlew run --args="--mode=config --environment=TEST"
+                mv config.yml countriesConfig.yml
+
+      - task: create-config-map
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: eidas-config
+          outputs:
+            - name: manifests
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                cd eidas-config/tools
+
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "generating configMap resource definition from file"
+                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yml -o yaml --dry-run \
+                  | yq -y '.metadata += {"annotations": {"kapp.k14s.io/versioned": "", "kapp.k14s.io/num-versions":"5"}}' \
+                  | tee ../../manifests/countriesConfigMap.yml
 
       - task: extract-chart
         image: chart
@@ -535,6 +595,7 @@ spec:
           image_resource: *task_toolbox
           inputs:
           - name: chart
+          - name: manifests
           outputs:
           - name: manifests
           params:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -102,6 +102,15 @@ spec:
         paths: [cloudhsm]
         branch: sandbox
 
+    - name: eidas-config
+      type: git
+      icon: bugle
+      source:
+        uri: https://github.com/alphagov/verify-eidas-config.git
+        branch: sandbox
+        username: "re-autom8-ci"
+        password: ((github.api-token))
+
     - name: alpine-image
       type: docker-image
       icon: toolbox
@@ -502,6 +511,56 @@ spec:
             trigger: true
           - get: tests-image
             passed: [build-proxy-node]
+          - get: eidas-config
+            trigger: true
+
+      - task: generate-config
+        config:
+          platform: linux
+          image_resource: *openjdk_image
+          inputs:
+            - name: eidas-config
+          outputs:
+            - name: eidas-config
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                cd eidas-config/tools
+                ./gradlew run --args="--mode=config --environment=TEST"
+                mv config.yml countriesConfig.yml
+
+      - task: create-config-map
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: eidas-config
+          outputs:
+            - name: manifests
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                cd eidas-config/tools
+
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "generating configMap resource definition from file"
+                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yml -o yaml --dry-run \
+                  | yq -y '.metadata += {"annotations": {"kapp.k14s.io/versioned": "", "kapp.k14s.io/num-versions":"5"}}' \
+                  | tee ../../manifests/countriesConfigMap.yml
 
       - task: extract-chart
         image: chart
@@ -523,6 +582,7 @@ spec:
           image_resource: *task_toolbox
           inputs:
           - name: chart
+          - name: manifests
           outputs:
           - name: manifests
           params:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -108,6 +108,7 @@ spec:
       source:
         uri: https://github.com/alphagov/verify-eidas-config.git
         branch: sandbox
+        paths: [test]
         username: "re-autom8-ci"
         password: ((github.api-token))
 
@@ -528,8 +529,7 @@ spec:
               - -euc
               - |
                 cd eidas-config/tools
-                ./gradlew run --args="--mode=config --environment=TEST"
-                mv config.yml countriesConfig.yml
+                ./gradlew run --args="generate-config --environment=test"
 
       - task: create-config-map
         config:
@@ -558,9 +558,9 @@ spec:
                 kubectl config use-context deployer
 
                 echo "generating configMap resource definition from file"
-                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yml -o yaml --dry-run \
+                kubectl -n "${NAMESPACE}" create configmap test-countries-config --from-file=countriesConfig.yaml -o yaml --dry-run \
                   | yq -y '.metadata += {"annotations": {"kapp.k14s.io/versioned": "", "kapp.k14s.io/num-versions":"5"}}' \
-                  | tee ../../manifests/countriesConfigMap.yml
+                  | tee ../../manifests/countriesConfigMap.yaml
 
       - task: extract-chart
         image: chart


### PR DESCRIPTION
This PR should not be merged before this: https://github.com/alphagov/verify-eidas-config/pull/2

This adds tasks to the build pipeline to create a configMap for
consumption by the proxy-node's metadata service, containing the
configuration for the countries.

The config is defined in the `verify-eidas-config` repo, as well as the
tooling to generate the truststore required. The resulting config file
from running the tool is used to populate a configMap.

We use kubectl with the `--dry-run` flag to generate the yaml resource
definition. We do this as we also use the `--from-file` flag - it's not
possible to define a configMap with static kubeyaml that references a
file in this way.

We edit the output of kubectl with `yq` to add a couple of annotations.
These annotations are used by `kapp`. They allow `kapp` to version the
configMap. This is required so that when we deploy the metadata-service
it is aware of which specific version of the configMap it is using. This way,
when the configMap changes and is redeployed, `kapp` knows that
metadata-service needs to also be redeployed - to pick up the latest
version of the configMap. The docs for this versioning [can be found
here](https://github.com/k14s/kapp/blob/master/docs/faq.md#updating-deployments-when-configmap-changes)

The versioning is only necessary as the metadata service currently only
reads the config file (mounted from the configMap) on startup. If it
could be designed to automatically "hot-reload" from the file we could
skip this, as the mounted config file is automatically updated when the
configMap is updated.

The final yaml resource definition for the configMap is added to the
`manifests` directory, which is where the other manifests are placed by
the `helm template` command. This allows the existing call to `kapp` to
deploy the configMap along with the apps themselves.

When we have the new pipelines for deploying to integration and prod we can
copy the pattern used here to update configMaps used for int and prod.

Co-authored-by: John Watts <john.watts@digital.cabinet-office.gov.uk>