### PR TITLE
EID-1881: Investigate snakeyaml

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,6 +8,6 @@ ignore:
         expires: 2020-03-15T00:00:00.000Z
   SNYK-JAVA-ORGYAML-537645:
     - '*':
-        reason: Fix not available, and used for reading config, not at runtime
+        reason: Fix not available, and used for reading config, not at runtime. See https://govukverify.atlassian.net/browse/EID-1881
         expires: 2020-03-15T00:00:00.000Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,6 @@ subprojects {
         verify_saml
         verify_saml_test
         proxy_node_test
-        soft_hsm
     }
 //    If any configurations are added/changed please ensure their dependencies are still being tested and monitored by
 //    Snyk. See the Snyk directory in the root of the project.

--- a/snyk/configurations.sh
+++ b/snyk/configurations.sh
@@ -4,4 +4,4 @@
 # Any new gradle configurations to be tested should be added here.
 
 # shellcheck disable=SC2034
-CONFIGURATIONS="common dropwizard eidas_saml ida_utils opensaml soft_hsm verify_saml dev_pki"
+CONFIGURATIONS="common dropwizard dropwizard_assets opensaml eidas_saml ida_utils verify_saml dev_pki"


### PR DESCRIPTION
### EID-1881: Add link to `.snyk` file about snakeyaml …
The snakeyaml vulnerability isn't going away anytime soon. You can read
a short summary at the added link.

### BAU: Remove soft_hsm configuration definition …
We no longer used the soft_hsm configuration so this cleans up a little.

It also sorts the list of configurations snyk tests to make it easier to
check the correct ones are being tested.