### PR TITLE
BAU: Add a killswitch to integration pipeline

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2019-12-15T00:00:00.000Z
+        expires: 2020-01-15T00:00:00.000Z
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617:
     - '*':
         reason: Fix not yet available in Dropwizard

--- a/ci/integration/killswitch-pipeline.yaml
+++ b/ci/integration/killswitch-pipeline.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: killswitch-integration
+spec:
+  exposed: false
+  paused: true
+  config:
+
+    task_toolbox: &task_toolbox
+      type: docker-image
+      source:
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
+
+    jobs:
+
+    - name: kill
+      plan:
+      - task: delete-resources
+        timeout: 10m
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/bash
+            args:
+              - -euc
+              - |
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                kubectl -n "${NAMESPACE}" delete virtualservices,deployments --all


### PR DESCRIPTION
Helps with fixing HSM key creation issues.

Provides a way to delete deployments, virtual services for integration releases, making it easier to diagnose remaining interactions with the HSM.

Does not require RE to assume admin role to delete things. We can redeploy a release by starting a job on the integration deploy pipeline (all currently paused).

This new pipeline is a copy of the prod killswitch, with a job name change.

There may be another PR to killswitch the VMC.