### PR TITLE
🚬EID-1854 Smoke Test Infrastructure

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -621,7 +621,7 @@ spec:
             - -euc
             - |
               cd /
-              bundle exec cucumber --strict --tags "not @ignore"
+              bundle exec cucumber features/proxy_node.feature --strict --tags "not @ignore"
 
     - name: release
       serial: true

--- a/ci/integration/smoke-test.yaml
+++ b/ci/integration/smoke-test.yaml
@@ -1,0 +1,75 @@
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: smoke-test
+spec:
+  exposed: true
+  config:
+
+    harbor_source: &harbor_source
+      username: ((harbor.harbor_username))
+      password: ((harbor.harbor_password))
+      harbor:
+        prevent_vul: "false"
+      notary:
+        url: ((harbor.notary_url))
+        root_key: ((harbor.root_key))
+        delegate_key: ((harbor.ci_key))
+        passphrase:
+          root: ((harbor.notary_root_passphrase))
+          snapshot: ((harbor.notary_snapshot_passphrase))
+          targets: ((harbor.notary_targets_passphrase))
+          delegation: ((harbor.notary_delegation_passphrase))
+
+    resource_types:
+
+    - name: harbor
+      type: docker-image
+      privileged: true
+      source:
+        repository: ((concourse.harbor-resource-image))
+        tag: ((concourse.harbor-resource-tag))
+
+    resources:
+
+    - name: every-10m-9-5
+      type: time
+      source:
+        interval: 10m
+        start: 9:00 AM
+        stop: 5:00 PM
+
+    - name: tests-image
+      type: harbor
+      source:
+        <<: *harbor_source
+        repository: registry.((cluster.domain))/eidas/acceptance-tests
+
+    jobs:
+
+    - name: smoke-test-integration
+      plan:
+
+      - get: every-10m-9-5
+        trigger: true
+
+      - task: test-chart-package
+        image: tests-image
+        attempts: 2
+        timeout: 2m
+        config:
+          platform: linux
+          params:
+            PROXY_NODE_URL: "https://test-integration-proxy-node.((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://test-integration-connector.((cluster.domain))"
+            STUB_IDP_USER: "stub-idp-demo-one"
+            SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
+          run:
+            path: /bin/bash
+            args:
+            - -euc
+            - |
+              cd /
+              bundle exec cucumber features/smoke_test.feature --strict --tags "not @ignore"

--- a/proxy-node-acceptance-tests/features/smoke_test.feature
+++ b/proxy-node-acceptance-tests/features/smoke_test.feature
@@ -1,0 +1,7 @@
+Feature: smoke-test feature
+
+    Scenario: Proxy node happy path - LOA Substantial
+        Given the proxy node is sent a LOA 'Substantial' request
+        And they progress through verify
+        And they login to stub idp
+        Then they should arrive at the success page


### PR DESCRIPTION
https://govukverify.atlassian.net/browse/EID-1854
Introduce infrastructure to support smoke testing our integration and production releases.

The idea of this PR is to reuse the existing harbor image we build for acceptance tests to also run smoke tests.

Therefore in our build pipeline we target only the acceptance test cucumber feature, plus introduce a new smoke test cucumber feature, which will be run in the new smoke-test pipeline.
The pipelines now invoke a cucumber test either by:
* `bundle exec cucumber features/proxy_node.feature` or
* `bundle exec cucumber features/smoke_test.feature`

This idea is being tested out on the release branch, as it has an integration release.

The integration smoke test job is triggered every 10 minutes. There are currently no consequences on failure.