### PR TITLE
BAU: Exclude smoke tests from the build pipeline tests

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -868,7 +868,7 @@ spec:
             - -euc
             - |
               cd /
-              bundle exec cucumber --strict --tags "not @ignore"
+              bundle exec cucumber --strict --tags "not @ignore" --exclude "smoke/"
 
     - name: release
       serial: true


### PR DESCRIPTION
The smoke tests are run separately and should not be part of deployment

Author: @CharlesIC