### PR TITLE
🛑 EID-1994 Stop Proxy Node Prod deploy if pipeline locked via S3

### DIFF
--- a/ci/deploy/deploy-pipeline.yaml
+++ b/ci/deploy/deploy-pipeline.yaml
@@ -45,6 +45,11 @@ spec:
         repository: ((concourse.github-resource-image))
         tag: ((concourse.github-resource-tag))
 
+    - name: slack-notification
+      type: docker-image
+      source:
+        repository: cfcommunity/slack-notification-resource
+
     resources:
 
     - name: release
@@ -73,6 +78,21 @@ spec:
       source:
         <<: *country_config
         paths: [proxy-node/production]
+
+    - name: production-lock
+      type: s3
+      source:
+        bucket: ((production-lock.S3BucketName))
+        region_name: ((production-lock.S3BucketRegion))
+        access_key_id: ((pipeline.AccessKeyID))
+        secret_access_key: ((pipeline.SecretAccessKey))
+        session_token: ((pipeline.SessionToken))
+        regexp: lock/(.*).lock
+
+    - name: slack-2nd-line
+      type: slack-notification
+      source:
+        url: ((verify-2nd-line-slack-webhook.url))
 
     jobs:
     - name: deploy-integration
@@ -221,6 +241,41 @@ spec:
 
         - get: verify-eidas-config-production
           trigger: true
+
+        - get: production-lock
+
+        - task: check-lockfile
+          on_failure:
+            put: slack-2nd-line
+            params:
+              text: |
+                Proxy Node Production Deploy stopped as the pipeline is locked.
+                See $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+              icon_emoji: ':stop:'
+          config:
+            platform: linux
+            image_resource:
+              type: docker-image
+              source:
+                repository: govsvc/aws-ruby
+                tag: 2.6.1
+            inputs:
+              - name: production-lock
+                path: lock-dir
+            run:
+              path: ruby
+              args:
+                - -e
+                - |
+                  require 'json'
+                  most_recent_lockfile = JSON.parse(File.read(Dir.glob('lock-dir/*.lock').sort.reverse.first))
+                  if most_recent_lockfile["is_locked"] == true
+                    puts '🛑 Production Deploy Pipeline is locked.'
+                    exit 1
+                  else
+                    puts '👍 Production Deploy Pipeline is unlocked.'
+                    exit 0
+                  end
 
         - task: generate-eidas-config
           config:

--- a/ci/deploy/killswitch-pipeline.yaml
+++ b/ci/deploy/killswitch-pipeline.yaml
@@ -29,8 +29,7 @@ spec:
           require 'json'
 
           content = {
-            is_locked: ENV['IS_LOCKED'] == 'true',
-            force: ENV['FORCE'] == 'true',
+            is_locked: ENV['IS_LOCKED'] == 'true'
           }
 
           puts "Lock file content is now: #{content.to_json}"
@@ -44,7 +43,7 @@ spec:
           repository: cfcommunity/slack-notification-resource
 
     resources:
-      -
+
       - name: verify-slack
         type: slack-notification
         source:
@@ -82,7 +81,6 @@ spec:
               outputs:
                 - name: lock-dir
               params:
-                FORCE: 'false'
                 IS_LOCKED: 'true'
               run: *create-lock-file
           - put: production-lock
@@ -108,7 +106,6 @@ spec:
                 outputs:
                   - name: lock-dir
                 params:
-                  FORCE: 'false'
                   IS_LOCKED: 'false'
                 run: *create-lock-file
             - put: production-lock
@@ -119,32 +116,6 @@ spec:
             << : *slack_defaults
             text: "The Proxy-Node Production deploy pipeline has been unlocked"
             icon_emoji: ':unlock:'
-
-    - name: force-unlock-proxy-deploy
-      serial: true
-      plan:
-        - task: create-force-lockfile
-          config:
-            platform: linux
-            image_resource:
-              type: docker-image
-              source:
-                repository: govsvc/aws-ruby
-                tag: 2.6.1
-            outputs:
-              - name: lock-dir
-            params:
-              FORCE: 'true'
-              IS_LOCKED: 'false'
-            run: *create-lock-file
-        - put: production-lock
-          params:
-            file: lock-dir/*.lock
-        - put: verify-slack
-          params:
-            << : *slack_defaults
-            text: "The Proxy-Node Production deploy pipeline has been FORCE unlocked"
-            icon_emoji: ':vader:'
 
     - name: kill-and-lock-prod
       plan:


### PR DESCRIPTION
Check the `lock-production` S3 bucket to see if someone has set a "lock" on the prod deploy pipeline.
Slack when the pipeline is locked, and the deploy won't happen.
Also remove the `force unlock` job which was a carry-over from the Hub pipeline as isn't used here.