### PR TITLE
EID-1951: Add integration smoketests for Estonia and Sweden

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2020-06-15T00:00:00.000Z
+        expires: 2020-12-15T00:00:00.000Z
 patch: {}

--- a/proxy-node-acceptance-tests/features/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/proxy_node.feature
@@ -1,64 +1,64 @@
 Feature: proxy-node feature
 
-    Scenario: Proxy node happy path - LOA LOW
-        Given the proxy node is sent a LOA 'Low' request from the stub connector
-        And they progress through verify
-        And they login to stub idp
-        Then they should arrive at the success page
+  Scenario: Proxy Node happy path - LOA LOW
+    Given the Proxy Node is sent an LOA 'Low' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP
+    Then  they should arrive at the Stub Connector success page
 
-    Scenario: Proxy node happy path - LOA Substantial
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp
-        Then they should arrive at the success page
+  Scenario: Proxy Node happy path - LOA Substantial
+    Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP
+    Then  they should arrive at the Stub Connector success page
 
-    Scenario: Proxy node happy path - TransientPid requested
-        Given the proxy node is sent a transientPid request
-        And they progress through verify
-        And they login to stub idp
-        Then they should arrive at the success page
-        And they should have a transient id
+  Scenario: Proxy Node happy path - Transient PID requested
+    Given the proxy node is sent a transient PID request
+    And   they progress through Verify
+    And   they login to Stub IDP
+    Then  they should arrive at the Stub Connector success page
+    And   they should have a transient PID
 
-    Scenario: Proxy node happy path - LOA High
-        Given the proxy node is sent a LOA 'High' request from the stub connector
-        Then the user should be presented with an error page
+  Scenario: Proxy Node happy path - LOA High
+    Given the Proxy Node is sent an LOA 'High' request from the Stub Connector
+    Then  the user should be presented with an error page
 
-    Scenario: Stub connector generates an Authn request with a missing signature
-        Given the stub connector supplies an authn request with a missing signature
-        Then the user should be presented with an error page
+  Scenario: Stub Connector generates an Authn request with a missing signature
+    Given the Stub Connector supplies an authentication request with a missing signature
+    Then  the user should be presented with an error page
 
-    Scenario: Stub connector generates an Authn request with an invalid signature
-        Given the stub connector supplies an authn request with an invalid signature
-        Then the user should be presented with an error page
+  Scenario: Stub Connector generates an Authn request with an invalid signature
+    Given the Stub Connector supplies an authentication request with a missing signature
+    Then  the user should be presented with an error page
 
-    Scenario: Show error page if page doesnt exist
-        Given the user accesses a invalid page
-        Then the user should be presented with an error page
+  Scenario: Show error page if page doesn't exist
+    Given the user accesses a invalid page
+    Then  the user should be presented with an error page
 
-    Scenario: Show error page if route is not accessible
-        Given the user accesses the gateway response url directly
-        Then the user should be presented with an error page
+  Scenario: Show error page if route is not accessible
+    Given the user accesses the Gateway response URL directly
+    Then  the user should be presented with an error page
 
-    Scenario: Show IDP error page if No Authn Context Event
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp with error event 'No Authn Context Event'
-        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+  Scenario: Show IDP error page if No Authn Context Event
+    Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP with error event 'No Authn Context Event'
+    Then  the user should be presented with a Hub error page indicating IDP could not sign them in
 
-    Scenario: Show IDP error page if Authn Failure Event
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp with error event 'Authn Failure'
-        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+  Scenario: Show IDP error page if Authn Failure Event
+    Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP with error event 'Authn Failure'
+    Then  the user should be presented with a Hub error page indicating IDP could not sign them in
 
-    Scenario: Show IDP error page if Submit Requester Error Event
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp with error event 'Submit Requester Error'
-        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+  Scenario: Show IDP error page if Submit Requester Error Event
+    Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP with error event 'Submit Requester Error'
+    Then  the user should be presented with a Hub error page indicating IDP could not sign them in
 
-    Scenario: Show IDP error page if Submit Fraud Event
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp with error event 'Submit Fraud Event'
-        Then the user should be presented with a Hub error page indicating IDP could not sign you in
+  Scenario: Show IDP error page if Submit Fraud Event
+    Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And   they progress through Verify
+    And   they login to Stub IDP with error event 'Submit Fraud Event'
+    Then  the user should be presented with a Hub error page indicating IDP could not sign them in

