### PR TITLE
☺️ EID-1894 Missing string placeholder in connector url

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -9,7 +9,7 @@
 
 {{- define "stubConnector.host" -}}
 {{- if .Values.stubConnector.enabled -}}
-{{- printf "%s.%s.%s" "stub-connector" .Release.Name .Release.Namespace (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- printf "%s.%s.%s.%s" "stub-connector" .Release.Name .Release.Namespace (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.stubConnector.host -}}
 {{- end -}}


### PR DESCRIPTION
I missed a placeholder in string substitution