### PR TITLE
EID-1964: Add alternative DNS names for the ingress TLS certs that are short enough for CN

### DIFF
--- a/chart/templates/gateway-ingress-certificate.yaml
+++ b/chart/templates/gateway-ingress-certificate.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-gateway-ingress-certificate
   dnsNames:
+  - pn.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}
   - {{ include "gateway.host" . }}
   issuerRef:
     name: letsencrypt-r53

--- a/chart/templates/stub-connector-ingress-certificate.yaml
+++ b/chart/templates/stub-connector-ingress-certificate.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-connector-ingress-certificate
   dnsNames:
+  - sc.{{ .Release.Namespace }}.{{ .Values.global.cluster.domain }}
   - {{ include "stubConnector.host" . }}
   issuerRef:
     name: letsencrypt-r53


### PR DESCRIPTION
Since we had to add the namespace to the URLs, the default config tried to generate Let's Encrypt certs with the new URLs as the DNS name and by default the CN (Common Name). However, the CN has a limit of 64 chars and the long URLs exceeded that. As as solution, add a DNS name to the list that's short enough to be picked as a CN for the new certs.

This will produce names such as `sc.verify-eidas-proxy-node-deploy.london.verify.govsvc.uk` which are just shy of 60 characters long.