### PR TITLE
EID-1953 Create New Metadata Signing Chain

### DIFF
--- a/chart/templates/metadata-signing-cert.yaml
+++ b/chart/templates/metadata-signing-cert.yaml
@@ -3,7 +3,7 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: {{ .Release.Name }}-proxy-node-metadata-signing-cert
+  name: {{ .Release.Name }}-proxy-node-metadata-signing-cert-a1
   namespace: {{ .Release.Namespace }}
 spec:
   countryCode: GB
@@ -14,5 +14,5 @@ spec:
   location: London
   CACert: false
   certificateAuthority:
-    secretName: proxy-node-metadata-ca
+    secretName: proxy-node-metadata-ca-a1
     namespace: {{ .Release.Namespace }}

--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -29,5 +29,5 @@ spec:
     organizationUnit: GDS
     location: London
   certificateAuthority:
-    secretName: {{ .Release.Name }}-proxy-node-metadata-signing-cert
+    secretName: {{ .Release.Name }}-proxy-node-metadata-signing-cert-a1
     namespace: {{ .Release.Namespace }}

--- a/ci/build/intermediate-metadata-certificate-request.yaml
+++ b/ci/build/intermediate-metadata-certificate-request.yaml
@@ -4,7 +4,7 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: proxy-node-metadata-ca
+  name: proxy-node-metadata-ca-a1
 spec:
   countryCode: GB
   commonName: Proxy Node Test Metadata CA
@@ -14,5 +14,5 @@ spec:
   location: London
   CACert: true
   certificateAuthority:
-    secretName: verify-root-ca-test
+    secretName: verify-root-ca-test-a1
     namespace: verify-metadata-controller


### PR DESCRIPTION
This is part 1 of [new test certificate chain for multi country proxy node build environment](https://govukverify.atlassian.net/browse/EID-1953) 
- Create metadata signing chain for build namespace

see for details:
https://github.com/alphagov/verify-proxy-node/blob/149d4fa9ff31722586d5070d6a9c3b24c2c390d3/doc/metadata_signing.md

Co-authored-by: Phillip Miller <phillip.miller@digital.cabinet-office.gov.uk>