### PR TITLE
EID-1960 Remember to delete the config value

### DIFF
--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -16,8 +16,6 @@ logging:
   appenders:
     - type: ${LOGGING_APPENDER:-logstash-console}
 
-proxyNodeMetadataForConnectorNodeUrl: ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL}
-
 vspConfiguration:
   url: ${VERIFY_SERVICE_PROVIDER_URL}
   clientConfig:

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -129,8 +129,7 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
         );
 
         final EidasFailureResponseGenerator failureResponseGenerator = new EidasFailureResponseGenerator(
-                EidasResponseBuilder::instance,
-                configuration.getProxyNodeMetadataForConnectorNodeUrl().toString()
+                EidasResponseBuilder::instance
         );
 
         final CredentialConfiguration credentialConfiguration = configuration.getCredentialConfiguration();

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
@@ -14,11 +14,6 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
     @Valid
     @NotNull
     @JsonProperty
-    private URI proxyNodeMetadataForConnectorNodeUrl;
-
-    @Valid
-    @NotNull
-    @JsonProperty
     private VerifyServiceProviderConfiguration vspConfiguration;
 
     @Valid
@@ -29,10 +24,6 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
     @NotNull
     @JsonProperty
     private URI metatronUri;
-
-    public URI getProxyNodeMetadataForConnectorNodeUrl() {
-        return proxyNodeMetadataForConnectorNodeUrl;
-    }
 
     public VerifyServiceProviderConfiguration getVspConfiguration() {
         return vspConfiguration;

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasFailureResponseGenerator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasFailureResponseGenerator.java
@@ -10,23 +10,22 @@ import java.util.function.Supplier;
 
 public class EidasFailureResponseGenerator {
 
-    private String proxyNodeMetadataForConnectorNodeUrl;
     private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier;
 
     public EidasFailureResponseGenerator(
-            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier,
-            String proxyNodeMetadataForConnectorNodeUrl) {
-        this.proxyNodeMetadataForConnectorNodeUrl = proxyNodeMetadataForConnectorNodeUrl;
+            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier
+    ) {
         this.eidasResponseBuilderSupplier = eidasResponseBuilderSupplier;
     }
 
     Response generateFailureSamlResponse(
+            String issuer,
             Status responseStatus,
             String eidasRequestId,
             String destinationUrl,
             String entityID) {
         return eidasResponseBuilderSupplier.get()
-                .withIssuer(proxyNodeMetadataForConnectorNodeUrl)
+                .withIssuer(issuer)
                 .withStatus(getMappedStatusCode(responseStatus))
                 .withInResponseTo(eidasRequestId)
                 .withIssueInstant(DateTime.now())

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
@@ -50,6 +50,7 @@ public class EidasResponseGenerator {
             final URI entityId) {
 
         final Response eidasResponse = failureResponseGenerator.generateFailureSamlResponse(
+                entityId.toString(),
                 responseStatus,
                 eidasRequestId,
                 destinationUrl,

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
@@ -26,7 +26,6 @@ public class TranslatorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
     @ClassRule
     public static final AppRule<TranslatorConfiguration> translatorAppRule = new AppRule<>(
             TranslatorApplication.class,
-            ConfigOverride.config("proxyNodeMetadataForConnectorNodeUrl", "http://proxy-node.uk"),
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri().toString()),
             ConfigOverride.config("metatronUri", metatronClientRule.baseUri().toString()),
             ConfigOverride.config("credentialConfiguration.type", "file"),
@@ -38,7 +37,6 @@ public class TranslatorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
     @ClassRule
     public static final AppRule<TranslatorConfiguration> translatorAppRuleWithECSigning = new AppRule<>(
             TranslatorApplication.class,
-            ConfigOverride.config("proxyNodeMetadataForConnectorNodeUrl", "http://proxy-node.uk"),
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri().toString()),
             ConfigOverride.config("metatronUri", metatronClientRule.baseUri().toString()),
             ConfigOverride.config("credentialConfiguration.type", "file"),


### PR DESCRIPTION
Delete proxyNodeMetadataForConnectorNodeUrl from the Configuration class and from the yaml file too.

As this is no longer an env var for k8s the value is never interpolated and Java tries to parse ${PROXY_NODE_METADATA_FOR_CONNECTOR_NODE_URL} as a URL.  Unsurprisingly this doesn't end well and the translator doesn't start at all which means tests never get run.