--- a/proxy-node-acceptance-tests/features/smoke/integration/ee-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/ee-request.feature
@@ -1,0 +1,9 @@
+Feature: eidas-proxy-node-smoke-test-ee-integration feature
+
+  Scenario: Proxy Node Estonia happy path - LOA Substantial
+    Given   the user visits the "Estonia" Stub Connector Node page
+    And     they navigate the "Estonia" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page
+    And     they progress through Verify
+    And     they login to Stub IDP
+    Then    they should arrive at the "Estonia" success page

--- a/proxy-node-acceptance-tests/features/smoke/integration/integration.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/integration.feature
@@ -1,7 +1,13 @@
 Feature: eidas-proxy-node-smoke-test-integration feature
 
-    Scenario: Integration proxy node happy path - LOA Substantial
-        Given the proxy node is sent a LOA 'Substantial' request from the stub connector
-        And they progress through verify
-        And they login to stub idp
-        Then they should arrive at the success page
+  Scenario: Integration Proxy Node happy path - LOA Substantial
+    Given   the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
+    And     they progress through Verify
+    And     they login to Stub IDP
+    Then    they should arrive at the Stub Connector success page
+
+  Scenario: Integration Proxy Node happy path - LOA Low
+    Given   the Proxy Node is sent an LOA 'Low' request from the Stub Connector
+    And     they progress through Verify
+    And     they login to Stub IDP
+    Then    they should arrive at the Stub Connector success page

--- a/proxy-node-acceptance-tests/features/smoke/integration/se-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/se-request.feature
@@ -1,0 +1,9 @@
+Feature: eidas-proxy-node-smoke-test-se-integration feature
+
+  Scenario: Proxy Node Sweden happy path - LOA Substantial
+    Given   the user visits the "Sweden" Stub Connector Node page
+    And     they navigate the "Sweden" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page
+    And     they progress through Verify
+    And     they login to Stub IDP
+    Then    they should arrive at the "Sweden" success page

--- a/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
@@ -2,5 +2,5 @@ Feature: eidas-proxy-node-smoke-test-nl-prod feature
 
   Scenario: Proxy Node Netherlands happy path - LOA Substantial
     Given   the user visits the "Netherlands" Stub Connector Node page
-    And     they navigate "Netherlands" journey to verify with UK identity
+    And     they navigate the "Netherlands" journey to verify with UK identity
     Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
@@ -1,6 +1,6 @@
 Feature: eidas-proxy-node-smoke-test-nl-prod feature
 
-    Scenario: Proxy node happy path - LOA Substantial
-        Given   the user visits the Netherlands Connector Node Stub Page
-        And     they choose the UK as the country to verify with
-        Then    they should arrive at the Verify Hub blue page
+  Scenario: Proxy Node Netherlands happy path - LOA Substantial
+    Given   the user visits the "Netherlands" Stub Connector Node page
+    And     they navigate "Netherlands" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -1,0 +1,60 @@
+# Start pages
+
+def country_stub_connector_url(country)
+  case country
+  when 'Netherlands'
+    'https://demo-portal.minez.nl/demoportal/etoegang'
+  when 'Estonia'
+    # 'https://tara-demo.herokuapp.com/first'
+    'https://tara-demo.herokuapp.com/auth?scope=eidas'
+  when 'Sweden'
+    'https://qa.test.swedenconnect.se/'
+  else
+    raise ArgumentError.new("Invalid country name: #{country}")
+  end
+end
+
+# Netherlands
+
+def navigate_netherlands_journey_to_uk
+  assert_text('Kies hoe u wilt inloggen')
+  click_link('English')
+  assert_text('Choose how to log in')
+  select "EU Login", :from => "authnServiceId"
+  click_button('Continue')
+  assert_text('Which country is your ID from?')
+  find('#country-GB').click
+  click_button('Continue')
+end
+
+# Estonia
+
+def navigate_estonia_journey_to_uk
+  assert_text("European Union member state's eID")
+  find('.selectize-control.js-select-country.single').click
+  find('div.option', text: 'United Kingdom').click
+  click_button('Continue')
+end
+
+def arrive_at_estonia_success_page
+  assert_text('Tere, Jack Cornelius Bauer !')
+  assert_text('"acr": "substantial"')
+  assert_text('date_of_birth": "1984-02-29"')
+end
+
+# Sweden
+
+def navigate_sweden_journey_to_uk
+  assert_text("Test your eID")
+  click_button("Foreign eID")
+  click_button("countryFlag_GB")
+end
+
+def arrive_at_sweden_success_page
+  assert_text("Your eID works for authentication.")
+  assert_text("Jack Cornelius")
+  assert_text("Bauer")
+  assert_text("1984-02-29")
+  assert_text("GB")
+  assert_text('Your authentication was made according to eIDAS assurance level "Substantial".')
+end

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -2,7 +2,16 @@ require 'yaml'
 require 'uri'
 require 'securerandom'
 
