### PR TITLE
EID-1973 metatron metadataresolver client timeout

### DIFF
--- a/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
+++ b/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
@@ -3,6 +3,8 @@ package uk.gov.ida.eidas.metatron.domain;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.saml.common.xml.SAMLConstants;
@@ -75,9 +77,12 @@ public class MetadataResolverService {
     }
 
     private Client getClient(EidasCountryConfig country) {
-        return country.getTlsTruststore().isPresent()
-                ? JerseyClientBuilder.newBuilder().trustStore(country.getTlsTruststore().get()).build()
-                : JerseyClientBuilder.newClient();
+        ClientConfig configuration = new ClientConfig();
+        configuration.property(ClientProperties.CONNECT_TIMEOUT, 10000);
+        configuration.property(ClientProperties.READ_TIMEOUT, 10000);
+        return country.getTlsTruststore()
+                .map(ts -> JerseyClientBuilder.newBuilder().trustStore(ts).withConfig(configuration).build())
+                .orElse(JerseyClientBuilder.newClient(configuration));
     }
 
     private List<MetadataFilter> getFilters(EidasCountryConfig country) {

--- a/metatron/src/main/java/uk/gov/ida/eidas/metatron/health/CountryMetadataHealthMetrics.java
+++ b/metatron/src/main/java/uk/gov/ida/eidas/metatron/health/CountryMetadataHealthMetrics.java
@@ -6,8 +6,8 @@ import uk.gov.ida.eidas.metatron.domain.MetadataResolverService;
 public class CountryMetadataHealthMetrics implements Runnable {
 
     private static final io.prometheus.client.Gauge METADATA_FETCH_GAUGE = Gauge
-            .build("country_metadata_health_metrics",
-                    "Country Metadata Health Metrics")
+            .build("verify_eidas_connector_metadata_health",
+                    "Connector Country Metadata Health Metrics")
             .labelNames("entity")
             .register();
 


### PR DESCRIPTION
Set a timeout for the per country client that fetches metadata.

If unset, the client never times out, the metatron never leaves its `init` method, and k8s reads the pod as unhealthy.
The pod is then continually killed and rescheduled.

This has been tested locally with integration config built from `verify-eidas-config` repo.

Also: set the metadata health metrics name to have the conventional `verify-eidas` prefix.