### PR TITLE
🍒BAU upgrade CloudHSM client to latest version

### DIFF
--- a/cloudhsm/Dockerfile
+++ b/cloudhsm/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cloudhsm
 
 # Install AWS CloudHSM client
 RUN yum install -y wget \
- && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-3.0.0-2.el7.x86_64.rpm \
+ && wget --progress=bar:force https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm \
  && yum install -y ./cloudhsm-client-*.rpm
 
 COPY init.sh .


### PR DESCRIPTION
Follow instructions at https://docs.aws.amazon.com/cloudhsm/latest/userguide/install-and-configure-client-linux.html for Amazon Linux 2.

This is a [cherry-pick](https://github.com/alphagov/verify-proxy-node/pull/607/commits/f199d1e339b852b44353e5c177c3df0b68d3509e) for the BAU production branch.

