### PR TITLE
EID-1856 Capybara smoke test for Netherlands prod

### DIFF
--- a/ci/integration/smoke-test.yaml
+++ b/ci/integration/smoke-test.yaml
@@ -73,4 +73,4 @@ spec:
             - -euc
             - |
               cd /
-              bundle exec cucumber features/smoke_test.feature --strict --tags "not @ignore"
+              bundle exec cucumber features/smoke/integration.feature --strict --tags "not @ignore"

--- a/proxy-node-acceptance-tests/features/smoke/integration.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration.feature
@@ -1,4 +1,4 @@
-Feature: smoke-test feature
+Feature: eidas-proxy-node-smoke-test-integration feature
 
     Scenario: Proxy node happy path - LOA Substantial
         Given the proxy node is sent a LOA 'Substantial' request

--- a/proxy-node-acceptance-tests/features/smoke/nl-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/nl-request.feature
@@ -1,0 +1,6 @@
+Feature: eidas-proxy-node-smoke-test-nl-prod feature
+
+    Scenario: Proxy node happy path - LOA Substantial
+        Given   the user visits the Netherlands Connector Node Stub Page
+        And     they choose the UK as the country to verify with
+        Then    they should arrive at the Verify Hub blue page

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -51,6 +51,25 @@ Given("the user accesses the gateway response url directly") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/SAML2/SSO/Response/POST')
 end
 
+Given("the user visits the Netherlands Connector Node Stub Page") do
+  visit('https://demo-portal.minez.nl/demoportal/etoegang')
+end
+
+And('they choose the UK as the country to verify with') do
+  assert_text('Kies hoe u wilt inloggen')
+  click_link('English')
+  assert_text('Choose how to log in')
+  select "EU Login", :from => "authnServiceId"
+  click_button('Continue')
+  assert_text('Which country is your ID from?')
+  find('#country-GB').click
+  click_button('Continue')
+end
+
+Then('they should arrive at the Verify Hub blue page') do
+  assert_text('Sign in with GOV.UK Verify')
+end
+
 Then('they should arrive at the success page') do
   assert_text('Response successfully received')
   assert_text('Jack Cornelius')


### PR DESCRIPTION
Add the Capybara smoke test with feature `nl-request.feature`, plus rename and move the feature `smoke_test.feature` to `smoke/integration.feature`.

The smoke test will be run by the hub smoke test pipeline.

This feature can be tested locally by:
* updating the `ENTRYPOINT` in `proxy-node-acceptance-tests/Dockerfile `to:
`ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "features/smoke/nl-request.feature", "--strict", "--tags", "not @ignore"]`
* running `./proxy-node-acceptance-tests/run-staging-tests.sh`

https://govukverify.atlassian.net/browse/EID-1855