### PR TITLE
BAU Use parallelStream in MetadataResolverService constructor

### DIFF
--- a/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
+++ b/metatron/src/main/java/uk/gov/ida/eidas/metatron/domain/MetadataResolverService.java
@@ -55,7 +55,7 @@ public class MetadataResolverService {
         this.metadataResolverFactory = metadataResolverFactory;
         this.credentialResolverFactory = credentialResolverFactory;
         this.expiredCertificateMetadataFilter = new ExpiredCertificateMetadataFilter();
-        this.countryConfigMap = countriesConfig.getCountries().stream()
+        this.countryConfigMap = countriesConfig.getCountries().parallelStream()
                 .collect(Collectors.toMap(EidasCountryConfig::getEntityId, this::createMetadataResolver));
     }
 
@@ -78,8 +78,8 @@ public class MetadataResolverService {
 
     private Client getClient(EidasCountryConfig country) {
         ClientConfig configuration = new ClientConfig();
-        configuration.property(ClientProperties.CONNECT_TIMEOUT, 10000);
-        configuration.property(ClientProperties.READ_TIMEOUT, 10000);
+        configuration.property(ClientProperties.CONNECT_TIMEOUT, 5_000);
+        configuration.property(ClientProperties.READ_TIMEOUT, 5_000);
         return country.getTlsTruststore()
                 .map(ts -> JerseyClientBuilder.newBuilder().trustStore(ts).withConfig(configuration).build())
                 .orElse(JerseyClientBuilder.newClient(configuration));


### PR DESCRIPTION
The MetadataResolverService needs to create a MetadataResolver for each configured country.  When it does this in series then any faulty countries must time out before the next country can be resolved.  As the resolvers are created during a stream operation we can replace `stream()` with `parallelStream()`.

Using the integration configuration, it can reduce the time taken to create the resolvers from ~42s to ~12s. Of the 12s, at least 10 are the time it takes for countries to timeout.  Reducing the timeout numbers in `getClient()` further speeds up the startup to ~8s.

You can test it by:

* generating a `countriesConfig.yaml` by running `verify-eidas-config.git/tools ./gradlew run --args="generate-config --environment=integration"`
* setting the environment variables `CONFIG_FILE` and `COUNTRIES_CONFIG_FILE` to suitable values (`src/dist/config.yml` for `CONFIG_FILE` and the file generated above for `COUNTRIES_CONFIG_FILE`)
* running the metatron `main` method.

**Example run configuration for IntelliJ**
![image](https://user-images.githubusercontent.com/44802846/88664325-d4335700-d0d4-11ea-9c46-5e1d15d493c8.png)


