### PR TITLE
🍒EID-1877 Decouple Stub Connector from the HSM

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: Fix not available
         expires: 2020-03-15T00:00:00.000Z
+  SNYK-JAVA-ORGYAML-537645:
+    - '*':
+        reason: Fix not available, and used for reading config, not at runtime
+        expires: 2020-01-15T00:00:00.000Z
 patch: {}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -31,6 +31,10 @@
 {{ printf "%s://%s%s" .Values.connector.metadata.scheme (include "connector.metadata.host" .) .Values.connector.metadata.path }}
 {{- end -}}
 
+{{- define "connector.metadata.assertionConsumerService.url" -}}
+{{ printf "%s://%s%s" .Values.connector.metadata.scheme (include "connector.metadata.host" .) .Values.connector.metadata.assertionConsumerServicePath }}
+{{- end -}}
+
 {{- define "connector.entityID" -}}
 {{- if .Values.stubConnector.enabled -}}
 {{ include "connector.metadata.url" . }}

--- a/chart/templates/esp-deployment.yaml
+++ b/chart/templates/esp-deployment.yaml
@@ -70,14 +70,11 @@ spec:
 {{- if .Values.stubConnector.enabled }}
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
           valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: metadataSigningTruststoreBase64
+            configMapKeyRef:
+              name: test-pki-configmap
+              key: stub_connector.truststore.base64
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: metadataSigningTruststorePassword
+          value: {{ .Values.connector.metadataSigningTruststorePassword }}
 {{- else }}
         - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
           value: {{ .Values.connector.metadataSigningTruststoreBase64 }}

--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -28,24 +28,16 @@ spec:
     spec:
       restartPolicy: Always
       volumes:
-      - name: hsm-client-crt
-        secret:
-          secretName: {{ .Release.Name }}-connector-metadata
-      - name: connector-metadata-volume
-        secret:
-          secretName: {{ .Release.Name }}-connector-metadata
-          items:
-          - key: metadata.xml
-            path: metadata.xml
-          - key: metadataCACerts
-            path: metadataCACerts
+      - name: test-pki-volume
+        configMap:
+          name: test-pki-configmap
       containers:
       - name: connector
         image: "{{ .Values.stubConnector.image.repository }}:{{ .Values.stubConnector.image.tag }}"
         imagePullPolicy: {{ .Values.stubConnector.image.pullPolicy }}
         volumeMounts:
-        - name: connector-metadata-volume
-          mountPath: /app/metadata
+        - name: test-pki-volume
+          mountPath: /app/pki
           readOnly: true
         ports:
         - name: http
@@ -70,6 +62,8 @@ spec:
           value: https://{{ include "stubConnector.host" . }}
         - name: CONNECTOR_NODE_ENTITY_ID
           value: {{ include "connector.entityID" . }}
+        - name: CONNECTOR_NODE_ACS_URL
+          value: {{ include "connector.metadata.assertionConsumerService.url" . }}
         - name: PROXY_NODE_ENTITY_ID
           valueFrom:
             secretKeyRef:
@@ -90,42 +84,4 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-proxy-node-metadata
               key: metadataSigningTruststorePassword
-        - name: SIGNER_CONFIG_TYPE
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: samlSigningKeyType
-        - name: HSM_SIGNING_KEY_LABEL
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: samlSigningKeyLabel
-        - name: CONNECTOR_SIGNING_CERT
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: samlSigningCertBase64
-        - name: HSM_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: hsmUser
-        - name: HSM_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: hsmPassword
-      - name: hsm-client
-        image: "{{ .Values.hsm.image.repository }}:{{ .Values.hsm.image.tag }}"
-        imagePullPolicy: {{ .Values.hsm.image.pullPolicy }}
-        env:
-        - name: HSM_IP
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-connector-metadata
-              key: hsmIP
-        volumeMounts:
-        - name: hsm-client-crt
-          mountPath: /opt/cloudhsm/etc/customerCA.crt
-          subPath: hsmCustomerCA.crt
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -20,6 +20,7 @@ connector:
     scheme: https
     port: 443
     path: /ConnectorMetadata
+    assertionConsumerServicePath: /SAML2/Response/POST
   metadataSigningTruststoreBase64:
   metadataSigningTruststorePassword: marshmallow
 

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -371,7 +371,6 @@ spec:
               build: src
               build_args:
                 component: stub-connector
-                TALKS_TO_HSM: true
               <<: *image_tag
           - put: tests-image
             get_params: {skip_download: true}

--- a/ci/build/test-pki.yaml
+++ b/ci/build/test-pki.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: build-test-pki
+spec:
+  exposed: true
+  config:
+
+    task_toolbox: &task_toolbox
+      type: docker-image
+      source:
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
+
+    resources:
+
+    - name: verify-dev-pki
+      type: git
+      source:
+        uri: https://github.com/alphagov/verify-dev-pki.git
+
+    jobs:
+
+    - name: build-test-pki
+      plan:
+      - get: verify-dev-pki
+      - task: assemble-pki
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: openjdk
+              tag: 11
+          inputs:
+            - name: verify-dev-pki
+          outputs:
+            - name: pki
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "create a truststore containing metadata-ca and ida-root-ca"
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-root-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-root-ca.pem.test
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-metadata-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-metadata-ca.pem.test
+                openssl base64 -A -in stub_connector.truststore > pki/stub_connector.truststore.base64
+
+                echo "copy keys and certs to pki/"
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.crt                pki/metadata_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.crt      pki/saml_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.pk8                pki/metadata_signing.pk8
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.pk8      pki/saml_signing.pk8
+
+      - task: apply-test-pki-configmap
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: pki
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "generating test-pki configMap from pki/, with data keys:"
+                ls pki/
+                kubectl -n "${NAMESPACE}" create configmap test-pki-configmap --from-file=pki --dry-run -o yaml | kubectl apply -f -

