### PR TITLE
BAU: temporarily ignore snyk vuln SNYK-JAVA-ORGYAML-537645

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,5 +9,5 @@ ignore:
   SNYK-JAVA-ORGYAML-537645:
     - '*':
         reason: Fix not available, and used for reading config, not at runtime
-        expires: 2020-01-15T00:00:00.000Z
+        expires: 2020-03-15T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
Snyk vuln https://snyk.io/vuln/SNYK-JAVA-ORGYAML-537645 is reported.
There are no direct usages of the library in Proxy Node runtime, it is used for reading dropwizard config.
The vuln is ignored for now to review mid-March.
Ideally a new dropwizard release would ensure that yaml parsing is sanitised as advised in the vuln,  - but the latest dropwizard version is 2.0.0 which doesn't mention it. 

The dependency tree can be analysed via `./gradlew allDeps`