### PR TITLE
BAU: Fix stub-connector ACS for docker local startup

### DIFF
--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -20,7 +20,7 @@ REDIS_SERVER_URI=""
 # Stub Connector config
 CONNECTOR_NODE_BASE_URL=http://localhost:6610
 CONNECTOR_NODE_ENTITY_ID=http://stub-connector:6610/ConnectorMetadata
-CONNECTOR_NODE_ACS_URL=http://stub-connector:6610/SAML2/Response
+CONNECTOR_NODE_ACS_URL=http://localhost:6610/SAML2/Response
 PROXY_NODE_ENTITY_ID=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_TRUSTSTORE=/app/metadata/metadata.truststore


### PR DESCRIPTION
The request to the URL is made from the outside the docker network on
the host so there's no way to resolve the hostname. Setting it localhost
fixes this.