### PR TITLE
Upgrade commons-codec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
 
 install:
-  - npm install -g snyk@1.146.0
+  - npm install -g snyk@1.305.0
 
 script:
   - ./gradlew --no-daemon --parallel test

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ subprojects {
                 substitute module("org.apache.santuario:xmlsec") because "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281" with module("org.apache.santuario:xmlsec:2.1.4")
                 substitute module("com.nimbusds:nimbus-jose-jwt") because "https://snyk.io/vuln/SNYK-JAVA-COMNIMBUSDS-536068" with module("com.nimbusds:nimbus-jose-jwt:8.2.1")
                 substitute module("org.yaml:snakeyaml") because "https://snyk.io/vuln/SNYK-JAVA-ORGYAML-537645" with module("org.yaml:snakeyaml:1.26")
+                substitute module("commons-codec:commons-codec") because "https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518" with module("commons-codec:commons-codec:1.13")
                 exclude group: "commons-beanutils", module: "commons-beanutils"
             }
         }


### PR DESCRIPTION
Upgrade commons-codec version based on https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Update: travis ran the snyk check successfully on this branch, where it was previously failing.