### PR TITLE
🤭 EID-1944 Kill only production resources

### DIFF
--- a/ci/deploy/killswitch-pipeline.yaml
+++ b/ci/deploy/killswitch-pipeline.yaml
@@ -140,7 +140,7 @@ spec:
                   kubectl config set-context deployer --user deployer --cluster self
                   kubectl config use-context deployer
 
-                  kubectl -n "${NAMESPACE}" delete virtualservices,deployments -l app.kubernetes.io/instance=production
+                  kubectl -n "${NAMESPACE}" delete virtualservices,deployments,gateways -l app.kubernetes.io/instance=production
         - do: *lock-proxy-node-pipeline
         - put: verify-slack
           params:

--- a/ci/deploy/killswitch-pipeline.yaml
+++ b/ci/deploy/killswitch-pipeline.yaml
@@ -140,7 +140,7 @@ spec:
                   kubectl config set-context deployer --user deployer --cluster self
                   kubectl config use-context deployer
 
-                  kubectl -n "${NAMESPACE}" delete virtualservices,deployments --all
+                  kubectl -n "${NAMESPACE}" delete virtualservices,deployments -l app.kubernetes.io/instance=production
         - do: *lock-proxy-node-pipeline
         - put: verify-slack
           params:


### PR DESCRIPTION
Delete deployments and virtualservices from production only, by targeting the label `app.kubernetes.io/instance=production`.

Previously we deleted integration resources too, as they're on the same namespace.