### PR TITLE
EID-1837 Clean up DTOs used between Gateway and ESP

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -7,7 +7,6 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.UsageType;
-import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.slf4j.event.Level;
 import se.litsec.opensaml.utils.ObjectUtils;
 import uk.gov.ida.notification.contracts.CountryMetadataResponse;
@@ -49,7 +48,7 @@ public class EidasSamlResource {
 
     @POST
     @Valid
-    public EidasSamlParserResponse post(@Valid EidasSamlParserRequest request) throws UnmarshallingException, XMLParserException, CertificateException, SignatureException {
+    public EidasSamlParserResponse post(@Valid EidasSamlParserRequest request) throws UnmarshallingException, XMLParserException, CertificateException {
 
         AuthnRequest authnRequest = unmarshallRequest(request);
 
@@ -62,7 +61,6 @@ public class EidasSamlResource {
         return new EidasSamlParserResponse(
                 authnRequest.getID(),
                 authnRequest.getIssuer().getValue(),
-                metatronResponse.getSamlEncryptionCertX509(),
                 metatronResponse.getDestination().toString());
     }
 

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -37,7 +37,6 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 
-@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class EidasSamlResourceTest {
 
@@ -94,7 +93,6 @@ public class EidasSamlResourceTest {
 
         assertThat(response.getRequestId()).isEqualTo(requestId);
         assertThat(response.getIssuerEntityId()).isEqualTo(issuerAsString);
-        assertThat(response.getConnectorEncryptionPublicCertificate()).isEqualTo(TEST_RP_PUBLIC_ENCRYPTION_CERT);
         assertThat(response.getDestination()).isEqualTo(TEST_CONNECTOR_DESTINATION);
 
         assertThat(MDC.get(ProxyNodeMDCKey.EIDAS_REQUEST_ID.name())).isEqualTo(requestId);

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -3,7 +3,6 @@ package uk.gov.ida.notification.resources;
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
 import io.prometheus.client.Counter;
-import org.apache.commons.lang.StringUtils;
 import org.opensaml.saml.saml2.ecp.RelayState;
 import uk.gov.ida.notification.MetricsUtils;
 import uk.gov.ida.notification.SamlFormViewBuilder;
@@ -95,15 +94,9 @@ public class EidasAuthnRequestResource {
             )
         );
 
-        String connectorEncryptionPublicCert = StringUtils.right(
-                eidasSamlParserResponse.getConnectorEncryptionPublicCertificate(),
-                10
-        );
-
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, eidasSamlParserResponse.getRequestId());
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, eidasSamlParserResponse.getIssuerEntityId());
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_DESTINATION, eidasSamlParserResponse.getDestination());
-        ProxyNodeLogger.addContext(ProxyNodeMDCKey.CONNECTOR_PUBLIC_ENC_CERT_SUFFIX, connectorEncryptionPublicCert);
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.HUB_REQUEST_ID, vspResponse.getRequestId());
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.HUB_URL, vspResponse.getSsoLocation().toString());
         ProxyNodeLogger.info("Authn requests received from ESP and VSP");

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
@@ -13,7 +13,6 @@ import javax.ws.rs.core.MediaType;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_DESTINATION_URL;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_EIDAS_REQUEST_ID;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_ENTITY_ID;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 
 @Path(Urls.EidasSamlParserUrls.EIDAS_AUTHN_REQUEST_PATH)
 @Produces(MediaType.APPLICATION_JSON)
@@ -25,7 +24,6 @@ public class TestEidasSamlResource {
         return new EidasSamlParserResponse(
                 SAMPLE_EIDAS_REQUEST_ID,
                 SAMPLE_ENTITY_ID,
-                STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
                 SAMPLE_DESTINATION_URL
         );
     }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
@@ -10,7 +10,6 @@ import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.contracts.EidasSamlParserRequest;
 import uk.gov.ida.notification.contracts.EidasSamlParserResponse;
 import uk.gov.ida.notification.exceptions.EidasSamlParserResponseException;
-import uk.gov.ida.notification.helpers.SelfSignedCertificateGenerator;
 import uk.gov.ida.notification.shared.istio.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.logging.ProxyNodeMDCKey;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
@@ -36,17 +35,8 @@ import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_REQ
 
 public class EidasSamlParserProxyTest {
 
-    private static final String UNCHAINED_PUBLIC_PEM;
     private static final String JOURNEY_ID = "this_is_not_a_uuid";
     private static final EidasSamlParserRequest eidasSamlParserRequest = new EidasSamlParserRequest(SAMPLE_HUB_SAML_AUTHN_REQUEST);
-
-    static {
-        try {
-            UNCHAINED_PUBLIC_PEM = new SelfSignedCertificateGenerator("test-cn").getCertificateAsPEM();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     @Path("/parse")
     @Produces(MediaType.APPLICATION_JSON)
@@ -56,7 +46,7 @@ public class EidasSamlParserProxyTest {
         @Valid
         @Path("/valid")
         public EidasSamlParserResponse testValidParse(EidasSamlParserRequest eidasSamlParserRequest) {
-            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, UNCHAINED_PUBLIC_PEM, SAMPLE_DESTINATION_URL);
+            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL);
         }
 
         @POST
@@ -79,7 +69,7 @@ public class EidasSamlParserProxyTest {
         @Path("/test-journey-id-header")
         public EidasSamlParserResponse testJourneyIdHeader(EidasSamlParserRequest eidasSamlParserRequest, @Context HttpHeaders headers) {
             TestESPResource.headers = headers.getRequestHeaders();
-            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, UNCHAINED_PUBLIC_PEM, SAMPLE_DESTINATION_URL);
+            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL);
         }
     }
 
