### PR TITLE
BAU fix proxy node build acceptance tests

### DIFF
--- a/ci/build/build-pipeline.yaml
+++ b/ci/build/build-pipeline.yaml
@@ -859,10 +859,7 @@ spec:
         config:
           platform: linux
           params:
-            PROXY_NODE_URL: "https://proxy-node.test.eidas.signin.service.gov.uk"
-            STUB_CONNECTOR_URL: "https://stub-connector.test.eidas.signin.service.gov.uk"
-            STUB_IDP_USER: "stub-idp-demo-one"
-            SELENIUM_HUB_URL: "https://selenium.tools.signin.service.gov.uk/wd/hub"
+            TEST_ENV: build
           run:
             path: /bin/bash
             args:

--- a/proxy-node-acceptance-tests/features/step_definitions/environments.yml
+++ b/proxy-node-acceptance-tests/features/step_definitions/environments.yml
@@ -9,7 +9,9 @@ docker-local:
 build:
   PROXY_NODE_URL: https://proxy-node.test.eidas.signin.service.gov.uk
   STUB_CONNECTOR_URL: https://stub-connector.test.eidas.signin.service.gov.uk
+  SELENIUM_HUB_URL: https://selenium.tools.signin.service.gov.uk/wd/hub
 
 integration:
   PROXY_NODE_URL: https://proxy-node.integration.eidas.signin.service.gov.uk
   STUB_CONNECTOR_URL: https://stub-connector.integration.eidas.signin.service.gov.uk
+  SELENIUM_HUB_URL: https://selenium.tools.signin.service.gov.uk/wd/hub


### PR DESCRIPTION
Build pipeline acc tests require a  TEST_ENV env var, and will fallback to local if not present.

Pass in the TEST_ENV env var of build as a key to environment.yaml.

