### PR TITLE
BAU: Remove .dockerignore when building Proxy Node

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -304,6 +304,7 @@ spec:
               params:
                 image: cloudhsm-jce-image-file/image.tar
                 additional_tags: cloudhsm-config/.git/short_ref
+
     - name: build-proxy-node
       serial: true
       serial_groups: [build-proxy-node]
@@ -356,6 +357,7 @@ spec:
               - -elc
               - |
                 cd src
+                rm -f .dockerignore
                 export GRADLE_USER_HOME=$(pwd)/home/gradle/.gradle
                 ./gradlew --console verbose --parallel -Pcloudhsm -PCI installDist
 


### PR DESCRIPTION
This will enable Docker to copy binaries in the following jobs that build images for individual PN apps.

We already do this in the VSP build step but forgot to include this line in the PN build job.