### PR TITLE
BAU Slack alert on a pipeline job failure

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -54,6 +54,14 @@ spec:
         repository: amazoncorretto
         tag: 11
 
+    slack-on-failure: &slack-on-failure
+      on_failure:
+        put: notify
+        params:
+          text: |
+            Proxy Node pipeline failed on the `$BUILD_PIPELINE_NAME.$BUILD_JOB_NAME` step.
+            https://ci.london.verify.govsvc.uk/teams/proxy-node-build/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
     resource_types:
 
     - name: github
@@ -68,6 +76,11 @@ spec:
       source:
         repository: ((concourse.harbor-resource-image))
         tag: ((concourse.harbor-resource-tag))
+
+    - name: slack-notification
+      type: docker-image
+      source:
+        repository: cfcommunity/slack-notification-resource
 
     resources:
 
@@ -184,6 +197,11 @@ spec:
         start: 3:00 AM
         stop: 4:00 AM
 
+    - name: notify
+      type: slack-notification
+      source:
+        url: ((slack-notifications.url))
+
     groups:
       - name: deployment
         jobs: [build-vsp-image, build-proxy-node, package, test, release, delete]
@@ -199,6 +217,7 @@ spec:
     - name: build-vsp-image
       serial: true
       serial_groups: [build-vsp]
+      *slack-on-failure
       plan:
       - in_parallel:
           steps:
@@ -239,6 +258,7 @@ spec:
     - name: build-cloudhsm
       serial: true
       serial_groups: [build-proxy-node]
+      *slack-on-failure
       plan:
       - get: cloudhsm-config
         trigger: true
@@ -264,6 +284,7 @@ spec:
     - name: build-proxy-node
       serial: true
       serial_groups: [build-proxy-node]
+      *slack-on-failure
       plan:
       - in_parallel:
           steps:
@@ -357,6 +378,7 @@ spec:
     - name: package
       serial: true
       serial_groups: [package, build-vsp, build-proxy-node]
+      *slack-on-failure
       plan:
       - in_parallel:
           steps:
@@ -512,6 +534,7 @@ spec:
     - name: delete
       serial: true
       serial_groups: [package]
+      *slack-on-failure
       plan:
         - get: nightly
           trigger: true
@@ -552,6 +575,7 @@ spec:
     - name: test
       serial: true
       serial_groups: [package]
+      *slack-on-failure
       plan:
 
       - in_parallel:
@@ -673,6 +697,7 @@ spec:
     - name: release
       serial: true
       serial_groups: [package]
+      *slack-on-failure
       plan:
 
       - get: chart

--- a/ci/build/slack-notification-secret-sealed.yaml
+++ b/ci/build/slack-notification-secret-sealed.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-notifications
+  namespace: verify-proxy-node-build
+spec:
+  template:
+    metadata:
+      name: slack-notifications
+      namespace: verify-proxy-node-build
+    type: Opaque
+  encryptedData:
+    url: AgAi69ah3/i9gPt/nQpeV3ILiFwxdl9cievB660FultkmDhza9sd1nBV1I5Ci+a9X0SXLViIN5GxJJWtKmIxgi8071WTJykLNBDpM2T+DtnqeFhHvFlJbeMBNQ+93QGWd+rsc5jo0NWGWmfh2ec7TJjiDXCOQASETN9tVaZXcrW9OU7ePwIJkreKLni5iluW3KmkPlfQQ8m7pYTuGCJh7km1m5F0AeXBYeF+R3fH5NeSfOU5E3neeGsPN6h1Qj5CL6RLMQvhBfjWzQhG3alqUbomSIgJ2EWOYeJAdh18VKu91RfCultcypWOVi/HGgnjBix80YeRmJ1hIGTFdi91AaW/4VImQ6RDV+JacUKhtmi7xBuOPAx3Pqw3kndnvdxDaWmbfSeFbWpEMdXqL9PQyOdLUqBmL35QZ4vIXwqHzw5v6McBa623nhuZJV7SXSfbr54acoiIjUdXoaQhKtOcUIHCcQdKQTFnvzl2kMeRm519cEQQSNMZlT1qZDljNBYRiVElgdovBFX4GSXf5NSsZOUWaIh8poSjMqtptEmS6HO3OYQIBn+YfzUzep1OvcsVBlKQZFhwslNJrNzrce5d6mOyAtK9nG9e7lpXngjkld4Lc5wRWTwxPQHXR9H4rdw4Tc2BHAzPMBA/CWicRNKy3R/98Cmc0XbwkE+BvtvUQIgFnWo1cJvtNvabCBkN5dKzMPz5+/6KPDTFbYCooz9rjgYfRGwFvSWpJbySc483aKvQYSjr9xe4+8LeawVz1hRpAX5MCe1yR6y0BYFWulRnVKdniA/DfxpMRVH87Mi24Jo=

--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -25,6 +25,14 @@ spec:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
 
