### PR TITLE
📊Metrics on country metadata health

### DIFF
--- a/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
+++ b/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
@@ -30,8 +30,10 @@ import java.net.URI;
 import java.security.cert.CertificateEncodingException;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class MetadataResolverService {
@@ -53,6 +55,10 @@ public class MetadataResolverService {
         this.expiredCertificateMetadataFilter = new ExpiredCertificateMetadataFilter();
         this.countryConfigMap = countriesConfig.getCountries().stream()
                 .collect(Collectors.toMap(EidasCountryConfig::getEntityId, this::createMetadataResolver));
+    }
+
+    public Set<URI> getResolvers() {
+        return Collections.unmodifiableSet(countryConfigMap.keySet());
     }
 
     public CountryMetadataResponse getCountryMetadataResponse(URI entityId) {

--- a/metatron/src/main/java/uk/gov/ida/eidas/metatron/health/CountryMetadataHealthMetrics.java
+++ b/metatron/src/main/java/uk/gov/ida/eidas/metatron/health/CountryMetadataHealthMetrics.java
@@ -1,0 +1,31 @@
+package uk.gov.ida.eidas.metatron.health;
+
+import io.prometheus.client.Gauge;
+import uk.gov.ida.eidas.metatron.domain.MetadataResolverService;
+
+public class CountryMetadataHealthMetrics implements Runnable {
+
+    private static final io.prometheus.client.Gauge METADATA_FETCH_GAUGE = Gauge
+            .build("country_metadata_health_metrics",
+                    "Country Metadata Health Metrics")
+            .labelNames("entity")
+            .register();
+
+    private final MetadataResolverService resolverService;
+
+    public CountryMetadataHealthMetrics(MetadataResolverService resolverService) {
+        this.resolverService = resolverService;
+    }
+
+    @Override
+    public void run() {
+        resolverService.getResolvers().stream().forEach(entityId -> {
+            try {
+                resolverService.getCountryMetadataResponse(entityId);
+                METADATA_FETCH_GAUGE.labels(entityId.toString()).set(1);
+            } catch (Exception e) {
+                METADATA_FETCH_GAUGE.labels(entityId.toString()).set(0);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Create a scheduled task in `metatron` that retrieves cached country metadata.
Report 1 or 0 to a Prometheus Gauge depending on presence of metadata.

Connector Node metadata is stored per country in a stateful MetadataResolver object, which retrieves metadata at intervals, and caches the result.
If the TTL of the cached metadata has expired, and there is no metadata for a country, a 0 will be sent to the Gauge, otherwise 1.

The scheduler runs the check every 5 minutes.

We can create Grafana dashes/alerts based on these metrics.