@@ -95,7 +85,6 @@ public class EidasSamlParserProxyTest {
 
         assertThat(SAMPLE_REQUEST_ID).isEqualTo(response.getRequestId());
         assertThat(SAMPLE_ENTITY_ID).isEqualTo(response.getIssuerEntityId());
-        assertThat(UNCHAINED_PUBLIC_PEM).isEqualTo(response.getConnectorEncryptionPublicCertificate());
         assertThat(SAMPLE_DESTINATION_URL).isEqualTo(response.getDestination());
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -48,7 +48,6 @@ public class HubResponseResourceTest {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
             "eidas_request_id_in_session",
             "http://entityId",
-            "connector_public_cert_in_session",
             "http://connector.node"
         );
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
@@ -20,7 +20,6 @@ public class TestGatewaySessionDataValidator {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
                 "hub-request-id",
                 "issuer",
-                "eidas-connector-public-key",
                 "eidas-destination"
         );
 
@@ -36,7 +35,6 @@ public class TestGatewaySessionDataValidator {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
                 null,
                 "issuer",
-                "eidas-connector-public-key",
                 ""
         );
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
@@ -3,7 +3,6 @@ package uk.gov.ida.notification.contracts;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotBlank;
 import uk.gov.ida.notification.validations.ValidDestinationUriString;
-import uk.gov.ida.notification.validations.ValidPEM;
 import uk.gov.ida.notification.validations.ValidSamlId;
 
 public class EidasSamlParserResponse {
@@ -19,11 +18,6 @@ public class EidasSamlParserResponse {
 
     @JsonProperty
     @NotBlank
-    @ValidPEM
-    private String connectorEncryptionPublicCertificate;
-
-    @JsonProperty
-    @NotBlank
     @ValidDestinationUriString
     private String destination;
 
@@ -31,10 +25,9 @@ public class EidasSamlParserResponse {
     public EidasSamlParserResponse() {
     }
 
-    public EidasSamlParserResponse(String requestId, String issuerEntityId, String connectorEncryptionPublicCertificate, String destination) {
+    public EidasSamlParserResponse(String requestId, String issuerEntityId, String destination) {
         this.requestId = requestId;
         this.issuerEntityId = issuerEntityId;
-        this.connectorEncryptionPublicCertificate = connectorEncryptionPublicCertificate;
         this.destination = destination;
     }
 
@@ -44,10 +37,6 @@ public class EidasSamlParserResponse {
 
     public String getIssuerEntityId() {
         return issuerEntityId;
-    }
-
-    public String getConnectorEncryptionPublicCertificate() {
-        return connectorEncryptionPublicCertificate;
     }
 
     public String getDestination() {

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/session/storage/RedisStorageService.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/session/storage/RedisStorageService.java
@@ -42,7 +42,7 @@ public class RedisStorageService extends AbstractStorageService {
     }
 
     @Override
-    public StorageRecord read(String context, String key) throws IOException {
+    public StorageRecord read(String context, String key) {
         List<KeyValue<String, String>> result = redis.hmget(key(context, key), "value", "version", "expiration");
         String value = result.get(0).getValueOrElse(null);
         if (value == null) return null;
@@ -99,7 +99,7 @@ public class RedisStorageService extends AbstractStorageService {
             return null;
         } else if (storedVersion != version) {
             redis.unwatch();
-            throw new VersionMismatchException(String.format("Expected version to be %l but it was %l", version, storedVersion));
+            throw new VersionMismatchException(String.format("Expected version to be %d but it was %d", version, storedVersion));
         } else {
             redis.multi();
             redis.hmset(key(context, key), Map.of("value", value, "expiration", Long.toString(expiration), "version", Long.toString(storedVersion + 1)));
@@ -140,7 +140,7 @@ public class RedisStorageService extends AbstractStorageService {
             return false;
         } else if (storedVersion != version) {
             redis.unwatch();
-            throw new VersionMismatchException(String.format("Expected version to be %l but it was %l", version, storedVersion));
+            throw new VersionMismatchException(String.format("Expected version to be %d but it was %d", version, storedVersion));
         } else {
             redis.multi();
             redis.del(key(context, key));

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -31,7 +31,6 @@ import static uk.gov.ida.notification.contracts.verifyserviceprovider.Translated
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder.buildTranslatedHubResponseIdentityVerified;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder.buildTranslatedHubResponseIdentityVerifiedNoAttributes;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder.buildTranslatedHubResponseRequestError;
-import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 
 public class HubResponseTranslatorTest {
 

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_CONNECTOR_ENCRYPTION_CERTIFICATE;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_DESTINATION_URL;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMPLE_EIDAS_REQUEST_ID;
 import static uk.gov.ida.notification.helpers.ValidationTestDataUtils.SAMLPLE_HUB_SAML_RESPONSE;


### PR DESCRIPTION
We no longer need to pass the encryption certificate around as it's possible to get the information from Metatron.

Remove connectorEncryptionPublicCertificate from EidasSamlParserResponse.

Update any use of EidasSamlParserResponse so that code will compile.

Update tests so that they reflect new DTO.

*NOTE* this depends on eid-1836 as it's branched from there - there's some dependency between because of the Redis change in eid-1836