### PR TITLE
EID-1806 Fix structure of args

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -588,7 +588,8 @@ spec:
             path: ./gradlew
             args:
               - run
-              - --args="generate-config --environment=test"
+              - --args
+              - "generate-config --environment=test"
 
       - task: create-config-map
         config:


### PR DESCRIPTION
Concourse didn't like the previous version. I've tested this locally and
it works.