### PR TITLE
🍒BAU: Preserve permanent Sanbox branch config

### DIFF
--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -561,7 +561,7 @@ spec:
           outputs:
           - name: proxy-node-chart-package
           params:
-            CLUSTER_PRIVATE_KEY: ((cluster.privateKey))
+            CLUSTER_PRIVATE_KEY: ((artefact-signing-key.privateKey))
           run:
             path: /bin/bash
             args:


### PR DESCRIPTION
Cherry pick from the Sandbox branch so the permanent config needed for this branch doesn't get accidentally deleted when rebasing on master