### PR TITLE
Serialise build-cloudhsm

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -256,35 +256,31 @@ spec:
       plan:
       - get: cloudhsm-config
         trigger: true
-      - in_parallel:
-          limit: 3
-          fail_fast: true
-          steps:
-          - task: build-cloudhsm
-            privileged: true
-            config:
-              <<: *build_config
-              params:
-                CONTEXT: cloudhsm-config/cloudhsm
-              inputs:
-              - name: cloudhsm-config
-          - put: cloudhsm-client-image
-            params:
-              <<: *image_put_params
-              additional_tags: cloudhsm-config/.git/short_ref
+      - task: build-cloudhsm
+        privileged: true
+        config:
+          <<: *build_config
+          params:
+            CONTEXT: cloudhsm-config/cloudhsm
+          inputs:
+          - name: cloudhsm-config
+      - put: cloudhsm-client-image
+        params:
+          <<: *image_put_params
+          additional_tags: cloudhsm-config/.git/short_ref
 
-          - task: build-cloudhsm-jce
-            privileged: true
-            config:
-              <<: *build_config
-              params:
-                CONTEXT: cloudhsm-config/cloudhsm/jdk-jce-image
-              inputs:
-              - name: cloudhsm-config
-          - put: cloudhsm-jce-image
-            params:
-              <<: *image_put_params
-              additional_tags: cloudhsm-config/.git/short_ref
+      - task: build-cloudhsm-jce
+        privileged: true
+        config:
+          <<: *build_config
+          params:
+            CONTEXT: cloudhsm-config/cloudhsm/jdk-jce-image
+          inputs:
+          - name: cloudhsm-config
+      - put: cloudhsm-jce-image
+        params:
+          <<: *image_put_params
+          additional_tags: cloudhsm-config/.git/short_ref
     - name: build-proxy-node
       serial: true
       serial_groups: [build-proxy-node]


### PR DESCRIPTION
This was fine when we just had two put steps - one for each image.
Now we build and put for each image separately. So we need to ensure build
happens before that image's put.