### PR TITLE
🎢 Separate deploy and test jobs in build pipeline

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -197,13 +197,13 @@ spec:
 
     groups:
       - name: deployment
-        jobs: [build-vsp-image, build-proxy-node, package, test, release, delete]
+        jobs: [build-vsp-image, build-proxy-node, package, deploy, test, release, delete]
       - name: proxy-node
-        jobs: [build-proxy-node, package, test, release, delete]
+        jobs: [build-proxy-node, package, deploy, test, release, delete]
       - name: components
         jobs: [build-cloudhsm, build-vsp-image]
       - name: all
-        jobs: [build-cloudhsm, build-vsp-image, build-proxy-node, package, test, release, delete]
+        jobs: [build-cloudhsm, build-vsp-image, build-proxy-node, package, deploy, test, release, delete]
 
     jobs:
 
@@ -701,7 +701,7 @@ spec:
                   --namespace "${RELEASE_NAMESPACE}" \
                   --app "${RELEASE_NAME}-${APP_NAME}"
 
-    - name: test
+    - name: deploy
       serial: true
       serial_groups: [package]
       on_failure: *slack-on-failure
@@ -712,8 +712,6 @@ spec:
           - get: chart
             passed: [delete]
             trigger: true
-          - get: tests-image
-            passed: [build-proxy-node]
           - get: eidas-config
             trigger: true
 
@@ -853,21 +851,34 @@ spec:
                 --diff-changes \
                 -f ./manifests/
 
-      - task: test-chart-package
-        image: tests-image
-        attempts: 2
-        timeout: 5m
-        config:
-          platform: linux
-          params:
-            TEST_ENV: build
-          run:
-            path: /bin/bash
-            args:
-            - -euc
-            - |
-              cd /
-              bundle exec cucumber --strict --tags "not @ignore" features/acceptance/
+    - name: test
+      serial: true
+      serial_groups: [package]
+      on_failure: *slack-on-failure
+      plan:
+
+        - in_parallel:
+            steps:
+              - get: chart
+                passed: [deploy]
+                trigger: true
+              - get: tests-image
+
+        - task: test-chart-package
+          image: tests-image1
+          attempts: 2
+          timeout: 5m
+          config:
+            platform: linux
+            params:
+              TEST_ENV: build
+            run:
+              path: /bin/bash
+              args:
+              - -euc
+              - |
+                cd /
+                bundle exec cucumber --strict --tags "not @ignore" features/acceptance/
 
     - name: release
       serial: true


### PR DESCRIPTION
Separate the deploy of the proxy node build from the acceptance tests which follow.

This has two benefits:
1) re-run only acceptance tests through concourse if they fail in a triggered build.
2) prepare for ZDD - another new zdd test job should run in parallel to the deploy job, and acceptance tests should run after deploy.

Tested the pipeline locally 👇 showing separate `deploy` and `test` jobs :
<img width="1335" alt="Screenshot 2020-06-05 at 16 17 37" src="https://user-images.githubusercontent.com/137389/83893636-1af57800-a748-11ea-8891-113013ac1a07.png">

It currently looks like:
<img width="1176" alt="Screenshot 2020-06-05 at 16 25 01" src="https://user-images.githubusercontent.com/137389/83894397-28f7c880-a749-11ea-9385-11d352d75657.png">
