### PR TITLE
EID-1911: NameID format compliance issue

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -4,6 +4,7 @@ import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.UsageType;
@@ -69,10 +70,12 @@ public class EidasSamlResource {
                                 .orElseThrow();
 
         this.logAuthnRequestMdcProperties(authnRequest);
+        boolean transientPid = NameID.TRANSIENT.equals(authnRequest.getNameIDPolicy().getFormat());
         return new EidasSamlParserResponse(
                 authnRequest.getID(),
                 authnRequest.getIssuer().getValue(),
-                assertionConsumerServiceURL);
+                assertionConsumerServiceURL,
+                transientPid);
     }
 
     private AuthnRequest unmarshallRequest(EidasSamlParserRequest request) throws UnmarshallingException, XMLParserException {

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -5,6 +5,7 @@ import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.NameID;
+import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.UsageType;
@@ -70,12 +71,15 @@ public class EidasSamlResource {
                                 .orElseThrow();
 
         this.logAuthnRequestMdcProperties(authnRequest);
-        boolean transientPid = NameID.TRANSIENT.equals(authnRequest.getNameIDPolicy().getFormat());
         return new EidasSamlParserResponse(
                 authnRequest.getID(),
                 authnRequest.getIssuer().getValue(),
                 assertionConsumerServiceURL,
-                transientPid);
+                assignTransientPid(authnRequest));
+    }
+
+    private boolean assignTransientPid(AuthnRequest authnRequest) {
+        return authnRequest.getNameIDPolicy() != null && NameID.TRANSIENT.equals(authnRequest.getNameIDPolicy().getFormat()) ? true : false;
     }
 
     private AuthnRequest unmarshallRequest(EidasSamlParserRequest request) throws UnmarshallingException, XMLParserException {

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlResource.java
@@ -5,7 +5,6 @@ import org.opensaml.core.xml.io.UnmarshallingException;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.NameID;
-import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.UsageType;
@@ -75,11 +74,11 @@ public class EidasSamlResource {
                 authnRequest.getID(),
                 authnRequest.getIssuer().getValue(),
                 assertionConsumerServiceURL,
-                assignTransientPid(authnRequest));
+                wantTransientPid(authnRequest));
     }
 
