### PR TITLE
fix snyk-reported vulns

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,9 +5,5 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2020-04-15T00:00:00.000Z
-  SNYK-JAVA-ORGCRYPTACULAR-543303:
-    - '*':
-        reason: Fix merged on repo but no release available. Believed to not currently be effected. See https://govukverify.atlassian.net/browse/EID-1921 for details of investigation.
-        expires: 2020-04-15T00:00:00.000Z
+        expires: 2020-05-15T00:00:00.000Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ subprojects {
                 substitute module("org.yaml:snakeyaml") because "https://snyk.io/vuln/SNYK-JAVA-ORGYAML-537645" with module("org.yaml:snakeyaml:1.26")
                 substitute module("commons-codec:commons-codec") because "https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518" with module("commons-codec:commons-codec:1.13")
                 substitute module("io.netty:netty-codec") because "https://snyk.io/vuln/SNYK-JAVA-IONETTY-564897" with module("io.netty:netty-codec:4.1.48.Final")
+                substitute module("org.cryptacular:cryptacular") because "https://snyk.io/vuln/SNYK-JAVA-ORGCRYPTACULAR-543303" with module("org.cryptacular:cryptacular:1.2.4")
                 exclude group: "commons-beanutils", module: "commons-beanutils"
             }
         }


### PR DESCRIPTION
Extend SNYK-JAVA-CAJULIUSDAVIES-30073 ignore, and upgrade org.cryptacular:cryptacular