### PR TITLE
EID-1994 Evaluate ruby script as UTF-8 (Emojis FTW)

### DIFF
--- a/ci/deploy/deploy-pipeline.yaml
+++ b/ci/deploy/deploy-pipeline.yaml
@@ -267,6 +267,7 @@ spec:
               args:
                 - -e
                 - |
+                  # encoding: utf-8
                   require 'json'
                   most_recent_lockfile = JSON.parse(File.read(Dir.glob('lock-dir/*.lock').sort.reverse.first))
                   if most_recent_lockfile["is_locked"] == true


### PR DESCRIPTION
The [deploy-to-production job is currently failing](https://ci.london.verify.govsvc.uk/teams/eidas-proxy-node-deploy/pipelines/deploy/jobs/deploy-production/builds/58).

Evaluate the check-lockfile task ruby script as utf-8, to allow emojis.

I tested this on a local concourse with the ruby code below and it works with `# encoding: utf-8`, fails with a `-e:4: invalid multibyte char (US-ASCII)` message without the encoding line.

````
              run:
                path: ruby
                args:
                  - -e
                  - |
                    # encoding: utf-8
                    require 'json'


                    contents = {
                        "is_locked" => true
                    }

                    File.open("1.lock","w") do |f|
                      f.write(contents.to_json)
                    end

                    most_recent_lockfile = JSON.parse(File.read(Dir.glob('*.lock').sort.reverse.first))
                    if most_recent_lockfile["is_locked"] == true
                      puts '🛑 Production Deploy Pipeline is locked.'
                      exit 1
                    else
                      puts '👍 Production Deploy Pipeline is unlocked.'
                      exit 0
                    end

````