### PR TITLE
BAU Upgrade rack to fix security warning

### DIFF
--- a/proxy-node-acceptance-tests/Gemfile.lock
+++ b/proxy-node-acceptance-tests/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     public_suffix (4.0.1)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (12.3.3)


### PR DESCRIPTION
[CVE-2019-16782](https://github.com/advisories/GHSA-hrqr-hxpp-chr3)