### PR TITLE
EID-1894 Include namespace in Proxy Node URLs

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 
 {{- define "gateway.host" -}}
-{{- printf "%s.%s.%s.%s" .Chart.Name "eidas" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s.%s.%s.%s" .Chart.Name .Release.Name .Release.Namespace (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "gateway.entityID" -}}
@@ -9,7 +9,7 @@
 
 {{- define "stubConnector.host" -}}
 {{- if .Values.stubConnector.enabled -}}
-{{- printf "%s.%s.%s" "stub-connector.eidas" .Release.Name (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s.%s.%s" "stub-connector" .Release.Name .Release.Namespace (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.stubConnector.host -}}
 {{- end -}}

--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -857,8 +857,8 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://proxy-node.eidas.test.((cluster.domain))"
-            STUB_CONNECTOR_URL: "https://stub-connector.eidas.test.((cluster.domain))"
+            PROXY_NODE_URL: "https://proxy-node.test.((namespace-deployer.namespace)).((cluster.domain))"
+            STUB_CONNECTOR_URL: "https://stub-connector.test.((namespace-deployer.namespace)).((cluster.domain))"
             STUB_IDP_USER: "stub-idp-demo-one"
             SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
           run:


### PR DESCRIPTION
Our deploy namespace `verify-eidas-proxy-node-deploy` needs to be part of our DNS name, which needs to end with `.<namespace>.`london.verify.govsvc.uk.

We have this constraint now so people who are allowed to administer other specific namespaces can't usurp our production system.

Add `.Release.Namespace` to gateway and connector hostnames to accommodate this.

This will affect the `verify-eidas-proxy-node-build` namespace urls too, expect further changes to docs and egress safelists.

We'll create CNAME records under `signin.service.gov.uk` to these urls.