### PR TITLE
Ensure environment variables are set to strings

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -363,7 +363,7 @@ spec:
               params:
                 CONTEXT: src
                 BUILD_ARG_component: proxy-node-translator
-                BUILD_ARG_TALKS_TO_HSM: true
+                BUILD_ARG_TALKS_TO_HSM: "true"
               inputs:
               - name: src
           - put: translator-image

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -351,7 +351,7 @@ spec:
               params:
                 CONTEXT: src
                 BUILD_ARG_component: proxy-node-translator
-                BUILD_ARG_TALKS_TO_HSM: true
+                BUILD_ARG_TALKS_TO_HSM: "true"
               inputs:
               - name: src
           - put: translator-image


### PR DESCRIPTION
YAML will take `true` as a boolean instead of a string "true".