### PR TITLE
Fix the last remaining harbor usage

### DIFF
--- a/ci/integration/principal.yaml
+++ b/ci/integration/principal.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: access.govsvc.uk/v1beta1
+kind: Principal
+metadata:
+  name: pipeline
+  labels:
+    group.access.govsvc.uk: pipeline
+

--- a/ci/integration/smoke-test.yaml
+++ b/ci/integration/smoke-test.yaml
@@ -8,30 +8,6 @@ spec:
   exposed: true
   config:
 
-    harbor_source: &harbor_source
-      username: ((harbor.harbor_username))
-      password: ((harbor.harbor_password))
-      harbor:
-        prevent_vul: "false"
-      notary:
-        url: ((harbor.notary_url))
-        root_key: ((harbor.root_key))
-        delegate_key: ((harbor.ci_key))
-        passphrase:
-          root: ((harbor.notary_root_passphrase))
-          snapshot: ((harbor.notary_snapshot_passphrase))
-          targets: ((harbor.notary_targets_passphrase))
-          delegation: ((harbor.notary_delegation_passphrase))
-
-    resource_types:
-
-    - name: harbor
-      type: docker-image
-      privileged: true
-      source:
-        repository: ((concourse.harbor-resource-image))
-        tag: ((concourse.harbor-resource-tag))
-
     resources:
 
     - name: every-10m-9-5
@@ -42,11 +18,12 @@ spec:
         stop: 5:00 PM
 
     - name: tests-image
-      type: harbor
+      type: registry-image
+      icon: file-document
       source:
-        <<: *harbor_source
-        repository: registry.((cluster.domain))/eidas/acceptance-tests
-
+        username: ((pipeline.ImageRegistryUsername))
+        password: ((pipeline.ImageRegistryPassword))
+        repository: 367051407649.dkr.ecr.eu-west-2.amazonaws.com/verify-verify-proxy-node-build-tests
     jobs:
 
     - name: smoke-test-integration


### PR DESCRIPTION
We no longer put to the harbor repository.
The full-URI-to-pull-across-namespace trick is borrowed from @bjgill in DCS.