### PR TITLE
EID-1953 build and integration releases to use separate metadata CA certs

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -38,11 +38,3 @@
 {{ printf "%s" (required "connector.entityID or stubConnector.enabled required" .Values.connector.entityID) }}
 {{- end -}}
 {{- end -}}
-
-{{- define "metadata.ca.name" -}}
-{{- if .Values.stubConnector.enabled -}}
-{{ printf "test-proxy-node-metadata-ca-a1" }}
-{{- else -}}
-{{ printf "production-proxy-node-metadata-ca-a1" }}
-{{- end -}}
-{{- end -}}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -38,3 +38,11 @@
 {{ printf "%s" (required "connector.entityID or stubConnector.enabled required" .Values.connector.entityID) }}
 {{- end -}}
 {{- end -}}
+
+{{- define "metadata.ca.name" -}}
+{{- if .Values.stubConnector.enabled -}}
+{{ printf "test-proxy-node-metadata-ca-a1" }}
+{{- else -}}
+{{ printf "production-proxy-node-metadata-ca-a1" }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/metadata-signing-cert.yaml
+++ b/chart/templates/metadata-signing-cert.yaml
@@ -3,7 +3,7 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: {{ .Release.Name }}-proxy-node-metadata-signing-cert-a1
+  name: {{ .Release.Name }}-proxy-node-metadata-signing-a1
   namespace: {{ .Release.Namespace }}
 spec:
   countryCode: GB
@@ -14,5 +14,5 @@ spec:
   location: London
   CACert: false
   certificateAuthority:
-    secretName: proxy-node-metadata-ca-a1
+    secretName: {{ include "metadata.ca.name" . }}
     namespace: {{ .Release.Namespace }}

--- a/chart/templates/metadata-signing-cert.yaml
+++ b/chart/templates/metadata-signing-cert.yaml
@@ -3,7 +3,7 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: {{ .Release.Name }}-proxy-node-metadata-signing-a1
+  name: proxy-node-metadata-signing-{{ .Release.Name }}-a1
   namespace: {{ .Release.Namespace }}
 spec:
   countryCode: GB
@@ -14,5 +14,5 @@ spec:
   location: London
   CACert: false
   certificateAuthority:
-    secretName: {{ include "metadata.ca.name" . }}
+    secretName: proxy-node-metadata-{{ .Release.Name }}-ca-a1
     namespace: {{ .Release.Namespace }}

--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -29,5 +29,5 @@ spec:
     organizationUnit: GDS
     location: London
   certificateAuthority:
-    secretName: {{ .Release.Name }}-proxy-node-metadata-signing-cert-a1
+    secretName: {{ .Release.Name }}-proxy-node-metadata-signing-a1
     namespace: {{ .Release.Namespace }}

--- a/chart/templates/metadata.yaml
+++ b/chart/templates/metadata.yaml
@@ -29,5 +29,5 @@ spec:
     organizationUnit: GDS
     location: London
   certificateAuthority:
-    secretName: {{ .Release.Name }}-proxy-node-metadata-signing-a1
+    secretName: proxy-node-metadata-signing-{{ .Release.Name }}-a1
     namespace: {{ .Release.Namespace }}

--- a/ci/build/test-metadata-certificate-request.yaml
+++ b/ci/build/test-metadata-certificate-request.yaml
@@ -4,7 +4,7 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: proxy-node-metadata-ca-a1
+  name: test-proxy-node-metadata-ca-a1
 spec:
   countryCode: GB
   commonName: Proxy Node Test Metadata CA

--- a/ci/deploy/integration-metadata-certificate-request.yaml
+++ b/ci/deploy/integration-metadata-certificate-request.yaml
@@ -4,11 +4,11 @@ kind: CertificateRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: proxy-node-metadata-test-ca-a1
-  namespace: verify-eidas-proxy-node-build
+  name: proxy-node-metadata-integration-ca-a1
+  namespace: verify-eidas-proxy-node-deploy
 spec:
   countryCode: GB
-  commonName: Proxy Node Test Metadata CA
+  commonName: Proxy Node Integration Metadata CA
   expiryMonths: 120
   organization: Cabinet Office
   organizationUnit: GDS


### PR DESCRIPTION
`test` and `integration` releases should use separate metadata-ca certificates like below:
````
└── verify-root-ca-test-a1
    └── proxy-node-metadata-ca-test-a1
        ├── verify-eidas-proxy-node-metadata-signing-test-a1
    └── proxy-node-metadata-ca-integration-a1
        └── verify-eidas-proxy-node-metadata-signing-integration-a1
````