### PR TITLE
EID-1876 Hub error page if can't build error SAML

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/GatewayApplication.java
@@ -147,9 +147,10 @@ public class GatewayApplication extends Application<GatewayConfiguration> {
             SessionStore sessionStore,
             URI errorPageRedirectUrl) {
 
+        ErrorPageExceptionMapper errorPageExceptionMapper = new ErrorPageExceptionMapper(errorPageRedirectUrl);
         environment.jersey().register(new MissingMetadataExceptionMapper());
-        environment.jersey().register(new ExceptionToSamlErrorResponseMapper(samlFormViewBuilder, translatorProxy, sessionStore));
-        environment.jersey().register(new ErrorPageExceptionMapper(errorPageRedirectUrl));
+        environment.jersey().register(new ExceptionToSamlErrorResponseMapper(samlFormViewBuilder, translatorProxy, sessionStore, errorPageExceptionMapper));
+        environment.jersey().register(errorPageExceptionMapper);
         environment.jersey().register(new ErrorPageRedirectResponseValidationExceptionMapper(errorPageRedirectUrl));
         environment.jersey().register(new GenericExceptionMapper(errorPageRedirectUrl));
     }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestExceptionMapperResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestExceptionMapperResource.java
@@ -26,6 +26,7 @@ public class TestExceptionMapperResource {
     public static final String SESSION_ID = "aSessionId";
     public static final String HUB_REQUEST_ID = "aHubRequestId";
     public static final String EIDAS_REQUEST_ID = "anEidasRequestId";
+    public static final String HUB_ERROR_PAGE_CONTENT = "hub error page";
 
     @GET
     @Path("/SessionAlreadyExistsException")
@@ -80,6 +81,12 @@ public class TestExceptionMapperResource {
     @Path("/RedisSerializationException")
     public Response getRedisSerializationException() {
         throw new RedisSerializationException("This is a message", new Exception("This caused a RedisSerializationException"));
+    }
+
+    @GET
+    @Path("/HubErrorPage")
+    public Response getHubErrorPage() {
+        return Response.ok(HUB_ERROR_PAGE_CONTENT).build();
     }
 
     @GET


### PR DESCRIPTION
When there is an error in response from translator to gateway, for a subset of errors we'll try to build an error saml response, by calling translator again to generate a signed error saml response.

This is handled by the translator `/generate-failure-response` resource.

We do not handle the case where this resource throws an ApplicationException - and a standard dropwizard error page is rendered.

You can see this being played out in this journey: https://gds.splunkcloud.com/en-GB/app/search/search?sid=1576743919.185861

This PR is to redirect to the hub error page in this scenario.

https://govukverify.atlassian.net/browse/EID-1876