### PR TITLE
Reduce the size of the built docker image

### DIFF
--- a/proxy-node-acceptance-tests/Dockerfile
+++ b/proxy-node-acceptance-tests/Dockerfile
@@ -1,10 +1,17 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.5 as bundler
 
 COPY Gemfile Gemfile
 COPY Gemfile.lock Gemfile.lock
 
 RUN gem install bundler
 RUN bundle install
+
+
+FROM ruby:2.6.5-slim
+
+COPY Gemfile Gemfile
+COPY Gemfile.lock Gemfile.lock
+COPY --from=bundler /usr/local/bundle/ /usr/local/bundle/
 
 COPY features /features
 


### PR DESCRIPTION
The proxy-node-acceptance-tests docker image is quite large right now.
This means that concourse does a lot of work copying it around.

This does two things to reduce the image size:

 - use the `ruby:2.6.5-slim` image as base, which is smaller
 - use multi-stage docker builds so that we don't include build
   dependencies (like gcc) in the final artefact

This reduces the size from ~899Mb to ~190Mb.

There was no documentation saying how to test this locally, so I
didn't.