### PR TITLE
Isolate istio resources to current namespace only.

### DIFF
--- a/chart/templates/gateway-ingress-virtual-service.yaml
+++ b/chart/templates/gateway-ingress-virtual-service.yaml
@@ -19,3 +19,5 @@ spec:
           host: {{ .Release.Name }}-gateway
           port:
             number: 80
+  exportTo:
+  - "."

--- a/chart/templates/metatron-ingress-virtual-service.yaml
+++ b/chart/templates/metatron-ingress-virtual-service.yaml
@@ -19,3 +19,5 @@ spec:
           host: {{ .Release.Name }}-metatron
           port:
             number: 80
+  exportTo:
+  - "."

--- a/chart/templates/stub-connector-gateway-egress-service-entry.yaml
+++ b/chart/templates/stub-connector-gateway-egress-service-entry.yaml
@@ -18,4 +18,6 @@ spec:
     protocol: TLS
   location: MESH_EXTERNAL
   resolution: DNS
+  exportTo:
+  - "."
 {{- end }}

--- a/chart/templates/stub-connector-ingress-virtual-service.yaml
+++ b/chart/templates/stub-connector-ingress-virtual-service.yaml
@@ -20,4 +20,6 @@ spec:
           host: {{ .Release.Name }}-connector
           port:
             number: 80
+  exportTo:
+  - "."
 {{- end -}}


### PR DESCRIPTION
ServiceEntry, DestinationRule, and VirtualService resources default to "all namespaces". We need a per-namespace configuration.

Pre-requisite of the dev-namespaces work.