### PR TITLE
BAU: Fix Metatron URL for docker local startup

### DIFF
--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -43,7 +43,7 @@ CONNECTOR_NODE_NATIONALITY_CODE=EU
 CONNECTOR_NODE_ISSUER_ID=${CONNECTOR_NODE_ENTITY_ID}
 TRANSLATOR_SIGNING_CERT=/app/pki/proxy-node-saml-signing.crt
 TRANSLATOR_SIGNING_KEY=/app/pki/proxy-node-saml-signing.pk8
-METATRON_URL=http://metatron:6670/metadata
+METATRON_URL=http://metatron:6670
 
 # VSP running against local Hub
 SERVICE_ENTITY_IDS=["http://proxy-node-gateway:6600/ServiceMetadata"]


### PR DESCRIPTION
The `/metatron/` path fragment is added in the ESP and translator by the
functions that build the clients.