-Given("the proxy node is sent a LOA {string} request from the stub connector") do |load_type|
+def country_stub_connector_url(country)
+  case country
+  when 'Netherlands'
+    'https://demo-portal.minez.nl/demoportal/etoegang'
+  else
+    raise ArgumentError.new("Invalid country name: #{country}")
+  end
+end
+
+Given("the Proxy Node is sent an LOA {string} request from the Stub Connector") do |load_type|
   loa_url = case load_type
     when "Low"
       "/RequestLow"
@@ -16,33 +25,33 @@ Given("the proxy node is sent a LOA {string} request from the stub connector") d
   visit(ENV.fetch('STUB_CONNECTOR_URL') + loa_url)
 end
 
-Given("the proxy node is sent a transientPid request") do
+Given("the proxy node is sent a transient PID request") do
   visit(ENV.fetch('STUB_CONNECTOR_URL') + "/RequestTransientPid")
 end
 
-And('they progress through verify') do
+And('they progress through Verify') do
   assert_text('Sign in with GOV.UK Verify')
   choose('start_form_selection_false', allow_label_click: true)
   click_button('Continue')
   find('button', :text => 'Stub Idp Demo One').click
 end
 
-Given(/^the stub connector supplies an authn request with (.*)$/) do |issue|
+Given(/^the Stub Connector supplies an authentication request with (.*)$/) do |issue|
   scenario_path_map = {
-    "a missing signature": "/MissingSignature",
-    "an invalid signature": "/InvalidSignature"
+      "a missing signature": "/MissingSignature",
+      "an invalid signature": "/InvalidSignature"
   }
   visit(ENV.fetch('STUB_CONNECTOR_URL') + scenario_path_map[issue.to_sym])
 end
 
-Given('they login to stub idp') do
+Given('they login to Stub IDP') do
   fill_in('username', with: ENV.fetch('STUB_IDP_USER'))
   fill_in('password', with: 'bar')
   click_on('SignIn')
   click_on('I Agree')
 end
 
-Given('they login to stub idp with error event {string}') do |error_button_text|
+Given('they login to Stub IDP with error event {string}') do |error_button_text|
   fill_in('username', with: ENV.fetch('STUB_IDP_USER'))
   fill_in('password', with: 'bar')
   click_on(error_button_text)
@@ -52,15 +61,49 @@ Given("the user accesses a invalid page") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/asdfasdfasfsaf')
 end
 
-Given("the user accesses the gateway response url directly") do
+Given("the user accesses the Gateway response URL directly") do
   visit(ENV.fetch('PROXY_NODE_URL') + '/SAML2/SSO/Response/POST')
 end
 
-Given("the user visits the Netherlands Connector Node Stub Page") do
-  visit('https://demo-portal.minez.nl/demoportal/etoegang')
+Given("the user visits the {string} Stub Connector Node page") do |country|
+  visit(country_stub_connector_url(country))
 end
 
-And('they choose the UK as the country to verify with') do
+And('they navigate {string} journey to verify with UK identity') do |country|
+  case country
+  when 'Netherlands'
+    navigate_netherlands_journey_to_uk
+  else
+    raise ArgumentError.new("Invalid country name: #{country}")
+  end
+end
+
+Then('they should arrive at the Verify Hub start page') do
+  assert_text('Sign in with GOV.UK Verify')
+end
+
+Then('they should arrive at the Stub Connector success page') do
+  assert_text('Response successfully received')
+  assert_text('Jack Cornelius')
+  assert_text('Bauer')
+  assert_text('1984-02-29')
+end
+
+And('they should have a transient PID') do
+  assert_text('GB/EU/_tr_')
+end
+
+Then("the user should be presented with a Hub error page indicating IDP could not sign them in") do
+  assert_text('Stub Idp Demo One couldn’t sign you in')
+  assert_text('You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.')
+end
+
+Then("the user should be presented with an error page") do
+  assert_text('Sorry, something went wrong')
+  assert_text('This may be because your session timed out or there was a system error.')
+end
+
+def navigate_netherlands_journey_to_uk
   assert_text('Kies hoe u wilt inloggen')
   click_link('English')
   assert_text('Choose how to log in')
