### PR TITLE
EID-1964 Stub Connector live and ready probe intervals

### DIFF
--- a/chart/templates/stub-connector-deployment.yaml
+++ b/chart/templates/stub-connector-deployment.yaml
@@ -48,13 +48,13 @@ spec:
           httpGet:
             path: /healthcheck
             port: mgmt
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
         readinessProbe:
           tcpSocket:
             port: http
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: 60
+          periodSeconds: 60
         env:
         - name: PORT
           value: "80"


### PR DESCRIPTION
Increase liveness and readiness probe initial delay and intervals.

This may help SC avoid failed health checks on reading Proxy Node metadata