### PR TITLE
EID-1949 Accept eIDAS compliant signing algos in ESP

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlParserApplication.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/EidasSamlParserApplication.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 
 import javax.ws.rs.client.Client;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
@@ -37,6 +38,8 @@ import uk.gov.ida.notification.shared.istio.IstioHeaderStorage;
 import uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter;
 import uk.gov.ida.notification.shared.proxy.MetatronProxy;
 import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
+
+import java.security.Security;
 
 public class EidasSamlParserApplication extends Application<EidasSamlParserConfiguration> {
     private MetatronProxy metatronProxy;
@@ -75,6 +78,7 @@ public class EidasSamlParserApplication extends Application<EidasSamlParserConfi
 
     @Override
     public void run(EidasSamlParserConfiguration configuration, Environment environment) throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
         ProxyNodeHealthCheck proxyNodeHealthCheck = new ProxyNodeHealthCheck("parser");
         environment.healthChecks().register(proxyNodeHealthCheck.getName(), proxyNodeHealthCheck);
 

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/EidasAuthnRequestBuilder.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/helpers/EidasAuthnRequestBuilder.java
@@ -6,10 +6,16 @@ import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.security.credential.Credential;
+import org.opensaml.xmlsec.algorithm.SignatureAlgorithm;
 import org.opensaml.xmlsec.algorithm.descriptors.SignatureRSASHA256;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.Signer;
-import org.w3c.dom.*;
+import org.w3c.dom.Attr;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
 import uk.gov.ida.notification.saml.SamlParser;
 import uk.gov.ida.saml.core.test.builders.SignatureBuilder;
 
@@ -18,6 +24,7 @@ import javax.xml.xpath.XPathExpressionException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 public class EidasAuthnRequestBuilder {
@@ -30,6 +37,7 @@ public class EidasAuthnRequestBuilder {
     private final String eidas = "http://eidas.europa.eu/saml-extensions";
     private HashMap<String, String> namespaceMap;
     private Credential signingCredential;
+    private SignatureAlgorithm signatureAlgorithm;
 
     public EidasAuthnRequestBuilder() throws Exception {
         parser = new SamlParser();
@@ -48,7 +56,7 @@ public class EidasAuthnRequestBuilder {
         if (this.signingCredential != null) {
             SignatureBuilder signatureBuilder = SignatureBuilder
                     .aSignature()
-                    .withSignatureAlgorithm(new SignatureRSASHA256())
+                    .withSignatureAlgorithm(Optional.ofNullable(signatureAlgorithm).orElseGet(SignatureRSASHA256::new))
                     .withSigningCredential(this.signingCredential);
             authnRequest.setSignature(signatureBuilder.build());
             XMLObjectProviderRegistrySupport
@@ -188,6 +196,11 @@ public class EidasAuthnRequestBuilder {
 
     public EidasAuthnRequestBuilder withSigningCredential(Credential credential) {
         this.signingCredential = credential;
+        return this;
+    }
+
+    public EidasAuthnRequestBuilder withSignatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
+        this.signatureAlgorithm = signatureAlgorithm;
         return this;
     }
 

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/ConnectorNodeCredentialConfiguration.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/ConnectorNodeCredentialConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.ida.notification.stubconnector;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.xml.security.signature.XMLSignature;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.x509.BasicX509Credential;
 import org.opensaml.security.x509.X509Credential;
@@ -44,7 +45,7 @@ public class ConnectorNodeCredentialConfiguration {
         if (samlSigningCredential.getPublicKey() instanceof ECPublicKey) {
             this.algorithm = SignatureConstants.ALGO_ID_SIGNATURE_ECDSA_SHA256;
         } else {
-            this.algorithm = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
+            this.algorithm = XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1;
         }
 
     }


### PR DESCRIPTION
Support the following AuthnRequest signing algos within the ESP:

http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1
http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1
http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1
http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256
http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384
http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512

by using BouncyCastleProvider as a SecurityProvider in the ESP.

Add an integration test to check that signing algo http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1 is supported.

Make http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1 the default signing algo used in stub-connector.