### PR TITLE
✅ EID-1992 Ignore not required attributes in eIDAS Request

### DIFF
--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
@@ -41,14 +41,18 @@ public class RequestedAttributesValidator {
     }
 
     private RequestedAttribute validateRequestedAttribute(RequestedAttribute requestedAttribute) {
-        if(!RequestedAttribute.URI_REFERENCE.equals(requestedAttribute.getNameFormat()))
+
+        if (!RequestedAttribute.URI_REFERENCE.equals(requestedAttribute.getNameFormat())) {
             throw new InvalidAuthnRequestException(nameFormatError(requestedAttribute));
+        }
 
-        if(mandatoryAttributes.contains(requestedAttribute.getName()) && !requestedAttribute.isRequired())
+        if (mandatoryAttributes.contains(requestedAttribute.getName()) && !requestedAttribute.isRequired()) {
             throw new InvalidAuthnRequestException(mandatoryAttributeError(requestedAttribute));
+        }
 
-        if(!mandatoryAttributes.contains(requestedAttribute.getName()) && requestedAttribute.isRequired())
+        if (!mandatoryAttributes.contains(requestedAttribute.getName()) && requestedAttribute.isRequired()) {
             throw new InvalidAuthnRequestException(optionalAttributeError(requestedAttribute));
+        }
 
         return requestedAttribute;
     }

--- a/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
+++ b/eidas-saml-parser/src/main/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidator.java
@@ -41,7 +41,6 @@ public class RequestedAttributesValidator {
     }
 
     private RequestedAttribute validateRequestedAttribute(RequestedAttribute requestedAttribute) {
-
         if (!RequestedAttribute.URI_REFERENCE.equals(requestedAttribute.getNameFormat())) {
             throw new InvalidAuthnRequestException(nameFormatError(requestedAttribute));
         }
@@ -69,4 +68,3 @@ public class RequestedAttributesValidator {
         return MessageFormat.format("Non-mandatory RequestedAttribute should not be required ''{0}''", requestedAttribute.getName());
     }
 }
