### PR TITLE
EID-1890 Capture request/response metrics per country

### DIFF
--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/EidasAuthnRequestResource.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.notification.resources;
 
+import com.codahale.metrics.annotation.ResponseMetered;
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
 import io.prometheus.client.Counter;
@@ -65,6 +66,7 @@ public class EidasAuthnRequestResource {
 
     @GET
     @Path(Urls.GatewayUrls.GATEWAY_EIDAS_AUTHN_REQUEST_REDIRECT_PATH)
+    @ResponseMetered
     public View handleRedirectBinding(
             @QueryParam(SamlFormMessageType.SAML_REQUEST) @ValidBase64Xml String encodedEidasAuthnRequest,
             @QueryParam("RelayState") String relayState,
@@ -75,6 +77,7 @@ public class EidasAuthnRequestResource {
     @POST
     @Path(Urls.GatewayUrls.GATEWAY_EIDAS_AUTHN_REQUEST_POST_PATH)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @ResponseMetered
     public View handlePostBinding(
             @FormParam(SamlFormMessageType.SAML_REQUEST) @ValidBase64Xml String encodedEidasAuthnRequest,
             @FormParam(RelayState.DEFAULT_ELEMENT_LOCAL_NAME) String eidasRelayState,

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.notification.resources;
 
+import com.codahale.metrics.annotation.ResponseMetered;
 import io.dropwizard.jersey.sessions.Session;
 import io.dropwizard.views.View;
 import io.prometheus.client.Counter;
@@ -57,6 +58,7 @@ public class HubResponseResource {
     @POST
     @Path(Urls.GatewayUrls.GATEWAY_HUB_RESPONSE_PATH)
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @ResponseMetered
     public View hubResponse(
         @FormParam(SamlFormMessageType.SAML_RESPONSE) @ValidBase64Xml String hubResponse,
         @FormParam("RelayState") String relayState,


### PR DESCRIPTION
In a multi-country Proxy Node, label our metrics by the country entity id, to indicate which countries our Proxy Node traffic is coming from.

Also capture response codes to our gateway urls using `@ResponseMetered`, to help with service level measurements of the Proxy Node.