-    private boolean assignTransientPid(AuthnRequest authnRequest) {
-        return authnRequest.getNameIDPolicy() != null && NameID.TRANSIENT.equals(authnRequest.getNameIDPolicy().getFormat()) ? true : false;
+    private boolean wantTransientPid(AuthnRequest authnRequest) {
+        return authnRequest.getNameIDPolicy() != null && NameID.TRANSIENT.equals(authnRequest.getNameIDPolicy().getFormat());
     }
 
     private AuthnRequest unmarshallRequest(EidasSamlParserRequest request) throws UnmarshallingException, XMLParserException {

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -96,7 +96,7 @@ public class EidasSamlResourceTest {
 
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
-        assertThat(response.isTransientPid()).isEqualTo(false);
+        assertThat(response.isTransientPidRequested()).isEqualTo(false);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class EidasSamlResourceTest {
 
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
-        assertThat(response.isTransientPid()).isEqualTo(false);
+        assertThat(response.isTransientPidRequested()).isEqualTo(false);
     }
 
     @Test
@@ -128,7 +128,7 @@ public class EidasSamlResourceTest {
 
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
-        assertThat(response.isTransientPid()).isEqualTo(true);
+        assertThat(response.isTransientPidRequested()).isEqualTo(true);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class EidasSamlResourceTest {
 
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
-        assertThat(response.isTransientPid()).isEqualTo(false);
+        assertThat(response.isTransientPidRequested()).isEqualTo(false);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class EidasSamlResourceTest {
 
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
-        assertThat(response.isTransientPid()).isEqualTo(false);
+        assertThat(response.isTransientPidRequested()).isEqualTo(false);
     }
 
     @Test

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/EidasSamlResourceTest.java
@@ -84,10 +84,26 @@ public class EidasSamlResourceTest {
     }
 
     @Test
-    public void shouldReturnFalseWhenNameIdIsNotTransient() throws Exception {
+    public void shouldReturnFalseWhenNameIdIsPersistent() throws Exception {
         final AuthnRequest eidasAuthnRequest = createEidasAuthnRequestBuilder().build();
         NameIDPolicy nameIDPolicy = SamlBuilder.build(NameIDPolicy.DEFAULT_ELEMENT_NAME);
         nameIDPolicy.setFormat(NameID.PERSISTENT);
+        eidasAuthnRequest.setNameIDPolicy(nameIDPolicy);
+
+        final CountryMetadataResponse countryMetadataResponse = createCountryMetadataResponse(eidasAuthnRequest, new AssertionConsumerService(UriBuilder.fromPath(TEST_CONNECTOR_DESTINATION).build(), 0, true));
+
+        when(mockMetatronProxy.getCountryMetadata(eidasAuthnRequest.getIssuer().getValue())).thenReturn(countryMetadataResponse);
+
+        final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
+
+        assertThat(response.isTransientPid()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNameIdIsUnspecified() throws Exception {
+        final AuthnRequest eidasAuthnRequest = createEidasAuthnRequestBuilder().build();
+        NameIDPolicy nameIDPolicy = SamlBuilder.build(NameIDPolicy.DEFAULT_ELEMENT_NAME);
+        nameIDPolicy.setFormat(NameID.UNSPECIFIED);
         eidasAuthnRequest.setNameIDPolicy(nameIDPolicy);
 
         final CountryMetadataResponse countryMetadataResponse = createCountryMetadataResponse(eidasAuthnRequest, new AssertionConsumerService(UriBuilder.fromPath(TEST_CONNECTOR_DESTINATION).build(), 0, true));
@@ -113,6 +129,36 @@ public class EidasSamlResourceTest {
         final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
 
         assertThat(response.isTransientPid()).isEqualTo(true);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNameIdIsNull() throws Exception {
+        final AuthnRequest eidasAuthnRequest = createEidasAuthnRequestBuilder().build();
+        NameIDPolicy nameIDPolicy = SamlBuilder.build(NameIDPolicy.DEFAULT_ELEMENT_NAME);
+        nameIDPolicy.setFormat(null);
+        eidasAuthnRequest.setNameIDPolicy(nameIDPolicy);
+
+        final CountryMetadataResponse countryMetadataResponse = createCountryMetadataResponse(eidasAuthnRequest, new AssertionConsumerService(UriBuilder.fromPath(TEST_CONNECTOR_DESTINATION).build(), 0, true));
+
+        when(mockMetatronProxy.getCountryMetadata(eidasAuthnRequest.getIssuer().getValue())).thenReturn(countryMetadataResponse);
+
+        final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
+
+        assertThat(response.isTransientPid()).isEqualTo(false);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenNameIdPolicyIsNull() throws Exception {
+        final AuthnRequest eidasAuthnRequest = createEidasAuthnRequestBuilder().build();
+        eidasAuthnRequest.setNameIDPolicy(null);
+
+        final CountryMetadataResponse countryMetadataResponse = createCountryMetadataResponse(eidasAuthnRequest, new AssertionConsumerService(UriBuilder.fromPath(TEST_CONNECTOR_DESTINATION).build(), 0, true));
+
+        when(mockMetatronProxy.getCountryMetadata(eidasAuthnRequest.getIssuer().getValue())).thenReturn(countryMetadataResponse);
+
+        final EidasSamlParserResponse response = postEidasAuthnRequest(eidasAuthnRequest);
+
+        assertThat(response.isTransientPid()).isEqualTo(false);
     }
 
     @Test

--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -12,6 +12,13 @@ Feature: proxy-node feature
         And they login to stub idp
         Then they should arrive at the success page
 
+    Scenario: Proxy node happy path - TransientPid requested
+        Given the proxy node is sent a transientPid request
+        And they progress through verify
+        And they login to stub idp
+        Then they should arrive at the success page
+        And they should have a transient id
+
     Scenario: Proxy node happy path - LOA High
         Given the proxy node is sent a LOA 'High' request from the stub connector
         Then the user should be presented with an error page

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -16,6 +16,10 @@ Given("the proxy node is sent a LOA {string} request from the stub connector") d
   visit(ENV.fetch('STUB_CONNECTOR_URL') + loa_url)
 end
 
+Given("the proxy node is sent a transientPid request") do
+  visit(ENV.fetch('STUB_CONNECTOR_URL') + "/RequestTransientPid")
+end
+
 And('they progress through verify') do
   assert_text('Sign in with GOV.UK Verify')
   choose('start_form_selection_false', allow_label_click: true)
@@ -76,6 +80,10 @@ Then('they should arrive at the success page') do
   assert_text('Jack Cornelius')
   assert_text('Bauer')
   assert_text('1984-02-29')
+end
+
+And('they should have a transient id') do
+  assert_text('GB/EU/_tr_')
 end
 
 Then("the user should be presented with a Hub error page indicating IDP could not sign you in") do

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -76,7 +76,7 @@ public class HubResponseResource {
             LEVEL_OF_ASSURANCE,
             UriBuilder.fromUri(sessionData.getEidasDestination()).build(),
             UriBuilder.fromUri(issuerEntityId).build(),
-            sessionData.isEidasTransientPid()
+            sessionData.isTransientPidRequested()
         );
 
         String eidasResponse = translatorProxy.getTranslatedHubResponse(translatorRequest, session.getId());

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/resources/HubResponseResource.java
@@ -75,7 +75,8 @@ public class HubResponseResource {
             sessionData.getEidasRequestId(),
             LEVEL_OF_ASSURANCE,
             UriBuilder.fromUri(sessionData.getEidasDestination()).build(),
-            UriBuilder.fromUri(issuerEntityId).build()
+            UriBuilder.fromUri(issuerEntityId).build(),
+            sessionData.isEidasTransientPid()
         );
 
         String eidasResponse = translatorProxy.getTranslatedHubResponse(translatorRequest, session.getId());

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
@@ -40,18 +40,23 @@ public class GatewaySessionData {
     @JsonProperty
     private final String eidasIssuerEntityId;
 
+    @JsonProperty
+    private final boolean eidasTransientPid;
+
     @JsonCreator
     public GatewaySessionData(
             @JsonProperty("HUB_REQUEST_ID") String hubRequestId,
             @JsonProperty("EIDAS_REQUEST_ID") String eidasRequestId,
             @JsonProperty("EIDAS_DESTINATION") String eidasDestination,
             @JsonProperty("eidasRelayState") String eidasRelayState,
-            @JsonProperty("eidasIssuerEntityId") String eidasIssuerEntityId) {
+            @JsonProperty("eidasIssuerEntityId") String eidasIssuerEntityId,
+            @JsonProperty("eidasTransientPid") boolean eidasTransientPid) {
         this.hubRequestId = hubRequestId;
         this.eidasRequestId = eidasRequestId;
         this.eidasDestination = eidasDestination;
         this.eidasRelayState = eidasRelayState;
         this.eidasIssuerEntityId = eidasIssuerEntityId;
+        this.eidasTransientPid = eidasTransientPid;
     }
 
     public GatewaySessionData(
@@ -63,6 +68,7 @@ public class GatewaySessionData {
         this.eidasDestination = eidasSamlParserResponse.getAssertionConsumerServiceLocation();
         this.eidasRelayState = eidasRelayState;
         this.eidasIssuerEntityId = eidasSamlParserResponse.getIssuerEntityId();
+        this.eidasTransientPid = eidasSamlParserResponse.isTransientPid();
         validate();
     }
 
@@ -103,5 +109,9 @@ public class GatewaySessionData {
 
     public String getEidasIssuerEntityId() {
         return eidasIssuerEntityId;
+    }
+
+    public boolean isEidasTransientPid() {
+        return this.eidasTransientPid;
     }
 }

--- a/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
+++ b/proxy-node-gateway/src/main/java/uk/gov/ida/notification/session/GatewaySessionData.java
@@ -41,7 +41,7 @@ public class GatewaySessionData {
     private final String eidasIssuerEntityId;
 
     @JsonProperty
-    private final boolean eidasTransientPid;
+    private final boolean transientPidRequested;
 
     @JsonCreator
     public GatewaySessionData(
@@ -50,13 +50,13 @@ public class GatewaySessionData {
             @JsonProperty("EIDAS_DESTINATION") String eidasDestination,
             @JsonProperty("eidasRelayState") String eidasRelayState,
             @JsonProperty("eidasIssuerEntityId") String eidasIssuerEntityId,
-            @JsonProperty("eidasTransientPid") boolean eidasTransientPid) {
+            @JsonProperty("transientPidRequested") boolean transientPidRequested) {
         this.hubRequestId = hubRequestId;
         this.eidasRequestId = eidasRequestId;
         this.eidasDestination = eidasDestination;
         this.eidasRelayState = eidasRelayState;
         this.eidasIssuerEntityId = eidasIssuerEntityId;
-        this.eidasTransientPid = eidasTransientPid;
+        this.transientPidRequested = transientPidRequested;
     }
 
     public GatewaySessionData(
@@ -68,7 +68,7 @@ public class GatewaySessionData {
         this.eidasDestination = eidasSamlParserResponse.getAssertionConsumerServiceLocation();
         this.eidasRelayState = eidasRelayState;
         this.eidasIssuerEntityId = eidasSamlParserResponse.getIssuerEntityId();
-        this.eidasTransientPid = eidasSamlParserResponse.isTransientPid();
+        this.transientPidRequested = eidasSamlParserResponse.isTransientPidRequested();
         validate();
     }
 
@@ -111,7 +111,7 @@ public class GatewaySessionData {
         return eidasIssuerEntityId;
     }
 
-    public boolean isEidasTransientPid() {
-        return this.eidasTransientPid;
+    public boolean isTransientPidRequested() {
+        return this.transientPidRequested;
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/SamlResponseExceptionMapperResourceRuleTest.java
@@ -43,7 +43,8 @@ public class SamlResponseExceptionMapperResourceRuleTest {
                         "EidasRequestId",
                         "EidasDestination",
                         "EidasRelayState",
-                        "EidasIssuer"
+                        "EidasIssuer",
+                        false
                 )
         );
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/rules/TestEidasSamlResource.java
@@ -24,7 +24,8 @@ public class TestEidasSamlResource {
         return new EidasSamlParserResponse(
                 SAMPLE_EIDAS_REQUEST_ID,
                 SAMPLE_ENTITY_ID,
-                SAMPLE_DESTINATION_URL
+                SAMPLE_DESTINATION_URL,
+                false
         );
     }
 }

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/EidasSamlParserProxyTest.java
@@ -46,7 +46,7 @@ public class EidasSamlParserProxyTest {
         @Valid
         @Path("/valid")
         public EidasSamlParserResponse testValidParse(EidasSamlParserRequest eidasSamlParserRequest) {
-            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL);
+            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL, false);
         }
 
         @POST
@@ -69,7 +69,7 @@ public class EidasSamlParserProxyTest {
         @Path("/test-journey-id-header")
         public EidasSamlParserResponse testJourneyIdHeader(EidasSamlParserRequest eidasSamlParserRequest, @Context HttpHeaders headers) {
             TestESPResource.headers = headers.getRequestHeaders();
-            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL);
+            return new EidasSamlParserResponse(SAMPLE_REQUEST_ID, SAMPLE_ENTITY_ID, SAMPLE_DESTINATION_URL, false);
         }
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/proxy/TranslatorProxyTest.java
@@ -82,7 +82,8 @@ public class TranslatorProxyTest {
                 "eidas_request_id",
                 "level_of_assurance",
                 UriBuilder.fromUri("http://connector.node").build(),
-                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build()
+                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build(),
+                false
         );
 
         final TranslatorProxy translatorProxy = new TranslatorProxy(
@@ -109,7 +110,8 @@ public class TranslatorProxyTest {
                 "eidas_request_id",
                 "level_of_assurance",
                 UriBuilder.fromUri("http://connector.node").build(),
-                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build()
+                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build(),
+                false
         );
 
         final TranslatorProxy translatorProxy = new TranslatorProxy(
@@ -135,7 +137,8 @@ public class TranslatorProxyTest {
                 "eidas_request_id",
                 "level_of_assurance",
                 UriBuilder.fromUri("http://connector.node").build(),
-                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build()
+                UriBuilder.fromUri("http://connector.node/ConnectorMetadata").build(),
+                false
         );
 
         final TranslatorProxy translatorProxy = new TranslatorProxy(

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -70,7 +70,8 @@ public class HubResponseResourceTest {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
             "eidas_request_id_in_session",
             "http://entityId",
-            "http://connector.node"
+            "http://connector.node",
+            false
         );
 
         AuthnRequestResponse vspResponse = new AuthnRequestResponse(

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestGatewaySessionDataValidator.java
@@ -20,7 +20,8 @@ public class TestGatewaySessionDataValidator {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
                 "hub-request-id",
                 "issuer",
-                "eidas-destination"
+                "eidas-destination",
+                false
         );
 
         new GatewaySessionData(
@@ -35,7 +36,8 @@ public class TestGatewaySessionDataValidator {
         EidasSamlParserResponse eidasSamlParserResponse = new EidasSamlParserResponse(
                 null,
                 "issuer",
-                ""
+                "",
+                false
         );
 
         new GatewaySessionData(

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestRedisSessions.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/session/TestRedisSessions.java
@@ -85,6 +85,7 @@ public class TestRedisSessions {
                 "anEidasRequestId",
                 "anEidasDestination",
                 "anEidasRelayState",
-                "eidasIssuer");
+                "eidasIssuer",
+                false);
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
@@ -21,14 +21,18 @@ public class EidasSamlParserResponse {
     @ValidDestinationUriString
     private String assertionConsumerServiceLocation;
 
+    @JsonProperty
+    private boolean transientPid;
+
     @SuppressWarnings("Needed for serialisaiton")
     public EidasSamlParserResponse() {
     }
 
-    public EidasSamlParserResponse(String requestId, String issuerEntityId, String assertionConsumerServiceLocation) {
+    public EidasSamlParserResponse(String requestId, String issuerEntityId, String assertionConsumerServiceLocation, boolean transientPid) {
         this.requestId = requestId;
         this.issuerEntityId = issuerEntityId;
         this.assertionConsumerServiceLocation = assertionConsumerServiceLocation;
+        this.transientPid = transientPid;
     }
 
     public String getRequestId() {
@@ -41,5 +45,9 @@ public class EidasSamlParserResponse {
 
     public String getAssertionConsumerServiceLocation() {
         return assertionConsumerServiceLocation;
+    }
+
+    public boolean isTransientPid() {
+        return transientPid;
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/EidasSamlParserResponse.java
@@ -22,17 +22,17 @@ public class EidasSamlParserResponse {
     private String assertionConsumerServiceLocation;
 
     @JsonProperty
-    private boolean transientPid;
+    private boolean transientPidRequested;
 
     @SuppressWarnings("Needed for serialisaiton")
     public EidasSamlParserResponse() {
     }
 
-    public EidasSamlParserResponse(String requestId, String issuerEntityId, String assertionConsumerServiceLocation, boolean transientPid) {
+    public EidasSamlParserResponse(String requestId, String issuerEntityId, String assertionConsumerServiceLocation, boolean transientPidRequested) {
         this.requestId = requestId;
         this.issuerEntityId = issuerEntityId;
         this.assertionConsumerServiceLocation = assertionConsumerServiceLocation;
-        this.transientPid = transientPid;
+        this.transientPidRequested = transientPidRequested;
     }
 
     public String getRequestId() {
@@ -47,7 +47,7 @@ public class EidasSamlParserResponse {
         return assertionConsumerServiceLocation;
     }
 
-    public boolean isTransientPid() {
-        return transientPid;
+    public boolean isTransientPidRequested() {
+        return transientPidRequested;
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
@@ -41,6 +41,9 @@ public class HubResponseTranslatorRequest {
     @JsonProperty
     private URI eidasIssuerEntityId;
 
+    @JsonProperty
+    private boolean eidasTransientPid;
+
     @SuppressWarnings("Needed for JSON serialisation")
     public HubResponseTranslatorRequest() {
     }
@@ -51,13 +54,15 @@ public class HubResponseTranslatorRequest {
             String eidasRequestId,
             String levelOfAssurance,
             URI destinationUrl,
-            URI eidasIssuerEntityId) {
+            URI eidasIssuerEntityId,
+            boolean eidasTransientPid) {
         this.samlResponse = samlResponse;
         this.requestId = requestId;
         this.eidasRequestId = eidasRequestId;
         this.levelOfAssurance = levelOfAssurance;
         this.destinationUrl = destinationUrl;
         this.eidasIssuerEntityId = eidasIssuerEntityId;
+        this.eidasTransientPid = eidasTransientPid;
     }
 
     public String getSamlResponse() {
@@ -82,5 +87,9 @@ public class HubResponseTranslatorRequest {
 
     public URI getDestinationUrl() {
         return destinationUrl;
+    }
+
+    public boolean isEidasTransientPid() {
+        return eidasTransientPid;
     }
 }

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
@@ -42,7 +42,7 @@ public class HubResponseTranslatorRequest {
     private URI eidasIssuerEntityId;
 
     @JsonProperty
-    private boolean eidasTransientPid;
+    private boolean transientPidRequested;
 
     @SuppressWarnings("Needed for JSON serialisation")
     public HubResponseTranslatorRequest() {
@@ -55,14 +55,14 @@ public class HubResponseTranslatorRequest {
             String levelOfAssurance,
             URI destinationUrl,
             URI eidasIssuerEntityId,
-            boolean eidasTransientPid) {
+            boolean transientPidRequested) {
         this.samlResponse = samlResponse;
         this.requestId = requestId;
         this.eidasRequestId = eidasRequestId;
         this.levelOfAssurance = levelOfAssurance;
         this.destinationUrl = destinationUrl;
         this.eidasIssuerEntityId = eidasIssuerEntityId;
-        this.eidasTransientPid = eidasTransientPid;
+        this.transientPidRequested = transientPidRequested;
     }
 
     public String getSamlResponse() {
@@ -89,7 +89,7 @@ public class HubResponseTranslatorRequest {
         return destinationUrl;
     }
 
-    public boolean isEidasTransientPid() {
-        return eidasTransientPid;
+    public boolean isTransientPidRequested() {
+        return transientPidRequested;
     }
 }

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
@@ -49,6 +49,14 @@ public class TranslatedHubResponseTestAssertions {
         assertThat(getAttributeValue(PidAttribute)).isEqualTo("GB/CC/123456");
     }
 
+    public static void checkPidTransient(Response decryptedEidasResponse) {
+        Assertion eidasAssertion = decryptedEidasResponse.getAssertions().get(0);
+        List<Attribute> attributes = eidasAssertion.getAttributeStatements().get(0).getAttributes();
+
+        final Attribute PidAttribute = attributes.get(3);
+        assertThat(getAttributeValue(PidAttribute)).startsWith("GB/CC/_tr");
+    }
+
     public static void checkAssertionStatementsValid(Response decryptedEidasResponse) {
         Assertion eidasAssertion = decryptedEidasResponse.getAssertions().get(0);
 

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -9,9 +9,6 @@ import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
-import javax.ws.rs.client.Client;
-
-import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
@@ -39,6 +36,8 @@ import uk.gov.ida.notification.translator.resources.HubResponseTranslatorResourc
 import uk.gov.ida.notification.translator.saml.EidasFailureResponseGenerator;
 import uk.gov.ida.notification.translator.saml.EidasResponseGenerator;
 import uk.gov.ida.notification.translator.saml.HubResponseTranslator;
+
+import javax.ws.rs.client.Client;
 
 public class TranslatorApplication extends Application<TranslatorConfiguration> {
     public static void main(String[] args) throws Exception {
@@ -116,7 +115,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     private void registerResources(TranslatorConfiguration configuration, Environment environment) {
         final EidasResponseGenerator eidasResponseGenerator = createEidasResponseGenerator(configuration, environment);
         final VerifyServiceProviderProxy vspProxy = configuration.getVspConfiguration().buildVerifyServiceProviderProxy(environment);
-        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy, new SecureRandomIdentifierGenerationStrategy());
+        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy);
 
         environment.jersey().register(hubResponseTranslatorResource);
     }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -10,6 +10,8 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 import javax.ws.rs.client.Client;
+
+import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
@@ -114,7 +116,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
     private void registerResources(TranslatorConfiguration configuration, Environment environment) {
         final EidasResponseGenerator eidasResponseGenerator = createEidasResponseGenerator(configuration, environment);
         final VerifyServiceProviderProxy vspProxy = configuration.getVspConfiguration().buildVerifyServiceProviderProxy(environment);
-        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy);
+        final HubResponseTranslatorResource hubResponseTranslatorResource = new HubResponseTranslatorResource(eidasResponseGenerator, vspProxy, new SecureRandomIdentifierGenerationStrategy());
 
         environment.jersey().register(hubResponseTranslatorResource);
     }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.notification.translator.resources;
 
-import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrategy;
 import org.glassfish.jersey.internal.util.Base64;
 import uk.gov.ida.eidas.logging.EidasAuthnResponseAttributesHashLogger;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
@@ -33,14 +32,11 @@ public class HubResponseTranslatorResource {
     private static final SamlObjectMarshaller MARSHALLER = new SamlObjectMarshaller();
     private final EidasResponseGenerator eidasResponseGenerator;
     private final VerifyServiceProviderProxy verifyServiceProviderProxy;
-    private final IdentifierGenerationStrategy identifierGenerator;
 
     public HubResponseTranslatorResource(EidasResponseGenerator eidasResponseGenerator,
-                                         VerifyServiceProviderProxy verifyServiceProviderProxy,
-                                         IdentifierGenerationStrategy identifierGenerator) {
+                                         VerifyServiceProviderProxy verifyServiceProviderProxy) {
         this.eidasResponseGenerator = eidasResponseGenerator;
         this.verifyServiceProviderProxy = verifyServiceProviderProxy;
-        this.identifierGenerator = identifierGenerator;
     }
 
     @POST
@@ -55,7 +51,7 @@ public class HubResponseTranslatorResource {
                 hubResponseTranslatorRequest.getRequestId(),
                 hubResponseTranslatorRequest.getDestinationUrl());
 
-        HubResponseContainer hubResponseContainer = new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse, identifierGenerator);
+        HubResponseContainer hubResponseContainer = new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse);
         final org.opensaml.saml.saml2.core.Response eidasResponse = eidasResponseGenerator.generateFromHubResponse(hubResponseContainer);
 
         logSamlResponse(eidasResponse);

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/resources/HubResponseTranslatorResource.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.notification.translator.resources;
 
+import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrategy;
 import org.glassfish.jersey.internal.util.Base64;
 import uk.gov.ida.eidas.logging.EidasAuthnResponseAttributesHashLogger;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
@@ -32,11 +33,14 @@ public class HubResponseTranslatorResource {
     private static final SamlObjectMarshaller MARSHALLER = new SamlObjectMarshaller();
     private final EidasResponseGenerator eidasResponseGenerator;
     private final VerifyServiceProviderProxy verifyServiceProviderProxy;
+    private final IdentifierGenerationStrategy identifierGenerator;
 
     public HubResponseTranslatorResource(EidasResponseGenerator eidasResponseGenerator,
-                                         VerifyServiceProviderProxy verifyServiceProviderProxy) {
+                                         VerifyServiceProviderProxy verifyServiceProviderProxy,
+                                         IdentifierGenerationStrategy identifierGenerator) {
         this.eidasResponseGenerator = eidasResponseGenerator;
         this.verifyServiceProviderProxy = verifyServiceProviderProxy;
+        this.identifierGenerator = identifierGenerator;
     }
 
     @POST
@@ -51,7 +55,7 @@ public class HubResponseTranslatorResource {
                 hubResponseTranslatorRequest.getRequestId(),
                 hubResponseTranslatorRequest.getDestinationUrl());
 
-        HubResponseContainer hubResponseContainer = new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse);
+        HubResponseContainer hubResponseContainer = new HubResponseContainer(hubResponseTranslatorRequest, translatedHubResponse, identifierGenerator);
         final org.opensaml.saml.saml2.core.Response eidasResponse = eidasResponseGenerator.generateFromHubResponse(hubResponseContainer);
 
         logSamlResponse(eidasResponse);

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
@@ -1,6 +1,5 @@
 package uk.gov.ida.notification.translator.saml;
 
-import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrategy;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
@@ -12,43 +11,31 @@ import java.util.Optional;
 
 public class HubResponseContainer {
 
-    private final Optional<String> pid;
+    private final String pid;
     private final String eidasRequestId;
     private final URI destinationURL;
     private final URI issuer;
     private final Attributes attributes;
     private final VspScenario vspScenario;
     private final VspLevelOfAssurance levelOfAssurance;
-    private final boolean eidasTransientPid;
+    private final boolean transientPidRequested;
 
 
     public HubResponseContainer(
             final HubResponseTranslatorRequest hubResponseTranslatorRequest,
-            final TranslatedHubResponse translatedHubResponse,
-            final IdentifierGenerationStrategy identifierGenerator) {
-        this.pid = generatePidForNameID(hubResponseTranslatorRequest, translatedHubResponse, identifierGenerator);
+            final TranslatedHubResponse translatedHubResponse) {
+        this.pid = translatedHubResponse.getPid().orElse(null);
         this.eidasRequestId = hubResponseTranslatorRequest.getEidasRequestId();
         this.destinationURL = hubResponseTranslatorRequest.getDestinationUrl();
         this.issuer = hubResponseTranslatorRequest.getEidasIssuerEntityId();
-        this.eidasTransientPid = hubResponseTranslatorRequest.isEidasTransientPid();
-
+        this.transientPidRequested = hubResponseTranslatorRequest.isTransientPidRequested();
         this.attributes = translatedHubResponse.getAttributes().orElse(null);
         this.vspScenario = translatedHubResponse.getScenario();
         this.levelOfAssurance = translatedHubResponse.getLevelOfAssurance().orElse(null);
     }
 
-    private Optional<String> generatePidForNameID(
-            HubResponseTranslatorRequest hubResponseTranslatorRequest,
-            TranslatedHubResponse translatedHubResponse,
-            IdentifierGenerationStrategy identifierGenerator) {
-        if (hubResponseTranslatorRequest.isEidasTransientPid()) {
-            return Optional.of(identifierGenerator.generateIdentifier());
-        }
-        return translatedHubResponse.getPid();
-    }
-
     Optional<String> getPid() {
-        return pid;
+        return Optional.ofNullable(pid);
     }
 
     String getEidasRequestId() {
@@ -63,8 +50,8 @@ public class HubResponseContainer {
         return issuer;
     }
 
-    public boolean isEidasTransientPid() {
-        return eidasTransientPid;
+    public boolean isTransientPidRequested() {
+        return transientPidRequested;
     }
 
     Optional<Attributes> getAttributes() {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
@@ -1,5 +1,6 @@
 package uk.gov.ida.notification.translator.saml;
 
+import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrategy;
 import uk.gov.ida.notification.contracts.HubResponseTranslatorRequest;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.Attributes;
 import uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponse;
@@ -11,28 +12,43 @@ import java.util.Optional;
 
 public class HubResponseContainer {
 
-    private final String pid;
+    private final Optional<String> pid;
     private final String eidasRequestId;
     private final URI destinationURL;
     private final URI issuer;
     private final Attributes attributes;
     private final VspScenario vspScenario;
     private final VspLevelOfAssurance levelOfAssurance;
+    private final boolean eidasTransientPid;
+
 
     public HubResponseContainer(
             final HubResponseTranslatorRequest hubResponseTranslatorRequest,
-            final TranslatedHubResponse translatedHubResponse) {
-        this.pid = translatedHubResponse.getPid().orElse(null);
+            final TranslatedHubResponse translatedHubResponse,
+            final IdentifierGenerationStrategy identifierGenerator) {
+        this.pid = generatePidForNameID(hubResponseTranslatorRequest, translatedHubResponse, identifierGenerator);
         this.eidasRequestId = hubResponseTranslatorRequest.getEidasRequestId();
         this.destinationURL = hubResponseTranslatorRequest.getDestinationUrl();
         this.issuer = hubResponseTranslatorRequest.getEidasIssuerEntityId();
+        this.eidasTransientPid = hubResponseTranslatorRequest.isEidasTransientPid();
+
         this.attributes = translatedHubResponse.getAttributes().orElse(null);
         this.vspScenario = translatedHubResponse.getScenario();
         this.levelOfAssurance = translatedHubResponse.getLevelOfAssurance().orElse(null);
     }
 
+    private Optional<String> generatePidForNameID(
+            HubResponseTranslatorRequest hubResponseTranslatorRequest,
+            TranslatedHubResponse translatedHubResponse,
+            IdentifierGenerationStrategy identifierGenerator) {
+        if (hubResponseTranslatorRequest.isEidasTransientPid()) {
+            return Optional.of(identifierGenerator.generateIdentifier());
+        }
+        return translatedHubResponse.getPid();
+    }
+
     Optional<String> getPid() {
-        return Optional.ofNullable(pid);
+        return pid;
     }
 
     String getEidasRequestId() {
@@ -43,8 +59,12 @@ public class HubResponseContainer {
         return destinationURL.toString();
     }
 
-    public URI getIssuer() {
+    URI getIssuer() {
         return issuer;
+    }
+
+    public boolean isEidasTransientPid() {
+        return eidasTransientPid;
     }
 
     Optional<Attributes> getAttributes() {

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/HubResponseTranslatorAppRuleTests.java
@@ -227,7 +227,6 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
                 .request()
                 .post(Entity.json(failureResponseGenerationRequest));
         Response response = new SamlParser().parseSamlString(Base64.decodeAsString(failureResponse.readEntity(String.class)));
-        
         assertThat(response.getStatus().getStatusCode().getValue()).isEqualTo("urn:oasis:names:tc:SAML:2.0:status:Requester");
     }
 
@@ -246,7 +245,8 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
                 ResponseBuilder.DEFAULT_REQUEST_ID,
                 "LEVEL_2",
                 URI.create(EIDAS_TEST_CONNECTOR_DESTINATION),
-                URI.create(EIDAS_TEST_CONNECTOR_DESTINATION)
+                URI.create(EIDAS_TEST_CONNECTOR_DESTINATION),
+                false
             );
 
         return postToTranslator(translatorAppRule, hubResponseTranslatorRequest,  Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH);
@@ -262,7 +262,8 @@ public class HubResponseTranslatorAppRuleTests extends TranslatorAppRuleTestBase
                         ResponseBuilder.DEFAULT_REQUEST_ID,
                         "LEVEL_2",
                         URI.create(EIDAS_TEST_CONNECTOR_DESTINATION),
-                        URI.create(EIDAS_TEST_CONNECTOR_DESTINATION)
+                        URI.create(EIDAS_TEST_CONNECTOR_DESTINATION),
+                        false
                 );
 
         return postToTranslator(translatorAppRule, hubResponseTranslatorRequest,  Urls.TranslatorUrls.TRANSLATE_HUB_RESPONSE_PATH);

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -1,5 +1,7 @@
 package uk.gov.ida.notification.translator.saml;
 
+import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrategy;
+import net.shibboleth.utilities.java.support.security.SecureRandomIdentifierGenerationStrategy;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.config.InitializationService;
@@ -26,6 +28,9 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createDateTime;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createNonMatchingTransliterableAttribute;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder.buildTranslatedHubResponseAuthenticationFailed;
@@ -51,6 +56,8 @@ public class HubResponseTranslatorTest {
     private AttributesBuilder attributesBuilder;
     private CountryMetadataResponse countryMetaDataResponse;
 
+    private IdentifierGenerationStrategy identifierGenerator = spy(new SecureRandomIdentifierGenerationStrategy());
+
     @Before
     public void setUp() {
         this.attributesBuilder = new AttributesBuilder();
@@ -73,6 +80,15 @@ public class HubResponseTranslatorTest {
         TranslatedHubResponseTestAssertions.checkAssertionStatementsValid(identityVerifiedResponse);
         TranslatedHubResponseTestAssertions.checkAllAttributesValid(identityVerifiedResponse);
         TranslatedHubResponseTestAssertions.checkResponseStatusCodeValidForIdentityVerifiedStatus(identityVerifiedResponse);
+        verifyNoInteractions(identifierGenerator);
+    }
+
+    @Test
+    public void translateShouldUseTransientIdWhenFlagged() {
+        final HubResponseContainer hubResponseContainer = buildHubResponseContainerwithTransientId(
+                buildTranslatedHubResponseIdentityVerified());
+        TRANSLATOR.getTranslatedHubResponse(hubResponseContainer, countryMetaDataResponse);
+        verify(identifierGenerator).generateIdentifier();
     }
 
     @Test
@@ -241,20 +257,25 @@ public class HubResponseTranslatorTest {
     }
 
     private HubResponseContainer buildHubResponseContainer(NonMatchingAttributes attributes) {
-        return new HubResponseContainer(buildHubResponseTranslatorRequest(), new TranslatedHubResponseBuilder().withAttributes(attributes).build());
+        return new HubResponseContainer(buildHubResponseTranslatorRequest(false), new TranslatedHubResponseBuilder().withAttributes(attributes).build(), identifierGenerator);
     }
 
     private HubResponseContainer buildHubResponseContainer(TranslatedHubResponse translatedHubResponse) {
-        return new HubResponseContainer(buildHubResponseTranslatorRequest(), translatedHubResponse);
+        return new HubResponseContainer(buildHubResponseTranslatorRequest(false), translatedHubResponse, identifierGenerator);
     }
 
-    private HubResponseTranslatorRequest buildHubResponseTranslatorRequest() {
+    private HubResponseContainer buildHubResponseContainerwithTransientId(TranslatedHubResponse translatedHubResponse) {
+        return new HubResponseContainer(buildHubResponseTranslatorRequest(true), translatedHubResponse, identifierGenerator);
+    }
+
+    private HubResponseTranslatorRequest buildHubResponseTranslatorRequest(boolean transientId) {
         return new HubResponseTranslatorRequest(
                 "",
                 "_request-id_of-20-chars-or-more",
                 ResponseBuilder.DEFAULT_REQUEST_ID,
                 "LEVEL_2",
                 URI.create("http://localhost:8081/bob"),
-                URI.create("http://localhost:8081/bob"));
+                URI.create("http://localhost:8081/bob"),
+                transientId);
     }
 }

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/validations/HubResponseTranslatorRequestValidationTests.java
@@ -37,7 +37,8 @@ public class HubResponseTranslatorRequestValidationTests extends AbstractDtoVali
                 null,
                 null,
                 null,
-                null);
+                null,
+                false);
 
         Map<String, List<ConstraintViolation<HubResponseTranslatorRequest>>> nullViolationsMap = validateAndMap(nullRequest);
 
@@ -52,7 +53,8 @@ public class HubResponseTranslatorRequestValidationTests extends AbstractDtoVali
                 SAMPLE_EIDAS_REQUEST_ID,
                 SAMPLE_LEVEL_OF_ASSURANCE,
                 URI.create(SAMPLE_DESTINATION_URL),
-                URI.create(SAMPLE_DESTINATION_URL));
+                URI.create(SAMPLE_DESTINATION_URL),
+                false);
 
         Map<String, List<ConstraintViolation<HubResponseTranslatorRequest>>> goodViolationsMap = validateAndMap(goodRequest);
 
@@ -67,7 +69,8 @@ public class HubResponseTranslatorRequestValidationTests extends AbstractDtoVali
                 "_2_is_too_short",
                 "LEVEL_7",
                 URI.create("xyz://something.somewhere/with/an/invalid/protocol"),
-                URI.create("xyz://something.somewhere/with/an/invalid/protocol"));
+                URI.create("xyz://something.somewhere/with/an/invalid/protocol"),
+                false);
 
         Map<String, List<ConstraintViolation<HubResponseTranslatorRequest>>> badViolationsMap = validateAndMap(badRequest);
 

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactory.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactory.java
@@ -44,7 +44,7 @@ public class EidasAuthnRequestContextFactory {
         SPTypeEnumeration spType,
         List<String> requestedAttributes,
         EidasLoaEnum loa,
-        SignatureSigningParameters signingParameters) throws ComponentInitializationException, MessageHandlerException {
+        SignatureSigningParameters signingParameters, boolean transientPidRequested) throws ComponentInitializationException, MessageHandlerException {
 
         AuthnRequest request = SamlBuilder.build(AuthnRequest.DEFAULT_ELEMENT_NAME);
         request.getNamespaceManager().registerNamespaceDeclaration(new Namespace(EidasConstants.EIDAS_NS, EidasConstants.EIDAS_PREFIX));
@@ -92,7 +92,7 @@ public class EidasAuthnRequestContextFactory {
         // Set the requested NameID policy to "persistent".
         //
         NameIDPolicy nameIDPolicy = SamlBuilder.build(NameIDPolicy.DEFAULT_ELEMENT_NAME);
-        nameIDPolicy.setFormat(NameID.PERSISTENT);
+        nameIDPolicy.setFormat(transientPidRequested ? NameID.TRANSIENT : NameID.PERSISTENT);
         nameIDPolicy.setAllowCreate(true);
         request.setNameIDPolicy(nameIDPolicy);
 

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/startpage.mustache
@@ -76,6 +76,7 @@
     <div>
         <a href="./RequestLow" class="submitBtn submitBtnGreen">Start Journey LOA Low</a>
         <a href="./RequestSubstantial" class="submitBtn submitBtnGreen">Start Journey LOA Substantial</a>
+        <a href="./RequestTransientPid" class="submitBtn submitBtnGreen">Start Journey Transient</a>
     </div>
     <div>
         <a href="./MissingSignature" class="submitBtn submitBtnRed">Send request with missing signature</a>

--- a/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/stubconnector/EidasAuthnRequestContextFactoryTest.java
@@ -37,7 +37,8 @@ public class EidasAuthnRequestContextFactoryTest {
                     SPTypeEnumeration.PUBLIC,
                     Collections.emptyList(),
                     EidasLoaEnum.LOA_SUBSTANTIAL,
-                    signingParams);
+                    signingParams,
+                    false);
         } catch (Exception e) {
             // expected
         }


### PR DESCRIPTION
The PID from the UK IDP is always returned to the country in our eIDAS SAML response, regardless of the name id format requested by the country.
Proxy Node does not publish or respect the transient and unspecified as acceptable name id formats in a SAML Request. Netherlands, for instance, always requests transient ids. Denmark have indicated we are non-compliant due to above.

If a SAML Request indicates a transient name id format, the SAML response to the country will contain a unique random identifier for the PersonIdentifier SAML attribute. In all other cases the PID from the IDP will be returned as the PersonIdentifier SAML attribute. This story will touch three services, the esp, gateway and translator.

- ESP is now able to determine if NameID is transient and stores that in the form of a boolean. This boolean is sent back to the gateway.
- The gateway can now use the getter for transient pid to see if the NameID is transient or not.
- The value of that is now stored in Redis.
- If the pid is transient then we append _tr to the pid
- Added tests to show the result of transientPid if the NameId is UNSPECIFIED, PERSISTENT or null
- Created a SecureRandomIdentifierGenerationStrategy to create the new pid if the NameId is transient

Ticket: https://govukverify.atlassian.net/browse/EID-1911