### PR TITLE
EID-2001 include specific libs bundled with latest CloudHSM JCE client

### DIFF
--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -1,3 +1,9 @@
+repositories {
+    // cloudhsm libraries downloaded from AWS
+    flatDir {
+        dirs '/opt/cloudhsm/java'
+    }
+}
 
 dependencies {
     implementation configurations.dropwizard,
@@ -8,7 +14,9 @@ dependencies {
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {
-        fileTree(include: ['*.jar'], dir: '/opt/cloudhsm/java')
+        implementation name: 'cloudhsm-3.0.0'
+        implementation name: 'log4j-api-2.8'
+        implementation name: 'log4j-core-2.8'
     }
 
     testImplementation configurations.verify_saml_test,

--- a/proxy-node-translator/build.gradle
+++ b/proxy-node-translator/build.gradle
@@ -14,9 +14,9 @@ dependencies {
             project(':proxy-node-shared')
 
     if (project.hasProperty('cloudhsm')) {
-        implementation name: 'cloudhsm-3.0.0'
-        implementation name: 'log4j-api-2.8'
-        implementation name: 'log4j-core-2.8'
+        implementation name: 'cloudhsm-3.1.2'
+        implementation name: 'log4j-api-2.13.3'
+        implementation name: 'log4j-core-2.13.3'
     }
 
     testImplementation configurations.verify_saml_test,


### PR DESCRIPTION
Reverts a commit that attempts to not use specific cloudhsm JCE jars.
Use the latest JCE client libs made available from building `cloudhsm/jdk-jce-image/Dockerfile`.
This is a bit of a hack until we can find a way to accept the latest JCE jars from AWS CloudHSM in a non-hardcoded way.
