### PR TITLE
Make smoke tests naming consistent with Connector Node smoke tests

### DIFF
--- a/proxy-node-acceptance-tests/features/smoke/integration/estonia.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/estonia.feature
@@ -1,4 +1,4 @@
-Feature: eidas-proxy-node-smoke-test-ee-integration feature
+Feature: eIDAS Proxy Node Smoke Test - Estonia - Integration
 
   Scenario: Proxy Node Estonia happy path - LOA Substantial
     Given   the user visits the "Estonia" Stub Connector Node page

--- a/proxy-node-acceptance-tests/features/smoke/integration/integration.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/integration.feature
@@ -1,4 +1,6 @@
-Feature: eidas-proxy-node-smoke-test-integration feature
+Feature: eIDAS Proxy Node Node Smoke Test Integration
+
+  This tests our integration instance of the Proxy Node
 
   Scenario: Integration Proxy Node happy path - LOA Substantial
     Given   the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector

--- a/proxy-node-acceptance-tests/features/smoke/integration/sweden.feature
+++ b/proxy-node-acceptance-tests/features/smoke/integration/sweden.feature
@@ -1,4 +1,4 @@
-Feature: eidas-proxy-node-smoke-test-se-integration feature
+Feature: eIDAS Proxy Node Smoke Test - Sweden - Integration
 
   Scenario: Proxy Node Sweden happy path - LOA Substantial
     Given   the user visits the "Sweden" Stub Connector Node page

--- a/proxy-node-acceptance-tests/features/smoke/production/netherlands.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/netherlands.feature
@@ -1,0 +1,6 @@
+Feature: eIDAS Proxy Node Smoke Test - Netherlands - Production
+
+    Scenario: Proxy Node Netherlands happy path - LOA Substantial
+        Given   the user visits the "Netherlands" Stub Connector Node page
+        And     they navigate the "Netherlands" journey to verify with UK identity
+        Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/nl-request.feature
@@ -1,6 +1,0 @@
-Feature: eidas-proxy-node-smoke-test-nl-prod feature
-
-  Scenario: Proxy Node Netherlands happy path - LOA Substantial
-    Given   the user visits the "Netherlands" Stub Connector Node page
-    And     they navigate the "Netherlands" journey to verify with UK identity
-    Then    they should arrive at the Verify Hub start page


### PR DESCRIPTION
To make them consistent with Connector Node tests and enable country status reporting the Proxy Node from alphagov/verify-terraform#1231

  - Rename to use country names

See also alphagov/verify-acceptance-tests#93