### PR TITLE
BAU: Do not delete HMRC connector on deploy

### DIFF
--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -588,8 +588,6 @@ spec:
                     --app "${RELEASE_NAME}-${APP_NAME}" \
                     --diff-changes \
                     -f ./manifests/
-                  echo "deleting ${RELEASE_NAMESPACE} connector pod"
-                  kubectl -n ${RELEASE_NAMESPACE} delete pod -l app.kubernetes.io/name=connector
 
     - name: deploy-hmrc-integration
       serial: true


### PR DESCRIPTION
We need the connector to stick around.