### PR TITLE
uSe new govsvc/aws-ruby image

### DIFF
--- a/ci/deploy/multi-country-killswitch-pipeline.yaml
+++ b/ci/deploy/multi-country-killswitch-pipeline.yaml
@@ -58,8 +58,8 @@ spec:
               image_resource:
                 type: docker-image
                 source:
-                  repository: gdsre/aws-ruby
-                  tag: 2.6.1-3.0.1
+                  repository: govsvc/aws-ruby
+                  tag: 2.6.1
               outputs:
                 - name: lock-dir
               run:
@@ -98,8 +98,8 @@ spec:
                 image_resource:
                   type: docker-image
                   source:
-                    repository: gdsre/aws-ruby
-                    tag: 2.6.1-3.0.1
+                    repository: govsvc/aws-ruby
+                    tag: 2.6.1
                 outputs:
                   - name: lock-dir
                 params:
@@ -138,8 +138,8 @@ spec:
             image_resource:
               type: docker-image
               source:
-                repository: gdsre/aws-ruby
-                tag: 2.6.1-3.0.1
+                repository: govsvc/aws-ruby
+                tag: 2.6.1
             outputs:
               - name: lock-dir
             params:


### PR DESCRIPTION
This image is now continuously deployed, we should prefer it.  We're
moving away from the `gdsre` organisation to the `govsvc` one.