### PR TITLE
BAU ignore SNYK-JAVA-ORGCRYPTACULAR-543303 temporarily

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,4 +10,8 @@ ignore:
     - '*':
         reason: Fix not available, and used for reading config, not at runtime. See https://govukverify.atlassian.net/browse/EID-1881
         expires: 2020-03-15T00:00:00.000Z
+  SNYK-JAVA-ORGCRYPTACULAR-543303:
+    - '*':
+        reason: Fix merged on repo but no release available
+        expires: 2020-03-15T00:00:00.000Z
 patch: {}


### PR DESCRIPTION
Ignore Snykk reported CVE https://snyk.io/vuln/SNYK-JAVA-ORGCRYPTACULAR-543303 until repo owners release 1.2.4.

Tested locally with `./snyk/test.sh`