### PR TITLE
BAU Only download HSM client libs for translator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ ARG TALKS_TO_HSM=false
 ENV LD_LIBRARY_PATH=/opt/cloudhsm/lib
 ENV HSM_PARTITION=PARTITION_1
 
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm .
-ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-3.0.0-2.el7.x86_64.rpm .
-
 RUN if ${TALKS_TO_HSM}; then echo "Installing CloudHSM libs" \
-    && yum install -y ./cloudhsm-client-*.rpm \
-    && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg ; fi
-
-RUN rm ./cloudhsm-client-*.rpm
+    && curl -Os https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm \
+    && curl -Os https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-3.0.0-2.el7.x86_64.rpm \
+    && yum install -y -q ./cloudhsm-client-*.rpm \
+    && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg \
+    && rm ./cloudhsm-client-*.rpm ; fi
 
 # Install Proxy Node app
 ARG TINI_VERSION=v0.18.0


### PR DESCRIPTION
Reduce build time by only downloading HSM client libs into the images where `TALKS_TO_HSM=true` i.e. `translator`.

Tested locally with:

`docker build . --build-arg component=proxy-node-gateway`
`docker build . --build-arg component=proxy-node-translator --build-arg TALKS_TO_HSM=true`

Only the translator build echoes `Installing CloudHSM libs`.