--- a/ci/integration/test-pki.yaml
+++ b/ci/integration/test-pki.yaml
@@ -1,0 +1,82 @@
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: integration-test-pki
+spec:
+  exposed: true
+  config:
+
+    task_toolbox: &task_toolbox
+      type: docker-image
+      source:
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
+
+    resources:
+
+    - name: verify-dev-pki
+      type: git
+      source:
+        uri: https://github.com/alphagov/verify-dev-pki.git
+
+    jobs:
+
+    - name: build-test-pki
+      plan:
+      - get: verify-dev-pki
+      - task: assemble-pki
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: openjdk
+              tag: 11
+          inputs:
+            - name: verify-dev-pki
+          outputs:
+            - name: pki
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "create a truststore containing metadata-ca and ida-root-ca"
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-root-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-root-ca.pem.test
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-metadata-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-metadata-ca.pem.test
+                openssl base64 -A -in stub_connector.truststore > pki/stub_connector.truststore.base64
+
+                echo "copy keys and certs to pki/"
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.crt                pki/metadata_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.crt      pki/saml_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.pk8                pki/metadata_signing.pk8
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.pk8      pki/saml_signing.pk8
+
+      - task: apply-test-pki-configmap
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: pki
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "generating test-pki configMap from pki/, with data keys:"
+                ls pki/
+                kubectl -n "${NAMESPACE}" create configmap test-pki-configmap --from-file=pki --dry-run -o yaml | kubectl apply -f -

--- a/ci/sandbox/test-pki.yaml
+++ b/ci/sandbox/test-pki.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: concourse.k8s.io/v1beta1
+kind: Pipeline
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: build-test-pki
+spec:
+  exposed: true
+  config:
+
+    task_toolbox: &task_toolbox
+      type: docker-image
+      source:
+        repository: ((concourse.task-toolbox-image))
+        tag: ((concourse.task-toolbox-tag))
+
+    resources:
+
+    - name: verify-dev-pki
+      type: git
+      source:
+        uri: https://github.com/alphagov/verify-dev-pki.git
+
+    jobs:
+
+    - name: build-test-pki
+      plan:
+      - get: verify-dev-pki
+      - task: assemble-pki
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: openjdk
+              tag: 11
+          inputs:
+            - name: verify-dev-pki
+          outputs:
+            - name: pki
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "create a truststore containing metadata-ca and ida-root-ca"
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-root-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-root-ca.pem.test
+                keytool -keystore ./stub_connector.truststore -import -v -file verify-dev-pki/src/main/resources/ca-certificates/ida-metadata-ca.pem.test -storepass marshmallow -trustcacerts -noprompt -alias ida-metadata-ca.pem.test
+                openssl base64 -A -in stub_connector.truststore > pki/stub_connector.truststore.base64
+
+                echo "cat metadata CA certs to pki/metadataCACerts"
+                cat verify-dev-pki/src/main/resources/ca-certificates/ida-metadata-ca.pem.test verify-dev-pki/src/main/resources/ca-certificates/ida-root-ca.pem.test > pki/metadataCACerts
+
+                echo "copy keys and certs to pki/"
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.crt                pki/metadata_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.crt      pki/saml_signing.crt
+                cp verify-dev-pki/src/main/resources/dev-keys/metadata_signing_a.pk8                pki/metadata_signing.pk8
+                cp verify-dev-pki/src/main/resources/dev-keys/stub_country_signing_primary.pk8      pki/saml_signing.pk8
+
+      - task: apply-test-pki-configmap
+        config:
+          platform: linux
+          image_resource: *task_toolbox
+          inputs:
+            - name: pki
+          params:
+            KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+            KUBERNETES_TOKEN: ((namespace-deployer.token))
+            NAMESPACE: ((namespace-deployer.namespace))
+          run:
+            path: /bin/sh
+            args:
+              - -euc
+              - |
+                echo "configuring kubectl"
+                echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                kubectl config set-context deployer --user deployer --cluster self
+                kubectl config use-context deployer
+
+                echo "generating test-pki configMap from pki/, with data keys:"
+                ls pki/
+                kubectl -n "${NAMESPACE}" create configmap test-pki-configmap --from-file=pki --dry-run -o yaml | kubectl apply -f -
+
+

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/ResponseAssertionDecrypter.java
@@ -6,8 +6,6 @@ import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.encryption.support.DecryptionException;
-import uk.gov.ida.notification.configuration.CloudHsmCredentialConfiguration;
-import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
 import uk.gov.ida.saml.security.DecrypterFactory;
 
 import java.util.Collections;