+    slack-on-failure: &slack-on-failure
+      on_failure:
+        put: notify
+        params:
+          text: |
+            Proxy Node pipeline failed on the `$BUILD_PIPELINE_NAME.$BUILD_JOB_NAME` step.
+            https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
     resource_types:
 
     - name: github
@@ -32,6 +40,11 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+
+    - name: slack-notification
+      type: docker-image
+      source:
+        repository: cfcommunity/slack-notification-resource
 
     resources:
 
@@ -50,10 +63,16 @@ spec:
         start: 8:00 AM
         stop: 8:00 PM
 
+    - name: notify
+      type: slack-notification
+      source:
+        url: ((slack-notifications.url))
+
     jobs:
 
     - name: deploy-dk-integration
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -147,6 +166,7 @@ spec:
 
     - name: deploy-nl-integration
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -239,6 +259,7 @@ spec:
 
     - name: deploy-se-integration
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -331,6 +352,7 @@ spec:
 
     - name: deploy-cz-integration
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -423,6 +445,7 @@ spec:
 
     - name: deploy-it-integration
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -515,6 +538,7 @@ spec:
 
     - name: deploy-test-integration
       serial: true
+      *slack-on-failure
       plan:
 
         - get: release
@@ -600,6 +624,7 @@ spec:
 
     - name: deploy-mt-integration
       serial: true
+      *slack-on-failure
       plan:
 
         - get: release

--- a/ci/integration/slack-notification-secret-sealed.yaml
+++ b/ci/integration/slack-notification-secret-sealed.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-notifications
+  namespace: verify-proxy-node-integration
+spec:
+  template:
+    metadata:
+      name: slack-notifications
+      namespace: verify-proxy-node-integration
+    type: Opaque
+  encryptedData:
+    url: AgA6Zz4Kmso6kkZm7MsVJtrCr1pA9+OtmzuaG6vTvOOJ0nFt9Kt6Ip2cyop0sX99NwjkaYpHRT5B5uZi/dw+puAxKvo+g7EnDkvkSrUm6FCtZbCG7hPBSh6xt5YDHcw4EFm2oZrQpWbbX3bfbwVPpyYPNEnxxz0OID0idAZ6Q0DSsvu8jJrtBW3bEFwfQ2CxXhXr0j4tu2zC8V4ShijCqq66TE2tsGhSLCbWhn+gkUJkS43NAUYyVuOj7/pr7QVJuVHtw/z2Tkh2mfxs3aUtuWuqkWVa5GVq8727cHgMxYPxN7cu6NIB4UdlTwgVrb4KEjv+2uak5r0QSar5/Utyfnfo8ciySbyYWoyeaq2NbUzBmd9ZCPsCVGKqVFcUpC0OLv3QiXmb6x3gcLVTT5QMH/Y++G0HziAJcJqnnqCblSn5jLcFkGOuHg+Jsd3ji1N/tkN2mz8yefbtMx2xuk9g31vElY++hX4f2EYztNKsjmBlFNwOU5b0B6rlNLnOGFlJinwnUqTD6pEZilYPKFSBUAsnFk6gisjbl0YPRQ1BaMXmGLNYDtfS0oldvQ9OqpM0uSWvzRxfntunmZ6Sla8sjUCLqHuwC8cNafepfg+1vAa/EclyyO/bJ4UIDRK/xm6wZydL1TdIvwFJ8vGP0MbHfckHXz2td8lNgBH+wMULI67SdheqgvVrvK9NfDzaTmt5Mzs5Wa1IFzeddrruVunapsLeCWOpFHTzO91Kj7s2M/yHEgkiCl82ddrNAPQeY/Zcm+AfKi1OXlIMJ1GsM6RmqP7zq+e79Bs+umJDkq5f+94=

--- a/ci/integration/smoke-test.yaml
+++ b/ci/integration/smoke-test.yaml
@@ -23,6 +23,14 @@ spec:
           targets: ((harbor.notary_targets_passphrase))
           delegation: ((harbor.notary_delegation_passphrase))
 
+    slack-on-failure: &slack-on-failure
+      on_failure:
+        put: notify
+        params:
+          text: |
+            Proxy Node Integration Smoke failed on the `$BUILD_PIPELINE_NAME.$BUILD_JOB_NAME` step.
+            https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
     resource_types:
 
     - name: harbor
@@ -31,6 +39,11 @@ spec:
       source:
         repository: ((concourse.harbor-resource-image))
         tag: ((concourse.harbor-resource-tag))
+
+    - name: slack-notification
+      type: docker-image
+      source:
+        repository: cfcommunity/slack-notification-resource
 
     resources:
 
@@ -47,9 +60,15 @@ spec:
         <<: *harbor_source
         repository: registry.((cluster.domain))/eidas/acceptance-tests
 
