### PR TITLE
BAU: Build VSP image locally for local startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,10 @@ services:
       - ./local-startup/pki/verify-dev-pki:/app/verify-dev-pki
 
   verify-service-provider:
-    image: registry.london.verify.govsvc.uk/eidas/verify-service-provider:latest
+    image: eidas/verify-service-provider
+    build:
+      context: ../verify-service-provider
+      dockerfile: ../verify-proxy-node/proxy-node-vsp-config/Dockerfile
     environment:
       JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:50402"
     entrypoint: ["bin/verify-service-provider"]
@@ -92,7 +95,7 @@ services:
       - "50402:50402"
 
   verify-service-provider-local-hub:
-    image: eidas/verify-service-provider
+    image: eidas/verify-service-provider-local-hub
     build:
       context: local-startup/vsp
     env_file: ./local-startup/docker.env

--- a/local-startup/vsp/Dockerfile
+++ b/local-startup/vsp/Dockerfile
@@ -1,6 +1,6 @@
 # Custom VSP image using Amazon JDK
 
-FROM registry.london.verify.govsvc.uk/eidas/verify-service-provider
+FROM eidas/verify-service-provider
 WORKDIR /verify-service-provider
 
 # Replace config file with the local version

--- a/startup-docker.sh
+++ b/startup-docker.sh
@@ -9,8 +9,14 @@ export VERIFY_USE_PUBLIC_BINARIES=${VERIFY_USE_PUBLIC_BINARIES:-false}
 if [[ "$*" =~ "--build" ]]; then BUILD_IMAGES=true; export USE_LOCAL_BUILD=true; else BUILD_IMAGES=false; fi
 if [[ "$*" =~ "--local-hub" ]]; then VSP=verify-service-provider-local-hub; else VSP=verify-service-provider; fi
 
+if ! [[ -d "../verify-service-provider" ]]; then
+  echo "The VSP repository needs to be cloned into $(cd .. && pwd)/verify-service-provider" && exit 1
+fi
+
 if ${BUILD_IMAGES}; then
-  echo "Building apps..." && ./gradlew --parallel installDist
+  echo "Building apps..." &&
+      ./gradlew --parallel installDist &&
+      pushd ../verify-service-provider; ./gradlew --parallel installDist; popd
   echo "Building images..." && docker-compose build --parallel
 fi
 


### PR DESCRIPTION
We no longer have access to the VSP image built in the pipeline. This change uses the local VSP repo to build the required image.