### PR TITLE
EID-1854 get the tests-image resource to use in smoke test task

### DIFF
--- a/ci/integration/smoke-test.yaml
+++ b/ci/integration/smoke-test.yaml
@@ -54,6 +54,7 @@ spec:
 
       - get: every-10m-9-5
         trigger: true
+      - get: tests-image
 
       - task: test-chart-package
         image: tests-image


### PR DESCRIPTION
Get the `tests-image` resource  to use in the task, otherwise the [pipeline fails](https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/configure-namespace/jobs/apply/builds/24).