### PR TITLE
EID-1964 ServiceEntry to allow egress from connector to gateway

### DIFF
--- a/chart/templates/stub-connector-gateway-egress-service-entry.yaml
+++ b/chart/templates/stub-connector-gateway-egress-service-entry.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   hosts:
   - {{ include "gateway.host" . }}
+  - {{ include "gateway.host.govuk" . }}
   ports:
   - name: https
     number: 443


### PR DESCRIPTION
stub-connector can't read proxy node metadata :(

Allow egress from stub-connector to the gov.uk Proxy Node gateway domain