### PR TITLE
🍒⛏BAU - Bump cloudhsm tools to 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ARG TALKS_TO_HSM=false
 ENV LD_LIBRARY_PATH=/opt/cloudhsm/lib
 ENV HSM_PARTITION=PARTITION_1
 
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-2.0.0-3.el7.x86_64.rpm .
+ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm .
+ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-3.0.0-2.el7.x86_64.rpm .
 
 RUN if ${TALKS_TO_HSM}; then echo "Installing CloudHSM libs" \
     && yum install -y ./cloudhsm-client-*.rpm \

--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cloudhsm
 
 # Install AWS CloudHSM client
 RUN yum install -y wget \
- && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm \
+ && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-*.rpm
 
 COPY init.sh .

--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -4,8 +4,8 @@ FROM amazoncorretto:11
 ENV LANG C.UTF-8
 
 # Install AWS CloudHSM client and libs
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-2.0.0-3.el7.x86_64.rpm .
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-2.0.0-3.el7.x86_64.rpm .
+ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm .
+ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-3.0.0-2.el7.x86_64.rpm .
 
 RUN yum install -y ./cloudhsm-client-*.rpm \
  && rm ./cloudhsm-client-*.rpm \

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -14,7 +14,7 @@ dependencies {
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {
-        compile name: 'cloudhsm-2.0.0'
+        compile name: 'cloudhsm-3.0.0'
         compile name: 'log4j-api-2.8'
         compile name: 'log4j-core-2.8'
     }

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -15,7 +15,7 @@ dependencies {
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {
-        compile name: 'cloudhsm-2.0.0'
+        compile name: 'cloudhsm-3.0.0'
         compile name: 'log4j-api-2.8'
         compile name: 'log4j-core-2.8'
     }


### PR DESCRIPTION
This is a cherry pick of a commit just merged to the release branch. Pulling the change into master.

There is a new major version of the [cloudhsm client software](https://docs.aws.amazon.com/cloudhsm/latest/userguide/client-history.html)

I was looking into this to see if they had released a fix to the issue
we're experiencing with the hsm retaining temporary keys. It looks like
this version does not fix that issue, but it's still probably a good
idea to upgrade.

I've applied this change to the sandbox without any issues.