### PR TITLE
EID-1873 add timestamp annotation on pod

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,5 +9,5 @@ ignore:
   SNYK-JAVA-ORGYAML-537645:
     - '*':
         reason: Fix not available, and used for reading config, not at runtime
-        expires: 2020-01-15T00:00:00.000Z
+        expires: 2020-03-15T00:00:00.000Z
 patch: {}

--- a/chart/templates/esp-deployment.yaml
+++ b/chart/templates/esp-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.esp.replicaCount }}
   strategy:
@@ -23,6 +21,8 @@ spec:
       labels:
         app.kubernetes.io/name: esp
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       affinity:
         podAntiAffinity:

--- a/chart/templates/esp-redis-deployment.yaml
+++ b/chart/templates/esp-redis-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     app.kubernetes.io/name: esp-redis
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: 1
   strategy:
@@ -23,6 +21,8 @@ spec:
       labels:
         app.kubernetes.io/name: esp-redis
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       containers:
       - name: redis

--- a/chart/templates/gateway-deployment.yaml
+++ b/chart/templates/gateway-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.gateway.replicaCount }}
   strategy:
@@ -23,6 +21,8 @@ spec:
       labels:
         app.kubernetes.io/name: gateway
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       restartPolicy: Always
       volumes:

--- a/chart/templates/gateway-redis-deployment.yaml
+++ b/chart/templates/gateway-redis-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: 1
   strategy:
@@ -23,6 +21,8 @@ spec:
       labels:
         app.kubernetes.io/name: gateway-redis
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       containers:
       - name: redis

--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.stubConnector.replicaCount }}
   strategy:
@@ -25,6 +23,8 @@ spec:
         app.kubernetes.io/name: connector
         app.kubernetes.io/instance: {{ .Release.Name }}
         talksToHsm: "true"
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       restartPolicy: Always
       volumes:

--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.translator.replicaCount }}
   strategy:
@@ -24,6 +22,8 @@ spec:
         app.kubernetes.io/name: translator
         app.kubernetes.io/instance: {{ .Release.Name }}
         talksToHsm: "true"
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       restartPolicy: Always
       volumes:

--- a/chart/templates/vsp-deployment.yaml
+++ b/chart/templates/vsp-deployment.yaml
@@ -8,8 +8,6 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  annotations:
-    timestamp: {{ .Release.Time }}
 spec:
   replicas: {{ .Values.vsp.replicaCount }}
   selector:
@@ -21,6 +19,8 @@ spec:
       labels:
         app.kubernetes.io/name: vsp
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        timestamp: {{ .Release.Time }}
     spec:
       containers:
       - name: vsp


### PR DESCRIPTION
Add a timestamp annotation on the spec template during helm templating.
This will mark the pod referenced in the deployment as changed, and k8s should reconcile with a redeploy.
This is required for nightly rolling.