### PR TITLE
BAU: Fix docker local-startup

### DIFF
--- a/local-startup/Dockerfile
+++ b/local-startup/Dockerfile
@@ -1,6 +1,6 @@
 # Base builder image
 
-FROM gradle:5.5.1-jdk11 AS build
+FROM gradle:6.0.1-jdk11 AS build
 WORKDIR /app
 
 ARG component

--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -20,12 +20,18 @@ REDIS_SERVER_URI=""
 # Stub Connector config
 CONNECTOR_NODE_BASE_URL=http://stub-connector:6610/
 CONNECTOR_NODE_ENTITY_ID=http://stub-connector:6610/ConnectorMetadata
-CONNECTOR_METADATA_FILE_PATH=/app/metadata/stub-connector-metadata.xml
-CONNECTOR_SIGNING_CERT=/app/pki/stub-connector-saml-signing.crt
-CONNECTOR_SIGNING_KEY=/app/pki/stub-connector-saml-signing.pk8
+CONNECTOR_NODE_ACS_URL=http://localhost:6610/SAML2/Response
 PROXY_NODE_ENTITY_ID=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_TRUSTSTORE=/app/metadata/metadata.truststore
+METADATA_SIGNING_PUBLIC_KEY=/app/pki/stub-connector-metadata-signing.crt
+METADATA_SIGNING_PRIVATE_KEY=/app/pki/stub-connector-metadata-signing.pk8
+SAML_SIGNING_PUBLIC_KEY=/app/pki/stub-connector-saml-signing.crt
+SAML_SIGNING_PRIVATE_KEY=/app/pki/stub-connector-saml-signing.pk8
+METADATA_ENCRYPTION_PUBLIC_KEY=/app/pki/stub-connector-saml-encryption.crt
+METADATA_ENCRYPTION_PRIVATE_KEY=/app/pki/stub-connector-saml-encryption.pk8
+
+
 
 # eIDAS SAML Parser config
 CONNECTOR_NODE_METADATA_URL=http://stub-connector:6610/ConnectorMetadata


### PR DESCRIPTION
The way that stub-connector got it's signing credentials had changed
slightly which prevented it from starting up.

Also bumps the gradle version the images are built on to match the new
gradle syntax being used.