### PR TITLE
Eid 1873 annotate deployments so they're rolled nightly

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,5 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2020-01-15T00:00:00.000Z
-  SNYK-JAVA-COMFASTERXMLJACKSONCORE-455617:
-    - '*':
-        reason: Fix not yet available in Dropwizard
-        expires: 2019-11-30T19:21:05.816Z
+        expires: 2020-03-15T00:00:00.000Z
 patch: {}

--- a/chart/templates/esp-deployment.yaml
+++ b/chart/templates/esp-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.esp.replicaCount }}
   strategy:

--- a/chart/templates/esp-redis-deployment.yaml
+++ b/chart/templates/esp-redis-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/name: esp-redis
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: 1
   strategy:

--- a/chart/templates/gateway-deployment.yaml
+++ b/chart/templates/gateway-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.gateway.replicaCount }}
   strategy:

--- a/chart/templates/gateway-redis-deployment.yaml
+++ b/chart/templates/gateway-redis-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: 1
   strategy:

--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.stubConnector.replicaCount }}
   strategy:

--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.translator.replicaCount }}
   strategy:

--- a/chart/templates/vsp-deployment.yaml
+++ b/chart/templates/vsp-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.vsp.replicaCount }}
   selector:


### PR DESCRIPTION
Replaces https://github.com/alphagov/verify-proxy-node/pull/420
I'm not 100% sure this will work, looking for opinions.

We release the apps nightly on a trigger in Concourse. However kapp's
behaviour is to only release stuff if it's changed. If nothing has
changed, kapp won't actually re-deploy apps for us. You can see an
example of this here.This may be
contributing to the issue with the HSM retaining keys.

We should be able to annotate these deployments with a timestamp. This
will mean that kapp detects a change in the app when in renders the
manifest and will redeploy it.