### PR TITLE
Make local docker-compose Proxy Node work end to end

### DIFF
--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -20,7 +20,7 @@ REDIS_SERVER_URI=""
 # Stub Connector config
 CONNECTOR_NODE_BASE_URL=http://localhost:6610
 CONNECTOR_NODE_ENTITY_ID=http://stub-connector:6610/ConnectorMetadata
-CONNECTOR_NODE_ACS_URL=http://localhost:6610/SAML2/Response
+CONNECTOR_NODE_ACS_URL=http://localhost:6610/SAML2/Response/POST
 PROXY_NODE_ENTITY_ID=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL=http://proxy-node-gateway:6600/ServiceMetadata
 PROXY_NODE_METADATA_TRUSTSTORE=/app/metadata/metadata.truststore


### PR DESCRIPTION
Make local `docker-compose` work end to end by setting the connector node callback correctly.

You should be able to test an end-to-end journey now by:
1) Starting Hub locally in `ida-hub-acceptance-tests`
2) Building and starting proxy node locally with `./startup-docker.sh --build --local-hub`
3) Starting a journey at http://localhost:6610/

This doesn't allow acceptance tests to run against local dev :(