### PR TITLE
EID-1960 Clean up ESP config

### DIFF
--- a/chart/templates/esp-deployment.yaml
+++ b/chart/templates/esp-deployment.yaml
@@ -63,25 +63,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-proxy-node-metadata
               key: postURL
-        - name: CONNECTOR_NODE_ENTITY_ID
-          value: {{ include "connector.entityID" . }}
-        - name: CONNECTOR_NODE_METADATA_URL
-          value: {{ include "connector.metadata.url" . }}
         - name: METATRON_URL
           value: http://{{ .Release.Name }}-metatron/
-{{- if .Values.stubConnector.enabled }}
-        - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
-          valueFrom:
-            configMapKeyRef:
-              name: test-pki-configmap
-              key: stub_connector.truststore.base64
-        - name: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
-          value: {{ .Values.connector.metadataSigningTruststorePassword }}
-{{- else }}
-        - name: CONNECTOR_NODE_METADATA_TRUSTSTORE
-          value: {{ .Values.connector.metadataSigningTruststoreBase64 }}
-        - name: CONNECTOR_NODE_METADATA_TRUSTSTORE_PASSWORD
-          value: {{ .Values.connector.metadataSigningTruststorePassword }}
-{{- end }}
         - name: REDIS_SERVER_URI
           value: redis://{{ .Release.Name }}-esp-redis:6379/

--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -33,7 +33,6 @@ METADATA_ENCRYPTION_PUBLIC_KEY=/app/pki/stub-connector-saml-encryption.crt
 METADATA_ENCRYPTION_PRIVATE_KEY=/app/pki/stub-connector-saml-encryption.pk8
 
 # eIDAS SAML Parser config
-CONNECTOR_NODE_METADATA_URL=http://stub-connector:6610/ConnectorMetadata
 CONNECTOR_NODE_METADATA_TRUSTSTORE=/app/metadata/metadata.truststore
 PROXY_NODE_AUTHN_REQUEST_ENDPOINT=http://localhost:6600/SAML2/SSO/POST
 


### PR DESCRIPTION
The ESP no longer refers to a singe connector node, so remove this left-over config.

Tested with local docker.