### PR TITLE
EID-1960 Remember to delete the config value

### DIFF
--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -16,8 +16,6 @@ logging:
   appenders:
     - type: ${LOGGING_APPENDER:-logstash-console}
 
-proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
-
 vspConfiguration:
   url: ${VERIFY_SERVICE_PROVIDER_URL}
   clientConfig:

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
@@ -14,11 +14,6 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
     @Valid
     @NotNull
     @JsonProperty
-    private URI proxyNodeMetadataForConnectorNodeUrl;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     private VerifyServiceProviderConfiguration vspConfiguration;
 
     @Valid
@@ -29,10 +24,6 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
     @NotNull
     @JsonProperty
     private URI metatronUri;
-
-    public URI getProxyNodeMetadataForConnectorNodeUrl() {
-        return proxyNodeMetadataForConnectorNodeUrl;
-    }
 
     public VerifyServiceProviderConfiguration getVspConfiguration() {
         return vspConfiguration;


### PR DESCRIPTION
Delete proxyNodeMetadataForConnectorNodeUrl from the Configuration class and from the yaml file too.

As this is no longer an env var for k8s the value is never interpolated and Java tries to parse ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL} as a URL.  Unsurprisingly this doesn't end well and the translator doesn't start at all which means tests never get run.