### PR TITLE
BAU set prod error page url for Proxy Node

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -9,5 +9,5 @@ ignore:
   SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972:
     - '*':
         reason: Not used directly by us; Fix not available
-        expires: 2020-09-07
+        expires: 2020-10-07
 patch: {}

--- a/ci/deploy/deploy-pipeline.yaml
+++ b/ci/deploy/deploy-pipeline.yaml
@@ -341,6 +341,7 @@ spec:
               RELEASE_NAMESPACE: ((namespace-deployer.namespace))
               RELEASE_NAME: production
               CLOUDHSM_IP: ((cluster.cloudHsmIp))
+              ERROR_PAGE_URL: https://www.signin.service.gov.uk/proxy-node-error
             run:
               path: /bin/bash
               args:
@@ -362,6 +363,7 @@ spec:
                     --set "global.qwacCertificate.enabled=true" \
                     --set "stubConnector.enabled=false" \
                     --set "vsp.secretName=vsp-production" \
+                    --set "gateway.errorPageURL=${ERROR_PAGE_URL}" \
                     --output-dir "./manifests/" \
                     ./release/*.tgz
 


### PR DESCRIPTION
Override the prod default error page [set in values.yaml](https://github.com/alphagov/verify-proxy-node/blob/0530d32c4327cfc1786b7b3543f0907d696a6c98/chart/values.yaml#L50). It's set to an integration url by default.

Also ignore a snyk vuln that is not used directly at runtime, for another month. We need to upgrade to Dropwizard 2 to mitigate.
