### PR TITLE
EID-1919 Configure Gateway to use QWAC

### DIFF
--- a/chart/templates/gateway-ingress-gateway.yaml
+++ b/chart/templates/gateway-ingress-gateway.yaml
@@ -26,6 +26,15 @@ spec:
       number: 443
       name: https
       protocol: HTTPS
+{{- if .Values.global.qwacCertificate.enabled -}}
+    tls:
+      mode: SIMPLE
+      serverCertificate: sds
+      privateKey: sds
+      credentialName: gateway-ingress-certificate-for-signin-sealed-secret
+    hosts:
+    - {{ include "gateway.host.govuk" . }}
+{{- else -}}
     tls:
       mode: SIMPLE
       serverCertificate: sds
@@ -33,3 +42,4 @@ spec:
       credentialName: {{ .Release.Name }}-gateway-ingress-certificate
     hosts:
     - {{ include "gateway.host" . }}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,8 @@ global:
     enabled: true
     ip: 127.0.0.1
   domainGovUK: eidas.signin.service.gov.uk
+  qwacCertificate:
+    enabled: false
 
 hubFqdn: www.integration.signin.service.gov.uk
 

--- a/ci/deploy/deploy-pipeline.yaml
+++ b/ci/deploy/deploy-pipeline.yaml
@@ -303,6 +303,7 @@ spec:
                     --set "global.cluster.name=${CLUSTER_NAME}" \
                     --set "global.cluster.domain=${CLUSTER_DOMAIN}" \
                     --set "global.cloudHsm.ip=${CLOUDHSM_IP}" \
+                    --set "global.qwacCertificate.enabled=true" \
                     --set "stubConnector.enabled=false" \
                     --set "vsp.secretName=vsp-production" \
                     --output-dir "./manifests/" \


### PR DESCRIPTION
add `qwac.enabled: false` to `values.yaml` so that the default is to not use QWAC

add conditional sections to `gateway-ingress-gateway.yaml` under the `tls` and `hosts` sections so that when `qwac.enabled` is true, `tls` is handled differently and a different hostname is used.

add `--set "gateway.qwac=true"` to inline bash used in `render-manifests` in `prod/depoly-pipeline.yaml` so that production uses the QWAC

cross fingers and hope for the best.