### PR TITLE
Add whitespace to kick configure-namespace pipeline

### DIFF
--- a/ci/build/intermediate-metadata-certificate-request.yaml
+++ b/ci/build/intermediate-metadata-certificate-request.yaml
@@ -16,3 +16,4 @@ spec:
   certificateAuthority:
     secretName: verify-root-ca-test-a1
     namespace: verify-metadata-controller
+


### PR DESCRIPTION
The configure-namespace pipeline only builds on changes to ci/build, 
so I've made a change here.