### PR TITLE
EID-1806 Call `gradlew` properly

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -585,7 +585,7 @@ spec:
             - name: eidas-config
           run:
             dir: eidas-config/tools
-            path: gradlew
+            path: ./gradlew
             args:
               - run
               - --args="generate-config --environment=test"


### PR DESCRIPTION
`gradlew` is not in the path, so we need to call it with a relative path
instead.