### PR TITLE
BAU Un-break the broken build

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
@@ -28,8 +28,8 @@ public class EidasSamlParserAppRuleTestBase extends AbstractSamlAppRuleTestBase 
 
     @ClassRule
     public static final RuleChain orderedRules = RuleChain
-            .outerRule(metadataClientRule)
-            .around(metatronService)
+            .outerRule(metatronService)
+            .around(metadataClientRule)
             .around(eidasSamlParserAppRule);
 
     protected static Response postEidasAuthnRequest(AuthnRequest authnRequest) throws URISyntaxException {


### PR DESCRIPTION
Some time ago, builds stopped building.  The test that fails doesn't fail locally or when Travis runs it.  This suggests some kind of race is going on and the wrong thing wins in the pipeline.  It looks like it's the mockatron that's providing the null pointer exceptions when it should be providing port numbers so I've changed the order in which the RuleChain is executed to see if that helps.