### PR TITLE
EID-1873 delete integration test connector on deploy

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: Fix not available
         expires: 2020-03-15T00:00:00.000Z
+  SNYK-JAVA-ORGYAML-537645:
+    - '*':
+        reason: Fix not available, and used for reading config, not at runtime
+        expires: 2020-01-15T00:00:00.000Z
 patch: {}

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -595,6 +595,8 @@ spec:
                     --app "${RELEASE_NAME}-${APP_NAME}" \
                     --diff-changes \
                     -f ./manifests/
+                  echo "deleting ${RELEASE_NAMESPACE} connector pod"
+                  kubectl -n ${RELEASE_NAMESPACE} delete pod -l app.kubernetes.io/name=connector
 
     - name: deploy-mt-integration
       serial: true


### PR DESCRIPTION
To reduce the creation of handles to CloudHSM keys, we redeploy our integration instances daily.
The current daily roll is however [not deleting](https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/deploy/jobs/deploy-test-integration/builds/173) the test-integration connector pod, so CloudHSM handles are not decreasing.

This commit explicitly deletes the connector pod in the current namespace during a deploy.
It's a bit of a band-aid, but is required to mitigate incidents during December holidays.

NB. This change is proven in the sandbox cluster.

https://govukverify.atlassian.net/browse/EID-1873