@@ -18,10 +16,6 @@ public class ResponseAssertionDecrypter {
 
     public ResponseAssertionDecrypter(Credential credential) {
         this.decrypter = new DecrypterFactory().createDecrypter(Collections.singletonList(credential));
-        if (credential.getEntityId() != null && credential.getEntityId().equals(CloudHsmCredentialConfiguration.ID)) {
-            ProxyNodeLogger.info("Using CloudHSM so set JCA provider to Cavium");
-            this.decrypter.setJCAProviderName("Cavium");
-        }
     }
 
     public Response decrypt(Response response) throws DecryptionException {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SignatureSigningParametersHelper.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/SignatureSigningParametersHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.ida.notification.saml;
 
-import org.opensaml.security.x509.BasicX509Credential;
+import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.SignatureSigningParameters;
 import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
@@ -13,7 +13,7 @@ public class SignatureSigningParametersHelper {
         keyInfoGeneratorFactory.setEmitEntityCertificate(true);
     }
 
-    public static SignatureSigningParameters build(BasicX509Credential credential, String algorithm) {
+    public static SignatureSigningParameters build(Credential credential, String algorithm) {
         SignatureSigningParameters signingParams = new SignatureSigningParameters();
         signingParams.setSignatureAlgorithm(algorithm);
         signingParams.setSignatureCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);

--- a/stub-connector/build.gradle
+++ b/stub-connector/build.gradle
@@ -1,10 +1,3 @@
-repositories {
-    // cloudhsm libraries downloaded from AWS
-    flatDir {
-        dirs '/opt/cloudhsm/java'
-    }
-}
-
 dependencies {
     compile configurations.dropwizard,
             configurations.dropwizard_assets,
@@ -14,11 +7,6 @@ dependencies {
             configurations.dev_pki,
             project(':proxy-node-shared')
 
-    if (project.hasProperty('cloudhsm')) {
-        compile name: 'cloudhsm-3.0.0'
-        compile name: 'log4j-api-2.8'
-        compile name: 'log4j-core-2.8'
-    }
 }
 
 group = 'uk.gov.ida.notification.stubconnector'

--- a/stub-connector/src/dist/config.yml
+++ b/stub-connector/src/dist/config.yml
@@ -18,12 +18,7 @@ logging:
 
 connectorNodeBaseUrl: ${CONNECTOR_NODE_BASE_URL}
 connectorNodeEntityId: ${CONNECTOR_NODE_ENTITY_ID}
-
-metadataPublishingConfiguration:
-  metadataFilePath: ${CONNECTOR_METADATA_FILE_PATH:-/app/metadata/metadata.xml}
-  metadataPublishPath: ${CONNECTOR_METADATA_PUBLISH_PATH:-/ConnectorMetadata}
-  metadataCACertsFilePath: ${CONNECTOR_METADATA_CA_CERTS_FILE_PATH:-/app/metadata/metadataCACerts}
-  metadataCertsPublishPath: ${CONNECTOR_METADATA_CERTS_PUBLISH_PATH:-/ConnectorMetadataSigningCertificates}
+connectorNodeMetadataExpiryMonths: ${CONNECTOR_NODE_METADATA_EXPIRY_MONTHS:-1}
 
 proxyNodeMetadataConfiguration:
   url: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
@@ -35,12 +30,29 @@ proxyNodeMetadataConfiguration:
     password: ${PROXY_NODE_METADATA_TRUSTSTORE_PASSWORD:-marshmallow}
 
 credentialConfiguration:
-  type: ${SIGNER_CONFIG_TYPE:-file}
-  hsmKeyLabel: ${HSM_SIGNING_KEY_LABEL:-stub_connector_key}
-  publicKey:
-    type: ${CERT_TYPES:-encoded}
-    cert: ${CONNECTOR_SIGNING_CERT}
-    name: stub_connector
-  privateKey:
-    type: ${KEY_TYPES:-encoded}
-    key: ${CONNECTOR_SIGNING_KEY}
+  metadataSigningPublicKey:
+    type: ${CERT_TYPES:-file}
+    cert: ${METADATA_SIGNING_PUBLIC_KEY:-/app/pki/metadata_signing.crt}
+  metadataSigningPrivateKey:
+    type: ${CERT_TYPES:-file}
+    key: ${METADATA_SIGNING_PRIVATE_KEY:-/app/pki/metadata_signing.pk8}
+  samlSigningPublicKey:
+    type: ${CERT_TYPES:-file}
+    cert: ${SAML_SIGNING_PUBLIC_KEY:-/app/pki/saml_signing.crt}
+  samlSigningPrivateKey:
+    type: ${CERT_TYPES:-file}
+    key: ${SAML_SIGNING_PRIVATE_KEY:-/app/pki/saml_signing.pk8}
+  samlEncryptionPublicKey:
+    type: ${CERT_TYPES:-file}
+    cert: ${METADATA_ENCRYPTION_PUBLIC_KEY:-/app/pki/saml_signing.crt}
+  samlEncryptionPrivateKey:
+    type: ${CERT_TYPES:-file}
+    key: ${METADATA_ENCRYPTION_PRIVATE_KEY:-/app/pki/saml_signing.pk8}
+
+connectorNodeTemplateConfig: # configuration for connector node mustache template
+  entity_id: ${CONNECTOR_NODE_ENTITY_ID}
+  acs_url: ${CONNECTOR_NODE_ACS_URL}
+  want_signed_assertions: ${WANT_SIGNED_ASSERTIONS:-true}
+  organization_name: ${ORGANIZATION_NAME:-eu_stub_country}
+  organization_display_name: ${ORGANIZATION_DISPLAY_NAME:-EU Stub Country}
+  organization_url: ${CONNECTOR_NODE_BASE_URL}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/ConnectorNodeCredentialConfiguration.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/ConnectorNodeCredentialConfiguration.java
@@ -1,0 +1,71 @@
+package uk.gov.ida.notification.stubconnector;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.x509.BasicX509Credential;
+import org.opensaml.security.x509.X509Credential;
+import org.opensaml.security.x509.X509Support;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import uk.gov.ida.common.shared.configuration.DeserializablePublicKeyConfiguration;
+import uk.gov.ida.common.shared.configuration.PrivateKeyConfiguration;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+
+public class ConnectorNodeCredentialConfiguration {
+
+    private final X509Credential metadataSigningCredential;
+    private final X509Credential samlSigningCredential;
+    private final X509Credential samlEncryptionCredential;
+    private final String algorithm;
+
+    @JsonCreator
+    public ConnectorNodeCredentialConfiguration(
+            @JsonProperty("metadataSigningPublicKey") DeserializablePublicKeyConfiguration metadataSigningPublicKey,
+            @JsonProperty("samlSigningPublicKey") DeserializablePublicKeyConfiguration samlSigningPublicKey,
+            @JsonProperty("samlEncryptionPublicKey") DeserializablePublicKeyConfiguration samlEncryptionPublicKey,
+            @JsonProperty("metadataSigningPrivateKey") PrivateKeyConfiguration metadataSigningPrivateKey,
+            @JsonProperty("samlSigningPrivateKey") PrivateKeyConfiguration samlSigningPrivateKey,
+            @JsonProperty("samlEncryptionPrivateKey") PrivateKeyConfiguration samlEncryptionPrivateKey
+    ) throws CertificateException {
+        this.metadataSigningCredential = new BasicX509Credential(
+                getX509Certificate(metadataSigningPublicKey),
+                metadataSigningPrivateKey.getPrivateKey());
+        this.samlSigningCredential = new BasicX509Credential(
+                getX509Certificate(samlSigningPublicKey),
+                samlSigningPrivateKey.getPrivateKey());
+        this.samlEncryptionCredential = new BasicX509Credential(
+                getX509Certificate(samlEncryptionPublicKey),
+                samlEncryptionPrivateKey.getPrivateKey());
+
+        if (samlSigningCredential.getPublicKey() instanceof ECPublicKey) {
+            this.algorithm = SignatureConstants.ALGO_ID_SIGNATURE_ECDSA_SHA256;
+        } else {
+            this.algorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+        }
+
+    }
+
+    private X509Certificate getX509Certificate(DeserializablePublicKeyConfiguration metadataSigningPublicKey) throws CertificateException {
+        return X509Support.decodeCertificate(metadataSigningPublicKey.getCert().getBytes());
+    }
+
+    public Credential getMetadataSigningCredential() {
+        return metadataSigningCredential;
+    }
+
+    public Credential getSamlSigningCredential() {
+        return samlSigningCredential;
+    }
+
+    public Credential getSamlEncryptionCredential() {
+        return samlEncryptionCredential;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/StubConnectorConfiguration.java
@@ -2,13 +2,12 @@ package uk.gov.ida.notification.stubconnector;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
-import uk.gov.ida.notification.configuration.CredentialConfiguration;
-import uk.gov.ida.notification.shared.metadata.MetadataPublishingConfiguration;
 import uk.gov.ida.saml.metadata.TrustStoreBackedMetadataConfiguration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.util.Map;
 
 public class StubConnectorConfiguration extends Configuration {
 
@@ -22,20 +21,25 @@ public class StubConnectorConfiguration extends Configuration {
     @JsonProperty
     private URI connectorNodeEntityId;
 
-    @Valid
-    @NotNull
+    /**
+     * Period of validity of connector node metadata in months,
+     */
     @JsonProperty
-    private CredentialConfiguration credentialConfiguration;
+    private Integer connectorNodeMetadataExpiryMonths = 1;
 
     @Valid
     @NotNull
     @JsonProperty
-    private MetadataPublishingConfiguration metadataPublishingConfiguration;
+    private ConnectorNodeCredentialConfiguration credentialConfiguration;
 
     @Valid
     @NotNull
     @JsonProperty
     private TrustStoreBackedMetadataConfiguration proxyNodeMetadataConfiguration;
+
+    @NotNull
+    @JsonProperty
+    private Map<String, String> connectorNodeTemplateConfig;
 
     public URI getConnectorNodeBaseUrl() {
         return connectorNodeBaseUrl;
@@ -53,11 +57,15 @@ public class StubConnectorConfiguration extends Configuration {
         return proxyNodeMetadataConfiguration;
     }
 
-    public MetadataPublishingConfiguration getMetadataPublishingConfiguration() {
-        return metadataPublishingConfiguration;
+    public ConnectorNodeCredentialConfiguration getCredentialConfiguration() {
+        return credentialConfiguration;
     }
 
-    public CredentialConfiguration getCredentialConfiguration() {
-        return credentialConfiguration;
+    public Map<String, String> getConnectorNodeTemplateConfig() {
+        return connectorNodeTemplateConfig;
+    }
+
+    public Integer getConnectorNodeMetadataExpiryMonths() {
+        return connectorNodeMetadataExpiryMonths;
     }
 }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/metadata/MetadataGenerator.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/metadata/MetadataGenerator.java
@@ -1,0 +1,114 @@
+package uk.gov.ida.notification.stubconnector.metadata;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import org.apache.xml.security.signature.XMLSignature;
+import org.joda.time.DateTime;
+import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.KeyDescriptor;
+import org.opensaml.saml.saml2.metadata.SSODescriptor;
+import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
+import org.opensaml.security.SecurityException;
+import org.opensaml.security.credential.Credential;
+import org.opensaml.security.credential.UsageType;
+import org.opensaml.xmlsec.SignatureSigningParameters;
+import org.opensaml.xmlsec.keyinfo.impl.X509KeyInfoGeneratorFactory;
+import org.opensaml.xmlsec.signature.KeyInfo;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.opensaml.xmlsec.signature.support.SignatureSupport;
+import org.opensaml.xmlsec.signature.support.SignatureValidator;
+import se.litsec.opensaml.utils.ObjectUtils;
+import uk.gov.ida.notification.stubconnector.StubConnectorConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class MetadataGenerator {
+
+    public static final String CONNECTOR_TEMPLATE_XML_MUSTACHE = "connector_template.xml.mustache";
+    public static final String TEMPLATE_KEY_ENTITY_ID = "entity_id";
+    private final X509KeyInfoGeneratorFactory keyInfoGeneratorFactory;
+    private final StubConnectorConfiguration configuration;
+
+    public MetadataGenerator(StubConnectorConfiguration configuration) {
+        this.configuration = configuration;
+        try {
+            InitializationService.initialize();
+        } catch (InitializationException e) {
+            throw new RuntimeException(e);
+        }
+        keyInfoGeneratorFactory = new X509KeyInfoGeneratorFactory();
+        keyInfoGeneratorFactory.setEmitEntityCertificate(true);
+    }
+
+    private String renderTemplate(String template, Map values) {
+        Mustache mustache = new DefaultMustacheFactory().compile(template);
+        StringWriter stringWriter = new StringWriter();
+        mustache.execute(stringWriter, values);
+        stringWriter.flush();
+        return stringWriter.toString();
+    }
+
+    public EntityDescriptor getConnectorMetadata() throws Exception {
+        Map<String, String> config = configuration.getConnectorNodeTemplateConfig();
+        config.put(TEMPLATE_KEY_ENTITY_ID, configuration.getConnectorNodeEntityId().toString());
+        String xml = renderTemplate(CONNECTOR_TEMPLATE_XML_MUSTACHE, config);
+        EntityDescriptor entityDescriptor = ObjectUtils.unmarshall(new ByteArrayInputStream(xml.getBytes()), EntityDescriptor.class);
+        entityDescriptor.setID("_" + UUID.randomUUID().toString());
+        entityDescriptor.setValidUntil(DateTime.now().plusMonths(configuration.getConnectorNodeMetadataExpiryMonths()));
+        updateSsoDescriptors(entityDescriptor);
+        sign(entityDescriptor);
+        return entityDescriptor;
+    }
+
+    private void sign(EntityDescriptor entityDescriptor) throws SecurityException, MarshallingException, SignatureException {
+        SignatureSigningParameters signingParams = new SignatureSigningParameters();
+        signingParams.setSignatureAlgorithm(XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256);
+        signingParams.setSignatureCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+        signingParams.setSigningCredential(configuration.getCredentialConfiguration().getMetadataSigningCredential());
+        signingParams.setKeyInfoGenerator(keyInfoGeneratorFactory.newInstance());
+        SignatureSupport.signObject(entityDescriptor, signingParams);
+        SAMLSignatureProfileValidator signatureProfileValidator = new SAMLSignatureProfileValidator();
+        signatureProfileValidator.validate(Optional.ofNullable(entityDescriptor.getSignature()).orElseThrow(() -> new RuntimeException("Signature missing")));
+        SignatureValidator.validate(entityDescriptor.getSignature(), configuration.getCredentialConfiguration().getMetadataSigningCredential());
+    }
+
+    private SSODescriptor getSsoDescriptor(EntityDescriptor entityDescriptor) {
+        return entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
+    }
+
+    private void updateSsoDescriptors(EntityDescriptor entityDescriptor) throws Exception {
+        SSODescriptor spSso = getSsoDescriptor(entityDescriptor);
+        addSamlSigningKeyDescriptor(spSso);
+        addSamlEncryptionDescriptor(spSso);
+    }
+
+    private void addSamlSigningKeyDescriptor(SSODescriptor spSso) throws Exception {
+        spSso.getKeyDescriptors().add(buildKeyDescriptor(UsageType.SIGNING, configuration.getCredentialConfiguration().getSamlSigningCredential()));
+    }
+
+    private void addSamlEncryptionDescriptor(SSODescriptor spSso) throws Exception {
+        spSso.getKeyDescriptors().add(buildKeyDescriptor(UsageType.ENCRYPTION, configuration.getCredentialConfiguration().getSamlEncryptionCredential()));
+    }
+
+    private KeyDescriptor buildKeyDescriptor(UsageType usageType, Credential credential) throws SecurityException {
+        KeyDescriptor keyDescriptor = (KeyDescriptor) XMLObjectSupport.buildXMLObject(KeyDescriptor.DEFAULT_ELEMENT_NAME);
+        keyDescriptor.setUse(usageType);
+        keyDescriptor.setKeyInfo(buildKeyInfo(credential));
+        return keyDescriptor;
+    }
+
+    private KeyInfo buildKeyInfo(Credential credential) throws SecurityException {
+        return keyInfoGeneratorFactory.newInstance().generate(credential);
+    }
+
+}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/MetadataResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/MetadataResource.java
@@ -1,0 +1,37 @@
+package uk.gov.ida.notification.stubconnector.resources;
+
+import io.dropwizard.jersey.caching.CacheControl;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import uk.gov.ida.notification.stubconnector.metadata.MetadataGenerator;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+@Path("/ConnectorMetadata")
+@Produces(MediaType.APPLICATION_XML)
+public class MetadataResource {
+
+    private final MetadataGenerator metadataGenerator;
+
+    public MetadataResource(MetadataGenerator metadataGenerator) {
+        this.metadataGenerator = metadataGenerator;
+    }
+
+    @GET
+    @CacheControl(maxAge = 1, maxAgeUnit = TimeUnit.DAYS)
+    public Response getConnectorNodeMetadata() throws Exception {
+        XMLObject xmlObject = metadataGenerator.getConnectorMetadata();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (outputStream) {
+            XMLObjectSupport.marshallToOutputStream(xmlObject, outputStream);
+            return Response.ok().entity(outputStream.toString(StandardCharsets.UTF_8)).build();
+        }
+    }
+}

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/SendAuthnRequestResource.java
@@ -21,10 +21,9 @@ import se.litsec.eidas.opensaml.ext.SPTypeEnumeration;
 import se.litsec.eidas.opensaml.ext.attributes.AttributeConstants;
 import uk.gov.ida.common.shared.configuration.EncodedPrivateKeyConfiguration;
 import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
-import uk.gov.ida.notification.configuration.CredentialConfiguration;
-import uk.gov.ida.notification.configuration.KeyFileCredentialConfiguration;
 import uk.gov.ida.notification.saml.SignatureSigningParametersHelper;
 import uk.gov.ida.notification.saml.metadata.Metadata;
+import uk.gov.ida.notification.stubconnector.ConnectorNodeCredentialConfiguration;
 import uk.gov.ida.notification.stubconnector.EidasAuthnRequestContextFactory;
 import uk.gov.ida.notification.stubconnector.StubConnectorConfiguration;
 import uk.gov.ida.notification.stubconnector.views.StartPageView;
@@ -117,18 +116,20 @@ public class SendAuthnRequestResource {
         @Session HttpSession session,
         @Context HttpServletResponse httpServletResponse
     ) throws Throwable {
-        JCEMapper.setProviderId("BC");
 
-        KeyFileCredentialConfiguration invalidCredentialConfiguration = new KeyFileCredentialConfiguration(
-            new X509CertificateConfiguration(TEST_PUBLIC_CERT),
-            new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
+        ConnectorNodeCredentialConfiguration invalidCredentialConfiguration = new ConnectorNodeCredentialConfiguration(
+                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+                new X509CertificateConfiguration(TEST_PUBLIC_CERT),
+                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY),
+                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY),
+                new EncodedPrivateKeyConfiguration(TEST_PRIVATE_KEY)
         );
         MessageContext context = generateAuthnRequestContext(session, EidasLoaEnum.LOA_SUBSTANTIAL, invalidCredentialConfiguration);
         encode(httpServletResponse, context);
 
         Response response = Response.ok().build();
 
-        JCEMapper.setProviderId("Cavium");
         return response;
     }
 
@@ -155,7 +156,7 @@ public class SendAuthnRequestResource {
     private MessageContext generateAuthnRequestContext(
         HttpSession session,
         EidasLoaEnum loaType,
-        CredentialConfiguration credentialConfiguration
+        ConnectorNodeCredentialConfiguration credentialConfiguration
     ) throws ResolverException, ComponentInitializationException, MessageHandlerException {
         String proxyNodeEntityId = configuration.getProxyNodeMetadataConfiguration().getExpectedEntityId();
         String connectorEntityId = configuration.getConnectorNodeEntityId().toString();
@@ -169,7 +170,7 @@ public class SendAuthnRequestResource {
         );
 
         SignatureSigningParameters signingParameters = SignatureSigningParametersHelper.build(
-            credentialConfiguration.getCredential(),
+            credentialConfiguration.getSamlSigningCredential(),
             credentialConfiguration.getAlgorithm());
 
         MessageContext context = contextFactory.generate(

--- a/stub-connector/src/main/resources/connector_template.xml.mustache
+++ b/stub-connector/src/main/resources/connector_template.xml.mustache
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:eidas="http://eidas.europa.eu/saml-extensions" xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" ID="_9ebc8854ec7f701da9749e87a801e5f2" entityID="{{entity_id}}" validUntil="2015-05-24T19:30:26.624Z">
+  <md:Extensions>
+    <eidas:SPType>public</eidas:SPType>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+    <alg:SigningMethod MinKeySize="256" Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <alg:SigningMethod MinKeySize="2048" MaxKeySize="4096" Algorithm="http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1"/>
+  </md:Extensions>
+  <md:SPSSODescriptor AuthnRequestsSigned="true" WantAssertionsSigned="{{want_signed_assertions}}" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{acs_url}}" index="1" isDefault="true"/>
+  </md:SPSSODescriptor>
+  <md:Organization>
+    <md:OrganizationName xml:lang="en">{{organization_name}}</md:OrganizationName>
+    <md:OrganizationDisplayName xml:lang="en">{{organization_display_name}}</md:OrganizationDisplayName>
+    <md:OrganizationURL xml:lang="en">{{organization_url}}</md:OrganizationURL>
+  </md:Organization>
+  <md:ContactPerson contactType="technical">
+    <md:Company>eIDAS Connector Operator</md:Company>
+    <md:GivenName>John</md:GivenName>
+    <md:SurName>Doe</md:SurName>
+    <md:EmailAddress>john.doe@eidas-connector.eu</md:EmailAddress>
+    <md:TelephoneNumber>+43 123456</md:TelephoneNumber>
+  </md:ContactPerson>
+</md:EntityDescriptor>

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
@@ -82,6 +82,12 @@
         <a href="./InvalidSignature" class="submitBtn submitBtnRed">Send request with invalid signature</a>
         <a href="./RequestHigh" class="submitBtn submitBtnRed">Start Journey LOA High</a>
     </div>
+    <div>
+        <p>
+            Other useful links:<br/>
+            <a href="/ConnectorMetadata">Connector Metadata</a>
+        </p>
+    </div>
 </div>
 </body>
 </html>

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/StubConnectorAssetsAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/StubConnectorAssetsAppRuleTests.java
@@ -2,6 +2,7 @@ package uk.gov.ida.notification.apprule;
 
 import io.dropwizard.testing.junit.DropwizardClientRule;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import uk.gov.ida.notification.apprule.base.StubConnectorAppRuleTestBase;
@@ -34,16 +35,7 @@ public class StubConnectorAssetsAppRuleTests extends StubConnectorAppRuleTestBas
     }
 
     @Test
-    public void shouldServeMetadata() throws IOException, URISyntaxException {
-        final String expectedMetadata = readResource("metadata/test-stub-connector-metadata.xml");
-
-        final Response response = stubConnectorAppRule.target(METADATA_PUBLISH_PATH).request().get();
-        final String metadata = response.readEntity(String.class);
-
-        assertThat(metadata).isEqualTo(expectedMetadata);
-    }
-
-    @Test
+    @Ignore("ignore until /ConnectorMetadataSigningCertificates resource created")
     public void shouldPublishMetadataSigningCertificates() throws URISyntaxException {
         final Response response = stubConnectorAppRule.target(METADATA_CERTS_PUBLISH_PATH).request().get();
         assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/base/StubConnectorAppRuleTestBase.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/base/StubConnectorAppRuleTestBase.java
@@ -25,12 +25,10 @@ public class StubConnectorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
     protected static final String METADATA_CERTS_PUBLISH_PATH = "/proxy-node-md-certs-publish-path";
     protected static final String METADATA_PUBLISH_PATH = "/stub-connector-md-publish-path";
     protected static final String ENTITY_ID = "http://stub-connector/Connector";
-
-    private static final String METADATA_FILE_PATH =
-            StubConnectorAppRuleTestBase.class.getClassLoader().getResource("metadata/test-stub-connector-metadata.xml").getPath();
-
-    private static final String METADATA_CA_CERTS_FILE_PATH =
-            StubConnectorAppRuleTestBase.class.getClassLoader().getResource("metadata/metadataCACerts").getPath();
+    protected static final String ACS_URL = "http://stub-connector/SAML2/Response/POST";
+    public static final String ENTITY_ORG_NAME = "stub country org name";
+    public static final String ENTITY_ORG_DISPLAY_NAME = "stub country org display name";
+    public static final String ENTITY_ORG_URL = "http://stub-connector/homepage";
 
     private Map<String, NewCookie> cookies;
 
@@ -44,6 +42,11 @@ public class StubConnectorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
         }
 
         return message;
+    }
+
+    protected String getConnectorMetadata(StubConnectorAppRule stubConnectorAppRule) throws URISyntaxException {
+        final Response response = stubConnectorAppRule.target("/ConnectorMetadata").request().get();
+        return response.readEntity(String.class);
     }
 
     protected String postEidasResponse(StubConnectorAppRule stubConnectorAppRule, String samlForm) throws URISyntaxException {
@@ -68,16 +71,28 @@ public class StubConnectorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
                 ConfigOverride.config("proxyNodeMetadataConfiguration.trustStore.store", METADATA_TRUSTSTORE.getAbsolutePath()),
                 ConfigOverride.config("proxyNodeMetadataConfiguration.trustStore.password", METADATA_TRUSTSTORE.getPassword()),
 
-                ConfigOverride.config("credentialConfiguration.type", "file"),
-                ConfigOverride.config("credentialConfiguration.publicKey.type", "x509"),
-                ConfigOverride.config("credentialConfiguration.publicKey.cert", TEST_PUBLIC_CERT),
-                ConfigOverride.config("credentialConfiguration.privateKey.key", TEST_PRIVATE_KEY),
+                ConfigOverride.config("credentialConfiguration.metadataSigningPublicKey.cert", TEST_PUBLIC_CERT),
+                ConfigOverride.config("credentialConfiguration.samlSigningPublicKey.cert", TEST_PUBLIC_CERT),
+                ConfigOverride.config("credentialConfiguration.samlEncryptionPublicKey.cert", TEST_PUBLIC_CERT),
+                ConfigOverride.config("credentialConfiguration.metadataSigningPrivateKey.key", TEST_PRIVATE_KEY),
+                ConfigOverride.config("credentialConfiguration.samlSigningPrivateKey.key", TEST_PRIVATE_KEY),
+                ConfigOverride.config("credentialConfiguration.samlEncryptionPrivateKey.key", TEST_PRIVATE_KEY),
 
-                ConfigOverride.config("metadataPublishingConfiguration.metadataFilePath", METADATA_FILE_PATH),
-                ConfigOverride.config("metadataPublishingConfiguration.metadataPublishPath", METADATA_PUBLISH_PATH),
-                ConfigOverride.config("metadataPublishingConfiguration.metadataCertsPublishPath", METADATA_CERTS_PUBLISH_PATH),
-                ConfigOverride.config("metadataPublishingConfiguration.metadataCACertsFilePath", METADATA_CA_CERTS_FILE_PATH)
-        ) {
+                ConfigOverride.config("credentialConfiguration.metadataSigningPublicKey.type", "x509"),
+                ConfigOverride.config("credentialConfiguration.samlSigningPublicKey.type", "x509"),
+                ConfigOverride.config("credentialConfiguration.samlEncryptionPublicKey.type", "x509"),
+                ConfigOverride.config("credentialConfiguration.metadataSigningPrivateKey.type", "encoded"),
+                ConfigOverride.config("credentialConfiguration.samlSigningPrivateKey.type", "encoded"),
+                ConfigOverride.config("credentialConfiguration.samlEncryptionPrivateKey.type", "encoded"),
+
+                ConfigOverride.config("connectorNodeTemplateConfig.entity_id", ENTITY_ID),
+                ConfigOverride.config("connectorNodeTemplateConfig.acs_url", ACS_URL),
+                ConfigOverride.config("connectorNodeTemplateConfig.organization_name", ENTITY_ORG_NAME),
+                ConfigOverride.config("connectorNodeTemplateConfig.organization_display_name", ENTITY_ORG_DISPLAY_NAME),
+                ConfigOverride.config("connectorNodeTemplateConfig.organization_url", ENTITY_ORG_URL),
+                ConfigOverride.config("connectorNodeTemplateConfig.want_signed_assertions", "true")
+
+                ) {
             @Override
             protected void before() {
                 waitForMetadata(proxyNodeMetadataUrl);

--- a/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/metadata/MetadataGeneratorTest.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/metadata/MetadataGeneratorTest.java
@@ -1,0 +1,66 @@
+package uk.gov.ida.notification.stubconnector.metadata;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import uk.gov.ida.common.shared.configuration.EncodedPrivateKeyConfiguration;
+import uk.gov.ida.common.shared.configuration.X509CertificateConfiguration;
+import uk.gov.ida.notification.stubconnector.StubConnectorConfiguration;
+import uk.gov.ida.notification.stubconnector.ConnectorNodeCredentialConfiguration;
+import uk.gov.ida.saml.core.test.TestCertificateStrings;
+
+import java.net.URI;
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataGeneratorTest {
+
+    private static final String ACS_URL = "acs url";
+    private static final String ENTITY_ID = "http://localhost/entity_id";
+
+    @Mock
+    private StubConnectorConfiguration configuration;
+
+    @Test
+    public void shouldCreateSignedConnectorNodeMetadata() throws Exception {
+
+        var templateConfig = new HashMap<String, String>();
+        templateConfig.put("want_signed_assertions", "true");
+        templateConfig.put("acs_url", ACS_URL);
+
+        var certConfig = new X509CertificateConfiguration(TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT);
+        var privateKeyConfig = new EncodedPrivateKeyConfiguration(TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY);
+        var credentialConfiguration = new ConnectorNodeCredentialConfiguration(
+                certConfig,
+                certConfig,
+                certConfig,
+                privateKeyConfig,
+                privateKeyConfig,
+                privateKeyConfig
+        );
+
+        when(configuration.getConnectorNodeEntityId()).thenReturn(URI.create(ENTITY_ID));
+        when(configuration.getConnectorNodeMetadataExpiryMonths()).thenReturn(1);
+        when(configuration.getCredentialConfiguration()).thenReturn(credentialConfiguration);
+        when(configuration.getConnectorNodeTemplateConfig()).thenReturn(templateConfig);
+
+        MetadataGenerator metadataGenerator = new MetadataGenerator(configuration);
+
+        EntityDescriptor connectorMetadata = metadataGenerator.getConnectorMetadata();
+        SPSSODescriptor spssoDescriptor = connectorMetadata.getSPSSODescriptor(SAMLConstants.SAML20P_NS);
+        AssertionConsumerService assertionConsumerService = spssoDescriptor.getAssertionConsumerServices().get(0);
+        assertThat(spssoDescriptor.getWantAssertionsSigned()).isTrue();
+        assertThat(connectorMetadata.getEntityID()).isEqualTo(ENTITY_ID);
+        assertThat(assertionConsumerService.getLocation()).isEqualTo(ACS_URL);
+        assertThat(connectorMetadata.isSigned()).isTrue();
+        assertThat(connectorMetadata.isValid()).isTrue();
+    }
+}


### PR DESCRIPTION
TLDR; The Stub Connector represents a stub country. It should not have its saml signing coupled to an HSM key.

Cherry pick from the release branch onto master, which is where we're doing multi-country dev.

The Stub Connector currently has its metadata certs+keys generated via the verify-metadata-controller, and the saml signing key is held in the HSM.

Every SAML request from stub connector is currently signed by a key in the CloudHSM. This was done as a convenience as the truststore for this signing is also generated via verify-metadata-controller, and easily made available to the ESP (the service that reads the connector metadata and then validates it against the truststore).

We want to model a a stub country that has its own PKI completely outside the HSM. The eventual goal is to run the Stub Connector in PaaS, to complete the separation.

This commit will:

* Create a pipeline to set a metadata signing cert+key, saml signing cert+key plus a metadata signing truststore, all from verify-dev-pki, into a cluster-wide configmap named test-pki-configmap
* Read test-pki-configmap to set a truststore in ESP
* Read test-pki-configmap via a volumeMount to provide metadata and saml signing credentials to the connector
* Remove HSM client config from stub connector
* Publish connector node metadata from a Resource using a mustache template. The method is equivalent to how connector node metadata is currently created in the verify-metadata-controller
* Use sensible default values in connector config.yml to avoid setting config via env vars