-

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
@@ -35,7 +35,6 @@ public class RequestedAttributesValidatorTest {
 
     @Test
     public void nonMandatoryAttributesCannotBeRequired() {
-
         RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
         List<RequestedAttribute> mandatoryPlusGenderRequestedAttributes = List.of(
                 setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
@@ -53,7 +52,6 @@ public class RequestedAttributesValidatorTest {
 
     @Test
     public void allMandatoryAttributesMustBeRequested() {
-
         RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
         List<RequestedAttribute> incompleteMandatoryAttributes = List.of(
                 setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
@@ -70,7 +68,6 @@ public class RequestedAttributesValidatorTest {
 
     @Test
     public void allMandatoryAttributesMustBeRequired() {
-
         RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
         List<RequestedAttribute> attributes = List.of(
                 setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
@@ -1,0 +1,100 @@
+package uk.gov.ida.notification.eidassaml.saml.validation.components;
+
+import org.junit.Test;
+import se.litsec.eidas.opensaml.ext.RequestedAttribute;
+import se.litsec.eidas.opensaml.ext.RequestedAttributes;
+import uk.gov.ida.notification.exceptions.authnrequest.InvalidAuthnRequestException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_GENDER_ATTRIBUTE_NAME;
+import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME;
+
+public class RequestedAttributesValidatorTest {
+
+    @Test
+    public void ignoreNonMandatoryAttributesThatAreNotRequired() {
+
+        RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
+        List<RequestedAttribute> mandatoryPlusGenderRequestedAttributes = List.of(
+                setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_GENDER_ATTRIBUTE_NAME, false));
+
+        when(requestedAttributes.getRequestedAttributes()).thenReturn(mandatoryPlusGenderRequestedAttributes);
+
+        new RequestedAttributesValidator().validate(requestedAttributes);
+    }
+
+    @Test
+    public void nonMandatoryAttributesCannotBeRequired() {
+
+        RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
+        List<RequestedAttribute> mandatoryPlusGenderRequestedAttributes = List.of(
+                setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_GENDER_ATTRIBUTE_NAME));
+
+        when(requestedAttributes.getRequestedAttributes()).thenReturn(mandatoryPlusGenderRequestedAttributes);
+
+        assertThatThrownBy(() -> new RequestedAttributesValidator().validate(requestedAttributes))
+                .isInstanceOf(InvalidAuthnRequestException.class)
+                .hasMessageContaining("Non-mandatory RequestedAttribute should not be required");
+    }
+
+    @Test
+    public void allMandatoryAttributesMustBeRequested() {
+
+        RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
+        List<RequestedAttribute> incompleteMandatoryAttributes = List.of(
+                setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME));
+
+        when(requestedAttributes.getRequestedAttributes()).thenReturn(incompleteMandatoryAttributes);
+
+        assertThatThrownBy(() -> new RequestedAttributesValidator().validate(requestedAttributes))
+                .isInstanceOf(InvalidAuthnRequestException.class)
+                .hasMessageContaining("Missing mandatory RequestedAttribute")
+                .hasMessageContaining("DateOfBirth");
+    }
+
+    @Test
+    public void allMandatoryAttributesMustBeRequired() {
+
+        RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
+        List<RequestedAttribute> attributes = List.of(
+                setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_FAMILY_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_CURRENT_GIVEN_NAME_ATTRIBUTE_NAME),
+                setupAttribute(EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME, false));
+
+        when(requestedAttributes.getRequestedAttributes()).thenReturn(attributes);
+
+        assertThatThrownBy(() -> new RequestedAttributesValidator().validate(requestedAttributes))
+                .isInstanceOf(InvalidAuthnRequestException.class)
+                .hasMessageContaining("Mandatory RequestedAttribute needs to be required");
+    }
+
+    private RequestedAttribute setupAttribute(String attributeName) {
+        return setupAttribute(attributeName, true);
+    }
+
+    private RequestedAttribute setupAttribute(String attributeName, boolean required) {
+        RequestedAttribute attribute = mock(RequestedAttribute.class, attributeName);
+        when(attribute.getName()).thenReturn(attributeName);
+        when(attribute.isRequired()).thenReturn(required);
+        when(attribute.getNameFormat()).thenReturn(RequestedAttribute.URI_REFERENCE);
+        return attribute;
+    }
+}

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/saml/validation/components/RequestedAttributesValidatorTest.java
@@ -20,7 +20,6 @@ public class RequestedAttributesValidatorTest {
 
     @Test
     public void ignoreNonMandatoryAttributesThatAreNotRequired() {
-
         RequestedAttributes requestedAttributes = mock(RequestedAttributes.class);
         List<RequestedAttribute> mandatoryPlusGenderRequestedAttributes = List.of(
                 setupAttribute(EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME),


### PR DESCRIPTION
According to EU Validator Node team test our Proxy Node is non-compliant. Their assessent:

> Requesting an unsupported mandatory attribute "unknown" along with mandatory attributes (minimum data set for a natural person) leads to authentication failure .According to the EIDAS specification, eIDAS Message Format v1.1-2, section 2.3.2, “Attributes requested that are not supported by an eIDAS-Service MUST be ignored by the eIDAS-Service.”

eIDAS spec states:

> 2.3.2. Requesting Attributes
> 
> ………
> 
> For attributes requested and being mandatory according to the eIDAS minimum data sets and [eIDAS-Attr-Profile] the attribute isRequired of <eidas:RequestedAttribute> MUST be set to “true”. 
> 
> For all optional attributes according to the eIDAS minimum data sets and [eIDAS-Attr-Profile] the attribute isRequired of <eidas:RequestedAttribute> MUST be set to “false”. 
> 
> When requesting a minimum data set, at least all attributes defined as mandatory within this minimum data set MUST be requested. At least one minimum data set MUST be requested in each <saml2p:AuthnRequest>.

* Ensure that optional requested attributes are ignored if they are set to required false.
* Add tests around mandatory attributes