### PR TITLE
EID-1985 - Add SubjectConfirmationData to eidas response

### DIFF
--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasAssertionBuilder.java
@@ -14,6 +14,8 @@ import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 
 import java.util.List;
 
@@ -30,8 +32,8 @@ public class EidasAssertionBuilder {
         return this;
     }
 
-    public EidasAssertionBuilder withSubject(String pid) {
-        assertion.setSubject(createSubject(pid));
+    public EidasAssertionBuilder withSubject(String pid, String requestId, String destination) {
+        assertion.setSubject(createSubject(pid, requestId, destination));
         return this;
     }
 
@@ -64,12 +66,24 @@ public class EidasAssertionBuilder {
         return assertion;
     }
 
-    private Subject createSubject(String pid) {
+    private Subject createSubject(String pid, String requestId, String destination) {
         Subject subject = SamlBuilder.build(Subject.DEFAULT_ELEMENT_NAME);
         NameID nameID = SamlBuilder.build(NameID.DEFAULT_ELEMENT_NAME);
         nameID.setValue(pid);
         nameID.setFormat(NameIDType.PERSISTENT);
         subject.setNameID(nameID);
+
+        SubjectConfirmationData subjectConfirmationData = SamlBuilder.build(SubjectConfirmationData.DEFAULT_ELEMENT_NAME);
+        subjectConfirmationData.setInResponseTo(requestId);
+        subjectConfirmationData.setNotBefore(DateTime.now());
+        subjectConfirmationData.setNotOnOrAfter(DateTime.now().plusMinutes(5));
+        subjectConfirmationData.setRecipient(destination);
+
+        SubjectConfirmation subjectConfirmation = SamlBuilder.build(SubjectConfirmation.DEFAULT_ELEMENT_NAME);
+        subjectConfirmation.setMethod("urn:oasis:names:tc:saml2:2.0:cm:bearer");
+        subjectConfirmation.setSubjectConfirmationData(subjectConfirmationData);
+
+        subject.getSubjectConfirmations().add(subjectConfirmation);
         return subject;
     }
 

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/saml/EidasResponseBuilder.java
@@ -60,8 +60,8 @@ public class EidasResponseBuilder {
         return this;
     }
 
-    public EidasResponseBuilder withAssertionSubject(String pid) {
-        assertionBuilder.withSubject(pid);
+    public EidasResponseBuilder withAssertionSubject(String pid, String requestId, String destination) {
+        assertionBuilder.withSubject(pid, requestId, destination);
         return this;
     }
 

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/EidasResponseBuilderTest.java
@@ -13,6 +13,9 @@ import org.opensaml.saml.saml2.core.Condition;
 import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.Subject;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
+import org.opensaml.saml.saml2.core.SubjectConfirmationData;
 import org.opensaml.saml.saml2.core.impl.AudienceRestrictionImpl;
 import se.litsec.eidas.opensaml.ext.attributes.CurrentGivenNameType;
 
@@ -81,7 +84,7 @@ public class EidasResponseBuilderTest {
 
         DateTime now = DateTime.now();
         Response response = EidasResponseBuilder.instance()
-                .withAssertionSubject("an assertion subject")
+                .withAssertionSubject("an assertion subject", "a request id", "an rp recipient url")
                 .withAssertionConditions("some assertion conditions")
                 .addAssertionAttributeStatement(Lists.newArrayList(attribute))
                 .addAssertionAuthnStatement("an authStatement", now)
@@ -93,7 +96,13 @@ public class EidasResponseBuilderTest {
 
         Assertion assertion = assertions.iterator().next();
 
-        assertThat(assertion.getSubject().getNameID().getValue()).contains("an assertion subject");
+        Subject subject = assertion.getSubject();
+        assertThat(subject.getNameID().getValue()).contains("an assertion subject");
+        assertThat(subject.getSubjectConfirmations().size()).isEqualTo(1);
+        SubjectConfirmation subjectConfirmation = subject.getSubjectConfirmations().iterator().next();
+        SubjectConfirmationData subjectConfirmationData = subjectConfirmation.getSubjectConfirmationData();
+        assertThat(subjectConfirmationData.getInResponseTo()).isEqualTo("a request id");
+        assertThat(subjectConfirmationData.getRecipient()).isEqualTo("an rp recipient url");
 
         Conditions conditions = assertion.getConditions();
         assertThat(conditions.getConditions().size()).isEqualTo(1);

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -88,7 +88,7 @@ public class HubResponseTranslator {
                 .withInResponseTo(hubResponseContainer.getEidasRequestId())
                 .withIssueInstant(now)
                 .withDestination(hubResponseContainer.getDestinationURL())
-                .withAssertionSubject(pid)
+                .withAssertionSubject(pid, hubResponseContainer.getEidasRequestId(), hubResponseContainer.getDestinationURL())
                 .withAssertionConditions(countryMetadataResponse.getEntityId())
                 .withLoa(getMappedLoa(hubResponseContainer.getLevelOfAssurance()), now)
                 .addAssertionAttributeStatement(eidasAttributes)

--- a/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
+++ b/stub-connector/src/test/java/uk/gov/ida/notification/apprule/EidasResponseValidatorAppRuleTests.java
@@ -184,7 +184,7 @@ public class EidasResponseValidatorAppRuleTests extends StubConnectorAppRuleTest
                 .withInResponseTo(authid)
                 .withIssueInstant(now)
                 .withDestination("http://stub-connector/SAML2/Response/POST")
-                .withAssertionSubject(UUID.randomUUID().toString())
+                .withAssertionSubject(UUID.randomUUID().toString(), authid, "http://stub-connector/SAML2/Response/POST")
                 .addAssertionAuthnStatement(EidasConstants.EIDAS_LOA_SUBSTANTIAL, now)
                 .addAssertionAttributeStatement(eidasAttributes)
                 .withAssertionConditions("http://localhost:5000/Metadata")


### PR DESCRIPTION
## Why 
Adding `<SubjectConfirmation>` and its child element `<SubjectConfirmationData>` to our eidas response assertion will make it easier for SAML parsing clients to process this expected but not mandatory element. It also constrains the circumstances under which the act of subject confirmation can take place.

The eIDAS spec does not require a `<SubjectConfirmation>`, but according to eidas colleagues, the lack of it is a problem for the eIDAS eGov and saml2int profiles.

## What
Add a `<SubjectConfirmation>` to `<Subject>` with method `“urn:oasis:names:tc:saml2:2.0:cm:bearer”`
Add a `<SubjectConfirmationData>` to `<SubjectConfirmation>` with attributes:
* NotBefore - time of now
* NotOnOrAfter - time of now plus 5 minutes, the same as  `<saml2:Conditions NotOnOrAfter attribute`
* Recipient - the same as response destination, for example  `<saml2p:Response Destination="http://localhost:6610/SAML2/Response/POST"`
* InResponseTo - the eidas request id, the same as response InResponseTo, for example `<saml2p:Response InResponseTo="_ad54dcc675afcc0c26898390cfc92828"`

With this commit I can produce a SAML response in local stub connector containing:
````        
<saml2:Subject>
    <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">GB/EU/44a276db28130110f83260bff62f547da4cb08b788ba895fbdcecb73bd70c0fb</saml2:NameID>
    <saml2:SubjectConfirmation Method="urn:oasis:names:tc:saml2:2.0:cm:bearer">
        <saml2:SubjectConfirmationData 
                InResponseTo="_ad54dcc675afcc0c26898390cfc92828" 
                NotBefore="2020-06-09T08:47:23.210Z" 
                NotOnOrAfter="2020-06-09T08:52:23.210Z"
               Recipient="http://localhost:6610/SAML2/Response/POST"/>
    </saml2:SubjectConfirmation>
</saml2:Subject>
````

See https://govukverify.atlassian.net/browse/EID-1985