### PR TITLE
EID-1917: Add smoke tests to all countries connected to Connector Node

### DIFF
--- a/proxy-node-acceptance-tests/features/smoke/es-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/es-request.feature
@@ -1,0 +1,7 @@
+Feature: eidas-proxy-node-smoke-test-es-prod feature
+
+    Scenario: Connector node happy path for Spain
+        Given   the user visits a government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Spain
+        Then    they should arrive at the Spain Hub

--- a/proxy-node-acceptance-tests/features/smoke/et-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/et-request.feature
@@ -1,0 +1,8 @@
+Feature: eidas-proxy-node-smoke-test-et-prod feature
+
+    Scenario: Connector node happy path for Estonia
+        Given   the user visits a government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Estonia
+        And     they navigate through Eidas
+        Then    they should arrive at the Estonia Hub

--- a/proxy-node-acceptance-tests/features/smoke/it-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/it-request.feature
@@ -1,0 +1,8 @@
+Feature: eidas-proxy-node-smoke-test-it-prod feature
+
+    Scenario: Connector node happy path for Italy
+        Given   the user visits a government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Italy
+        And     they navigate through Eidas
+        Then    they should arrive at the Italy Hub

--- a/proxy-node-acceptance-tests/features/smoke/lu-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/lu-request.feature
@@ -1,0 +1,7 @@
+Feature: eidas-proxy-node-smoke-test-lu-prod feature
+
+    Scenario: Connector node happy path for Luxembourg
+        Given   the user visits a government service
+        And     they choose sign in with a digital identity from another European country
+        And     they select Luxembourg
+        Then    they should arrive at the Luxembourg Hub

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -55,6 +55,54 @@ Given("the user visits the Netherlands Connector Node Stub Page") do
   visit('https://demo-portal.minez.nl/demoportal/etoegang')
 end
 
+Given("the user visits a government service") do
+  visit('https://www.gov.uk/personal-tax-account/sign-in/prove-identity')
+end
+
+And('they choose sign in with a digital identity from another European country') do
+  find('label', text: 'Sign in with a digital identity from another European country').click
+  click_button('Continue')
+end
+
+And('they select Spain') do
+  click_button('Select DNIe')
+end
+
+Then('they should arrive at the Spain Hub') do
+  assert_text('Identificación con DNIe')
+end
+
+And('they select Estonia') do
+  click_button('Select ID-kaart')
+end
+
+Then('they should arrive at the Estonia Hub') do
+  assert_text('Turvaliseks autentimiseks Euroopa e-teenustes')
+end 
+
+And('they select Italy') do
+  click_button('Select SPID')
+end
+
+Then('they should arrive at the Italy Hub') do
+  assert_text('Italian eIDAS Login')
+end 
+
+And('they select Luxembourg') do
+  click_button('Select eAccess')
+end
+
+Then('they should arrive at the Luxembourg Hub') do
+  assert_text('eIDAS Authentication Service')
+end 
+
+And('they navigate through Eidas') do
+  assert_text('YOUR BASIC INFORMATION')
+  click_button('Next')
+  assert_text('YOUR ADDITIONAL INFORMATION')
+  click_button('Next')
+end
+
 And('they choose the UK as the country to verify with') do
   assert_text('Kies hoe u wilt inloggen')
   click_link('English')


### PR DESCRIPTION
The tests all start from the 'Personal tax account' service. From there sign in with a digital identity from another European country is selected. Then the country of choice is selected and then we check that we have reached the countries hub by asserting we can see specialised text on the page.

The smoke test will be run by the hub smoke test pipeline.

These feature can be tested locally by:

- updating the ENTRYPOINT in proxy-node-acceptance-tests/Dockerfile to:
`ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "features/smoke/{insert the country abbreviation}-request.feature", "--strict", "--tags", "not @ignore"]`

- running ./proxy-node-acceptance-tests/run-staging-tests.sh


Add a smoke test for each country to the Verify Hub Smoke pipeline: https://github.com/alphagov/verify-terraform/pull/1162