@@ -69,29 +112,4 @@ And('they choose the UK as the country to verify with') do
   assert_text('Which country is your ID from?')
   find('#country-GB').click
   click_button('Continue')
-end
-
-Then('they should arrive at the Verify Hub blue page') do
-  assert_text('Sign in with GOV.UK Verify')
-end
-
-Then('they should arrive at the success page') do
-  assert_text('Response successfully received')
-  assert_text('Jack Cornelius')
-  assert_text('Bauer')
-  assert_text('1984-02-29')
-end
-
-And('they should have a transient id') do
-  assert_text('GB/EU/_tr_')
-end
-
-Then("the user should be presented with a Hub error page indicating IDP could not sign you in") do
-  assert_text('Stub Idp Demo One couldn’t sign you in')
-  assert_text('You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.')
-end
-
-Then("the user should be presented with an error page") do
-  assert_text('Sorry, something went wrong')
-  assert_text('This may be because your session timed out or there was a system error.')
 end

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -2,26 +2,17 @@ require 'yaml'
 require 'uri'
 require 'securerandom'
 
-def country_stub_connector_url(country)
-  case country
-  when 'Netherlands'
-    'https://demo-portal.minez.nl/demoportal/etoegang'
-  else
-    raise ArgumentError.new("Invalid country name: #{country}")
-  end
-end
-
 Given("the Proxy Node is sent an LOA {string} request from the Stub Connector") do |load_type|
   loa_url = case load_type
-    when "Low"
-      "/RequestLow"
-    when "Substantial"
-      "/RequestSubstantial"
-    when "High"
-      "/RequestHigh"
-    else
-      "/BadRequest"
-  end
+            when "Low"
+              "/RequestLow"
+            when "Substantial"
+              "/RequestSubstantial"
+            when "High"
+              "/RequestHigh"
+            else
+              "/BadRequest"
+            end
   visit(ENV.fetch('STUB_CONNECTOR_URL') + loa_url)
 end
 
@@ -69,13 +60,12 @@ Given("the user visits the {string} Stub Connector Node page") do |country|
   visit(country_stub_connector_url(country))
 end
 
-And('they navigate {string} journey to verify with UK identity') do |country|
-  case country
-  when 'Netherlands'
-    navigate_netherlands_journey_to_uk
-  else
-    raise ArgumentError.new("Invalid country name: #{country}")
-  end
+And('they navigate the {string} journey to verify with UK identity') do |country|
+  send("navigate_#{country.downcase}_journey_to_uk")
+end
+
+Then('they should arrive at the {string} success page') do |country|
+  send("arrive_at_#{country.downcase}_success_page")
 end
 
 Then('they should arrive at the Verify Hub start page') do
@@ -84,6 +74,7 @@ end
 
 Then('they should arrive at the Stub Connector success page') do
   assert_text('Response successfully received')
+  assert_text('Saml Validity: VALID')
   assert_text('Jack Cornelius')
   assert_text('Bauer')
   assert_text('1984-02-29')
@@ -101,15 +92,4 @@ end
 Then("the user should be presented with an error page") do
   assert_text('Sorry, something went wrong')
   assert_text('This may be because your session timed out or there was a system error.')
-end
-
-def navigate_netherlands_journey_to_uk
-  assert_text('Kies hoe u wilt inloggen')
-  click_link('English')
-  assert_text('Choose how to log in')
-  select "EU Login", :from => "authnServiceId"
-  click_button('Continue')
-  assert_text('Which country is your ID from?')
-  find('#country-GB').click
-  click_button('Continue')
 end


### PR DESCRIPTION
Improve Cucumber tests
  - Refactor country specific bits into separate methods for reusability
  - Improve spacing and capitalisation to make tests looks clean and tidy

Add smoke tests for Sweden and Estonia
  - Move country specific methods to a separate file for better organisation
  - Call country methods by constructing their names