### PR TITLE
set domain to sandbox.signin.service.gov.uk

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 global:
   cluster:
     name:
-    domain:
+    domain: sandbox.signin.service.gov.uk
   cloudHsm:
     enabled: true
     ip: 127.0.0.1

--- a/ci/sandbox/build-pipeline.yaml
+++ b/ci/sandbox/build-pipeline.yaml
@@ -708,7 +708,6 @@ spec:
           - name: manifests
           params:
             CLUSTER_NAME: ((cluster.name))
-            CLUSTER_DOMAIN: ((cluster.domain))
             CLUSTER_PUBLIC_KEY: ((artefact-signing-key.publicKey))
             RELEASE_NAMESPACE: ((namespace-deployer.namespace))
             RELEASE_NAME: test
@@ -730,7 +729,6 @@ spec:
                 --name "${RELEASE_NAME}" \
                 --namespace "${RELEASE_NAMESPACE}" \
                 --set "global.cluster.name=${CLUSTER_NAME}" \
-                --set "global.cluster.domain=${CLUSTER_DOMAIN}" \
                 --set "global.cloudHsm.ip=${CLOUDHSM_IP}" \
                 --set "stubConnector.enabled=true" \
                 --set "vsp.secretName=vsp" \


### PR DESCRIPTION
We want to use `signin.service.gov.uk` for Proxy Node.
We're testing this on sandbox.
We need to merge a PR onto the sandbox branch for the `configure-namespace` pipeline to accept the merge.