### PR TITLE
EID-1875 HSM monitoring on the eIDAS dashboard

### DIFF
--- a/ci/prod/dashboard.yaml
+++ b/ci/prod/dashboard.yaml
@@ -24,18 +24,152 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 22,
       "links": [],
       "panels": [
         {
-          "cacheTimeout": null,
+          "alert": {
+            "alertRuleTags": {},
+            "conditions": [
+              {
+                "evaluator": {
+                  "params": [
+                    1000
+                  ],
+                  "type": "gt"
+                },
+                "operator": {
+                  "type": "and"
+                },
+                "query": {
+                  "params": [
+                    "A",
+                    "5m",
+                    "now"
+                  ]
+                },
+                "reducer": {
+                  "params": [],
+                  "type": "avg"
+                },
+                "type": "query"
+              }
+            ],
+            "executionErrorState": "alerting",
+            "for": "5m",
+            "frequency": "1m",
+            "handler": 1,
+            "name": "HSM alert",
+            "noDataState": "no_data",
+            "notifications": []
+          },
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Cloudwatch",
+          "fill": 1,
+          "fillGradient": 0,
           "gridPos": {
             "h": 8,
             "w": 12,
             "x": 0,
             "y": 0
           },
-          "id": 4,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dimensions": {
+                "Region": "eu-west-2"
+              },
+              "expression": "",
+              "highResolution": false,
+              "id": "",
+              "metricName": "HsmKeysSessionOccupied",
+              "namespace": "AWS/CloudHSM",
+              "period": "",
+              "refId": "A",
+              "region": "default",
+              "returnData": false,
+              "statistics": [
+                "Maximum"
+              ]
+            }
+          ],
+          "thresholds": [
+            {
+              "colorMode": "critical",
+              "fill": true,
+              "line": true,
+              "op": "gt",
+              "value": 1000,
+              "yaxis": "left"
+            }
+          ],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "HSM Monitoring",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "links": [],
           "options": {
             "displayMode": "gradient",
@@ -215,5 +349,5 @@ data:
       "timezone": "",
       "title": "eIDAS Proxy Node Monitoring",
       "uid": "0F-KUN1Wk",
-      "version": 1
+      "version": 3
     }


### PR DESCRIPTION
Monitor open sessions so as to keep an eye on resource leaks.

The last PR had (I think) an errant `id` field that was never supposed to be there (see <https://grafana.com/docs/grafana/latest/administration/provisioning/#making-changes-to-a-provisioned-dashboard>).

The same thing applied ok in the Sandbox so hopefully this will be ok.

https://govukverify.atlassian.net/browse/EID-1875