### PR TITLE
EID-1919 eIDAS requirement: TLS v1.2 must be used

### DIFF
--- a/chart/templates/gateway-ingress-gateway.yaml
+++ b/chart/templates/gateway-ingress-gateway.yaml
@@ -36,6 +36,7 @@ spec:
       serverCertificate: sds
       privateKey: sds
       credentialName: gateway-ingress-certificate-for-signin-sealed-secret
+      minProtocolVersion: TLSV1_2
     hosts:
     - {{ include "gateway.host.govuk" . }}
 {{- else }}
@@ -44,6 +45,7 @@ spec:
       serverCertificate: sds
       privateKey: sds
       credentialName: {{ .Release.Name }}-gateway-ingress-certificate
+      minProtocolVersion: TLSV1_2
     hosts:
     - {{ include "gateway.host" . }}
 {{- end -}}


### PR DESCRIPTION
From the eIDAS spec: 

> eIDAS nodes MUST use TLS 1.2. Prior TLS versions MUST NOT be accepted.

Improve TLS security. The list of (old) browsers that could not use TLS1.2 is: https://caniuse.com/#feat=tls1-2
