### PR TITLE
Supply metatron URL to conf via kubeyaml

### DIFF
--- a/chart/templates/esp-deployment.yaml
+++ b/chart/templates/esp-deployment.yaml
@@ -83,3 +83,5 @@ spec:
 {{- end }}
         - name: REDIS_SERVER_URI
           value: redis://{{ .Release.Name }}-esp-redis:6379/
+        - name: METATRON_URI
+          value: http://{{ .Release.Name }}-metatron/

--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -102,3 +102,5 @@ spec:
         - name: hsm-client-crt
           mountPath: /opt/cloudhsm/etc/customerCA.crt
           subPath: hsmCustomerCA.crt
+        - name: METATRON_URI
+          value: http://{{ .Release.Name }}-metatron/

--- a/eidas-saml-parser/src/dist/config.yml
+++ b/eidas-saml-parser/src/dist/config.yml
@@ -16,7 +16,7 @@ logging:
   appenders:
     - type: ${LOGGING_APPENDER:-logstash-console}
 
-metatronUri: ${METATRON_URL}
+metatronUri: ${METATRON_URI}
 
 replayChecker:
   redisUrl: ${REDIS_SERVER_URI}


### PR DESCRIPTION
Supply `METATRON_URI` env var to `esp` and `translator` dropwizard config.

To fix current deployment showing this error on `esp` and `translator`:

> java.lang.IllegalArgumentException: Illegal character in path at index 1: ${METATRON_URL}