### PR TITLE
BAU Back to Basics for the Broken Build

### DIFF
--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/base/EidasSamlParserAppRuleTestBase.java
@@ -22,9 +22,15 @@ public class EidasSamlParserAppRuleTestBase extends AbstractSamlAppRuleTestBase 
 
     private static final SamlObjectMarshaller SAML_OBJECT_MARSHALLER = new SamlObjectMarshaller();
     protected static final SamlObjectSigner SAML_OBJECT_SIGNER = createSamlObjectSigner();
-    private static final DropwizardClientRule metadataClientRule = createTestMetadataClientRule();
-    private static final DropwizardClientRule metatronService = createInitialisedClientRule(new TestMetatronResource());
-    private static final EidasSamlParserAppRule eidasSamlParserAppRule = createEidasSamlParserRule(metadataClientRule);
+
+    @ClassRule
+    public static final DropwizardClientRule metadataClientRule = createTestMetadataClientRule();
+
+    @ClassRule
+    public static final DropwizardClientRule metatronService = createInitialisedClientRule(new TestMetatronResource());
+
+    @ClassRule
+    public static final EidasSamlParserAppRule eidasSamlParserAppRule = createEidasSamlParserRule(metadataClientRule);
 
     @ClassRule
     public static final RuleChain orderedRules = RuleChain

--- a/metatron/src/test/java/uk/gov/ida/eidas/metatron/apprule/rules/MetatronTests.java
+++ b/metatron/src/test/java/uk/gov/ida/eidas/metatron/apprule/rules/MetatronTests.java
@@ -31,16 +31,15 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.security.cert.X509Certificate;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
+import static uk.gov.ida.notification.apprule.rules.AbstractSamlAppRuleTestBase.waitWhile;
 
 @RunWith(OpenSAMLRunner.class)
 public class MetatronTests {
@@ -69,15 +68,6 @@ public class MetatronTests {
         metatronAppRule = new MetatronAppRule();
 
         return RuleChain.outerRule(testMetadataServer).around(metatronAppRule);
-    }
-
-    private static void waitWhile(Supplier<Boolean> condition, String message) {
-        LocalDateTime giveUpAfter = LocalDateTime.now().plusSeconds(15);
-        while(condition.get()) {
-            if ( LocalDateTime.now().isAfter(giveUpAfter)) {
-                Assert.fail("Timed out while " + message);
-            }
-        }
     }
 
     @Test

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/AbstractSamlAppRuleTestBase.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/AbstractSamlAppRuleTestBase.java
@@ -3,6 +3,7 @@ package uk.gov.ida.notification.apprule.rules;
 import com.google.common.base.Stopwatch;
 import io.dropwizard.testing.junit.DropwizardClientRule;
 import keystore.KeyStoreResource;
+import org.junit.Assert;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import uk.gov.ida.notification.VerifySamlInitializer;
@@ -13,7 +14,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Scanner;
+import java.util.function.Supplier;
 
 import static keystore.builders.KeyStoreResourceBuilder.aKeyStoreResource;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PUBLIC_CERT;
@@ -93,6 +96,15 @@ public abstract class AbstractSamlAppRuleTestBase {
 
         if (connectorMetadata.equals("")) {
             throw new RuntimeException("Couldn't fetch metadata from " + metadataUrl);
+        }
+    }
+
+    public static void waitWhile(Supplier<Boolean> condition, String message) {
+        LocalDateTime giveUpAfter = LocalDateTime.now().plusSeconds(15);
+        while(condition.get()) {
+            if ( LocalDateTime.now().isAfter(giveUpAfter)) {
+                Assert.fail("Timed out while " + message);
+            }
         }
     }
 


### PR DESCRIPTION
Use the @ClassRule annotation (as the designers of Dropwizard intended) to hopefully ensure we have everything we want when we need it.