### PR TITLE
no rootfs param for alpine-image with registry-image resource

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -490,7 +490,6 @@ spec:
           - get: cloudhsm-client-image
             passed: [build-cloudhsm]
           - get: alpine-image
-            params: {rootfs: true}
           - get: release
 
       - task: generate-chart-values

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -490,6 +490,8 @@ spec:
           - get: cloudhsm-client-image
             passed: [build-cloudhsm]
           - get: alpine-image
+            params:
+              format: oci
           - get: release
 
       - task: generate-chart-values
@@ -616,11 +618,11 @@ spec:
                 "./${CHART_NAME}"
               cp chart-version/tag proxy-node-chart-package/
               cp ./src/.git/ref proxy-node-chart-package/
-              tar -rf alpine-image/rootfs.tar proxy-node-chart-package/
+              tar -rf alpine-image/image.tar proxy-node-chart-package/
 
       - put: chart
         params:
-          image: alpine-image/rootfs.tar
+          image: alpine-image/image.tar
           additional_tags: src/.git/short_ref
 
     - name: delete

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -477,7 +477,6 @@ spec:
           - get: cloudhsm-client-image
             passed: [build-cloudhsm]
           - get: alpine-image
-            params: {rootfs: true}
 
       - task: generate-chart-values
         config:

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -477,6 +477,8 @@ spec:
           - get: cloudhsm-client-image
             passed: [build-cloudhsm]
           - get: alpine-image
+            params:
+              format: oci
 
       - task: generate-chart-values
         config:
@@ -596,11 +598,11 @@ spec:
                 --key "${KEY_ID}" \
                 "./${CHART_NAME}"
               cp chart-version/tag proxy-node-chart-package/
-              tar -rf alpine-image/rootfs.tar proxy-node-chart-package/
+              tar -rf alpine-image/image.tar proxy-node-chart-package/
 
       - put: chart
         params:
-          image: alpine-image/rootfs.tar
+          image: alpine-image/image.tar
           additional_tags: src/.git/short_ref
 
     - name: test


### PR DESCRIPTION
format parameter defaults to rootfs