### PR TITLE
🚭BAU remove smoke tests from build acceptance tests

### DIFF
--- a/proxy-node-acceptance-tests/Dockerfile
+++ b/proxy-node-acceptance-tests/Dockerfile
@@ -9,4 +9,4 @@ RUN bundle install
 COPY features /features
 COPY wait-for-it.sh /
 
-ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "--strict", "--tags", "not @ignore"]
+ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "features/proxy_node.feature", "--strict", "--tags", "not @ignore"]

--- a/proxy-node-acceptance-tests/Dockerfile
+++ b/proxy-node-acceptance-tests/Dockerfile
@@ -9,4 +9,4 @@ RUN bundle install
 COPY features /features
 COPY wait-for-it.sh /
 
-ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "features/proxy_node.feature", "--strict", "--tags", "not @ignore"]
+ENTRYPOINT ["./wait-for-it.sh", "http://selenium-hub:4444/status", "--", "bundle", "exec", "cucumber", "--exclude", "smoke/", "--strict", "--tags", "not @ignore"]


### PR DESCRIPTION
We currently run all cucumber feature tests in our build pipeline, including tests in features/smoke that should be run only from the Hub smoke pipeline.

In the build pipeline, run only the features/proxy_node.feature, which covers build acceptance tests.

Tested locally with:
`./run-staging-tests.sh`