### PR TITLE
BAU Use latest provided CloudHSM JCE dependencies

### DIFF
--- a/cloudhsm/jdk-jce-image/Dockerfile
+++ b/cloudhsm/jdk-jce-image/Dockerfile
@@ -10,3 +10,7 @@ ADD https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-cli
 RUN yum install -y ./cloudhsm-client-*.rpm \
  && rm ./cloudhsm-client-*.rpm \
  && sed -i 's/UNIXSOCKET/TCPSOCKET/g' /opt/cloudhsm/data/application.cfg
+
+RUN rm /opt/cloudhsm/java/cloudhsm-test*.jar && \
+    rm /opt/cloudhsm/java/hamcrest*.jar && \
+    rm /opt/cloudhsm/java/junit*.jar

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -1,9 +1,3 @@
-repositories {
-    // cloudhsm libraries downloaded from AWS
-    flatDir {
-        dirs '/opt/cloudhsm/java'
-    }
-}
 
 dependencies {
     implementation configurations.dropwizard,
@@ -14,9 +8,7 @@ dependencies {
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {
-        implementation name: 'cloudhsm-3.0.0'
-        implementation name: 'log4j-api-2.8'
-        implementation name: 'log4j-core-2.8'
+        fileTree(include: ['*.jar'], dir: '/opt/cloudhsm/java')
     }
 
     testImplementation configurations.verify_saml_test,


### PR DESCRIPTION
The build is broken as we're referencing libs which are not part of the latest CloudHSM JCE release.

We use the `latest` CLoudHSM JCE release, which contains these jars:

cloudhsm-3.1.2.jar
cloudhsm-test-3.1.2.jar
hamcrest-all-1.3.jar
junit.jar
log4j-api-2.13.3.jar
log4j-core-2.13.3.jar

Remove the hamcrest, cloudhsm-test and junit jars, and accept others as dependencies for this API.