### PR TITLE
BAU Test Metatron ingress/egress logging

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,4 +6,8 @@ ignore:
     - '*':
         reason: Fix not available
         expires: 2020-12-15T00:00:00.000Z
+  SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972:
+    - '*':
+        reason: Not used directly by us; Fix not available
+        expires: 2020-09-07
 patch: {}

--- a/metatron/build.gradle
+++ b/metatron/build.gradle
@@ -8,7 +8,8 @@ dependencies {
             configurations.opensaml,
             project(':proxy-node-shared')
 
-    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0'
+    testImplementation 'com.github.stefanbirkner:system-rules:1.19.0',
+            configurations.ida_utils
 }
 
 apply plugin: 'application'

--- a/metatron/src/test/java/uk/gov/ida/eidas/metatron/apprule/MetatronAppRuleTests.java
+++ b/metatron/src/test/java/uk/gov/ida/eidas/metatron/apprule/MetatronAppRuleTests.java
@@ -1,27 +1,46 @@
 package uk.gov.ida.eidas.metatron.apprule;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.ida.common.shared.security.X509CertificateFactory;
 import uk.gov.ida.eidas.metatron.MetatronApplication;
 import uk.gov.ida.eidas.metatron.MetatronConfiguration;
 import uk.gov.ida.eidas.metatron.apprule.rules.CountryMetadataClientRule;
 import uk.gov.ida.eidas.metatron.apprule.rules.TestCountryMetadataResource;
 import uk.gov.ida.eidas.metatron.resources.MetatronResource;
+import uk.gov.ida.jerseyclient.ErrorHandlingClient;
+import uk.gov.ida.jerseyclient.JsonResponseProcessor;
 import uk.gov.ida.notification.apprule.rules.AppRule;
 import uk.gov.ida.notification.contracts.metadata.CountryMetadataResponse;
+import uk.gov.ida.notification.shared.istio.IstioHeaderStorage;
+import uk.gov.ida.notification.shared.logging.ProxyNodeLogger;
+import uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter;
+import uk.gov.ida.notification.shared.logging.ProxyNodeMDCKey;
+import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 import uk.gov.ida.saml.core.test.OpenSAMLRunner;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URISyntaxException;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter.MESSAGE_EGRESS;
+import static uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter.MESSAGE_INGRESS;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_ENCRYPTION_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SIGNING_CERT;
 
@@ -112,6 +131,40 @@ public class MetatronAppRuleTests {
         Response response = metatronAppRule.target(getUriString(entityId)).request().get();
         assertThat(response.getStatusInfo()).isEqualTo(Response.Status.BAD_REQUEST);
         assertResponseIsAnErrorMap(response);
+    }
+
+    @Test
+    public void ingressAndEgressShouldBeLoggedByFilter() throws URISyntaxException {
+
+        Appender<ILoggingEvent> appender = mock(Appender.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(ProxyNodeLogger.class);
+        logger.addAppender(appender);
+
+        String entityId = getEntityId(TestCountryMetadataResource.VALID_TWO);
+
+        ProxyNodeJsonClient client = new ProxyNodeJsonClient(
+                new ErrorHandlingClient(new JerseyClientBuilder(metatronAppRule.getEnvironment()).build("header-passing-client")),
+                new JsonResponseProcessor(new ObjectMapper()),
+                new IstioHeaderStorage());
+
+        MDC.put(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name(), "proxy-node-journey-id");
+
+        metatronAppRule.get(getUriString(entityId), client, String.class);
+
+        ArgumentCaptor<ILoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(ILoggingEvent.class);
+        verify(appender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
+
+        final List<ILoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        final Map<String, String> mdcPropertyMap = logEvents.stream()
+                .filter(e -> e.getMessage().equals(ProxyNodeLoggingFilter.MESSAGE_INGRESS))
+                .findFirst()
+                .map(ILoggingEvent::getMDCPropertyMap)
+                .orElseThrow();
+
+        assertThat(mdcPropertyMap.get(ProxyNodeMDCKey.PROXY_NODE_JOURNEY_ID.name())).isEqualTo("proxy-node-journey-id");
+        assertThat(logEvents).filteredOn(e -> e.getMessage().equals(MESSAGE_INGRESS)).hasSize(1);
+        assertThat(logEvents).filteredOn(e -> e.getMessage().equals(MESSAGE_EGRESS)).hasSize(1);
+
     }
 
     private String getEntityId(String name) {

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/AppRule.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/AppRule.java
@@ -6,6 +6,7 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.client.ClientProperties;
+import uk.gov.ida.notification.shared.proxy.ProxyNodeJsonClient;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
@@ -39,6 +40,10 @@ public class AppRule<T extends Configuration> extends DropwizardAppRule<T> {
 
     public WebTarget target(String path) throws URISyntaxException {
         return target(path, getLocalPort());
+    }
+
+    public <T> T get(String path, ProxyNodeJsonClient client, Class<T> clazz) throws URISyntaxException {
+        return client.get(new URI(path), clazz);
     }
 
     private WebTarget target(String path, int port) throws URISyntaxException {


### PR DESCRIPTION
Add test for `metatron` ingress and egress logging including verifying logging of `PROXY_NODE_JOURNEY_ID` on ingress.

Modify AppRule to enable injection of `ProxyNodeJsonClient` when making a `GET` request (since `ProxyNodeJsonClient` passes the headers to `metatron` that need logging).

Modify `build.gradle` so that `ida_utils` dependencies are available to `testImplementation`.