### PR TITLE
EID-1960 Stop using hardcoded values

### DIFF
--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -53,15 +53,6 @@ spec:
         env:
         - name: PORT
           value: "80"
-        - name: CONNECTOR_NODE_ISSUER_ID
-          value: {{ include "connector.entityID" . }}
-        - name: CONNECTOR_NODE_NATIONALITY_CODE
-          value: {{ .Values.translator.connectorNodeNationalityCode }}
-        - name: PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-proxy-node-metadata
-              key: entityID
         - name: SIGNER_CONFIG_TYPE
           valueFrom:
             secretKeyRef:

--- a/local-startup/docker.env
+++ b/local-startup/docker.env
@@ -38,8 +38,6 @@ CONNECTOR_NODE_METADATA_TRUSTSTORE=/app/metadata/metadata.truststore
 PROXY_NODE_AUTHN_REQUEST_ENDPOINT=http://localhost:6600/SAML2/SSO/POST
 
 # Translator config
-CONNECTOR_NODE_NATIONALITY_CODE=EU
-CONNECTOR_NODE_ISSUER_ID=${CONNECTOR_NODE_ENTITY_ID}
 TRANSLATOR_SIGNING_CERT=/app/pki/proxy-node-saml-signing.crt
 TRANSLATOR_SIGNING_KEY=/app/pki/proxy-node-saml-signing.pk8
 METATRON_URL=http://metatron:6670/

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -125,8 +125,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
         MetatronProxy metatronProxy = createMetatronProxy(configuration, environment);
 
         final HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
-                EidasResponseBuilder::instance,
-                configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
+                EidasResponseBuilder::instance
         );
 
         final EidasFailureResponseGenerator failureResponseGenerator = new EidasFailureResponseGenerator(

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -33,15 +33,12 @@ public class HubResponseTranslator {
     private static final String PID_PREFIX = "GB/%s/%s";
     private static final String TRANSIENT_PREFIX = "_tr";
     private static final SecureRandomIdentifierGenerationStrategy ID_GENERATOR_STRATEGY = new SecureRandomIdentifierGenerationStrategy();
-    private String proxyNodeMetadataForConnectorNodeUrl;
     private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier;
 
 
     public HubResponseTranslator(
-            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier,
-            String proxyNodeMetadataForConnectorNodeUrl) {
+            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier) {
         this.eidasResponseBuilderSupplier = eidasResponseBuilderSupplier;
-        this.proxyNodeMetadataForConnectorNodeUrl = proxyNodeMetadataForConnectorNodeUrl;
     }
 
     Response getTranslatedHubResponse(HubResponseContainer hubResponseContainer, CountryMetadataResponse countryMetadataResponse) {
@@ -85,7 +82,7 @@ public class HubResponseTranslator {
                 .collect(Collectors.toList());
 
         return eidasResponseBuilderSupplier.get()
-                .withIssuer(proxyNodeMetadataForConnectorNodeUrl)
+                .withIssuer(hubResponseContainer.getIssuer().toString())
                 .withStatus(getMappedStatusCode(hubResponseContainer.getVspScenario()))
                 .withInResponseTo(hubResponseContainer.getEidasRequestId())
                 .withIssueInstant(now)

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -45,8 +45,7 @@ public class HubResponseTranslatorTest {
         }
     }
 
-    private static final HubResponseTranslator TRANSLATOR = new HubResponseTranslator(EidasResponseBuilder::instance,
-            "Issuer");
+    private static final HubResponseTranslator TRANSLATOR = new HubResponseTranslator(EidasResponseBuilder::instance);
 
     private AttributesBuilder attributesBuilder;
     private CountryMetadataResponse countryMetaDataResponse;


### PR DESCRIPTION
HubResponseTranslator was using a value derived from the deployment yaml rather than the request.  Now it isn't, it's using Metatron to retrieve that information.

Co-authored-by: Phillip Miller <phillip.miller@digital.cabinet-office.gov.uk>