+    - name: notify
+      type: slack-notification
+      source:
+        url: ((slack-notifications.url))
+
     jobs:
 
     - name: smoke-test-integration
+      *slack-on-failure
       plan:
 
       - get: every-10m-9-5

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -25,6 +25,14 @@ spec:
         repository: ((concourse.task-toolbox-image))
         tag: ((concourse.task-toolbox-tag))
 
+    slack-on-failure: &slack-on-failure
+      on_failure:
+        put: notify
+        params:
+          text: |
+            Proxy Node pipeline failed on the `$BUILD_PIPELINE_NAME.$BUILD_JOB_NAME` step.
+            https://ci.london.verify.govsvc.uk/teams/proxy-node-prod/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+
     resource_types:
 
     - name: github
@@ -32,6 +40,11 @@ spec:
       source:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
+
+    - name: slack-notification
+      type: docker-image
+      source:
+        repository: cfcommunity/slack-notification-resource
 
     resources:
 
@@ -50,10 +63,16 @@ spec:
         start: 3:00 AM
         stop: 4:00 AM
 
+    - name: notify
+      type: slack-notification
+      source:
+        url: ((slack-notifications.url))
+
     jobs:
 
     - name: deploy-nl-production
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -150,6 +169,7 @@ spec:
 
     - name: deploy-se-production
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -246,6 +266,7 @@ spec:
 
     - name: deploy-cz-production
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -342,6 +363,7 @@ spec:
 
     - name: deploy-it-production
       serial: true
+      *slack-on-failure
       plan:
 
       - get: release
@@ -438,6 +460,7 @@ spec:
 
     - name: deploy-mt-production
       serial: true
+      *slack-on-failure
       plan:
 
         - get: release

--- a/ci/prod/slack-notification-secret-sealed.yaml
+++ b/ci/prod/slack-notification-secret-sealed.yaml
@@ -1,0 +1,13 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: slack-notifications
+  namespace: verify-proxy-node-prod
+spec:
+  template:
+    metadata:
+      name: slack-notifications
+      namespace: verify-proxy-node-prod
+    type: Opaque
+  encryptedData:
+    url: AgBRt0BMffxhEUFE6Z5dtY2BKWNrxWSYgFRbC8gjPppauPOkQVjDU6/+NfJYLPELxIHIYszMlk9L+T8xHhlf4z5id7snMI9RUAvLlr9Z3y4L2MOzdHsGRmSTO8rbhcYdWsr5TxvZErGGo7tT9PjjB67GE1RLqB9cZ3UqwMSmisWQ0KSIM+P54C8DAN0ZgIxOpt6O80JhhhdwrGJyR/30/zGfJmyBaXaYWSbqQHxY49JsrvWsVGw0nIZ2BfgWBv5KkHzH77XuplWbi5Ji7In8f8nCZLBaT7BmKAQIWLtus2tZYhAx08AKAQZ07MU/C3He9QveErOE1nQSK7eosLmJXzAoijm3DiV7f3wLimHr8OyCxGb07UdFGjJSMUDsPHI6RYYYtJWVvx93Fd0uAVa3v/ofxv/wSHe7id9C41Ufy4C8NoVg8a6aQ4nPuQNdI75zwNVPnhVSb8ZAbZstF2IlabhDaOFWegDZ239J7zaLimP+s9eC1QYhpy3wnfUERldJkgthS2AkR9YZ7K7ZqiWvs7mjA79nTtkC6hufTGBSzh7jHXrsOFlyqPBZk9fOyXcWtehFcPvUlxIKw2rcZ9Oc96fWqwKy69yig0gJWNwAQ4dP3bO83d4S3r5XLIxus3dA/v4Qb/GZwqjp5M6935czZb2E0VlEF61iwYrqwRWMyZnxF1x662bcpEueNO9mf2bTWl6PL6+ZCujKKKKMVRVzZdxlog4t8loMY77E38KBP3D9YnBGH8iex84S+gIey8NEdhcHzCN740PTFMrDf54ihKddbZeo4YBcGHbFMqDEpEA=


### PR DESCRIPTION
Send a slack message to `#verify-eidas-alerts` when a concourse job fails on the
* [build](https://ci.london.verify.govsvc.uk/teams/proxy-node-build/pipelines/build-release),
* [integration deploy](https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/deploy),
* [integration smoke](https://ci.london.verify.govsvc.uk/teams/proxy-node-integration/pipelines/smoke-test) or 
* [prod deploy](https://ci.london.verify.govsvc.uk/teams/proxy-node-prod/pipelines/deploy) pipelines.

The slack webhook url required by the resource is referenced in each pipeline via the `((slack-notifications.url))` var. The value of this url is set via a sealed secret per namespace.

Secrets are sealed [using this method](https://verify-team-manual.cloudapps.digital/documentation/support/eidas-proxy-node/connecting-vsp-to-hub.html#creating-a-sealed-secret-for-the-vsp).