### PR TITLE
EID-2012 set eIDAS response issuer as Proxy Node entity id

### DIFF
--- a/chart/templates/translator-deployment.yaml
+++ b/chart/templates/translator-deployment.yaml
@@ -82,6 +82,8 @@ spec:
           value: http://{{ .Release.Name }}-vsp/
         - name: METATRON_URL
           value: http://{{ .Release.Name }}-metatron/
+        - name: PROXY_NODE_ENTITY_ID
+          value: "{{ include "gateway.entityID" . }}"
       - name: hsm-client
         image: "{{ .Values.hsm.image.repository }}:{{ .Values.hsm.image.tag }}"
         imagePullPolicy: {{ .Values.hsm.image.pullPolicy }}

--- a/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
+++ b/eidas-saml-parser/src/test/java/uk/gov/ida/notification/eidassaml/apprule/EspAuthnRequestAppRuleTest.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.CONNECTOR_ENTITY_DESTINATION;
 import static uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter.MESSAGE_EGRESS;
 import static uk.gov.ida.notification.shared.logging.ProxyNodeLoggingFilter.MESSAGE_INGRESS;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.METADATA_SIGNING_A_PRIVATE_KEY;
@@ -67,7 +68,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         request = new EidasAuthnRequestBuilder()
                 .withIssuer(TestMetadataResource.CONNECTOR_ENTITY_ID)
                 .withDestination("http://proxy-node/eidasAuthnRequest")
-                .withAssertionConsumerServiceURL("http://assertionConsumerService.net");
+                .withAssertionConsumerServiceURL(CONNECTOR_ENTITY_DESTINATION);
     }
 
     @Test
@@ -83,7 +84,7 @@ public class EspAuthnRequestAppRuleTest extends EidasSamlParserAppRuleTestBase {
         EidasAuthnRequestBuilder builder = new EidasAuthnRequestBuilder()
                 .withIssuer(TestMetadataResource.CONNECTOR_ENTITY_ID)
                 .withDestination("http://proxy-node/eidasAuthnRequest")
-                .withAssertionConsumerServiceURL("http://assertionConsumerService.net")
+                .withAssertionConsumerServiceURL(CONNECTOR_ENTITY_DESTINATION)
                 .withSigningCredential(signingCredential)
                 .withSignatureAlgorithm(new SignatureRSASSAPSS());
 

--- a/proxy-node-acceptance-tests/features/acceptance/proxy_node.feature
+++ b/proxy-node-acceptance-tests/features/acceptance/proxy_node.feature
@@ -5,12 +5,14 @@ Feature: Proxy Node acceptance tests
     And   they progress through Verify
     And   they login to Stub IDP
     Then  they should arrive at the Stub Connector success page
+    And  they should have a response issued by the Proxy Node
 
   Scenario: Proxy Node happy path - LOA Substantial
     Given the Proxy Node is sent an LOA 'Substantial' request from the Stub Connector
     And   they progress through Verify
     And   they login to Stub IDP
     Then  they should arrive at the Stub Connector success page
+    And  they should have a response issued by the Proxy Node
 
   Scenario: Proxy Node happy path - Transient PID requested
     Given the proxy node is sent a transient PID request
@@ -18,6 +20,7 @@ Feature: Proxy Node acceptance tests
     And   they login to Stub IDP
     Then  they should arrive at the Stub Connector success page
     And   they should have a transient PID
+    And  they should have a response issued by the Proxy Node
 
   Scenario: Proxy Node happy path - LOA High
     Given the Proxy Node is sent an LOA 'High' request from the Stub Connector

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -88,7 +88,7 @@ And('they should have a transient PID') do
 end
 
 And('they should have a response issued by the Proxy Node') do
-  assert_text(env('PROXY_NODE_URL') + '/ServiceMetadata')
+  assert_text('Issuer: ' + env('PROXY_NODE_URL') + '/ServiceMetadata')
 end
 
 Then("the user should be presented with a Hub error page indicating IDP could not sign them in") do

--- a/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/user_steps.rb
@@ -87,6 +87,10 @@ And('they should have a transient PID') do
   assert_text('GB/EU/_tr_')
 end
 
+And('they should have a response issued by the Proxy Node') do
+  assert_text(env('PROXY_NODE_URL') + '/ServiceMetadata')
+end
+
 Then("the user should be presented with a Hub error page indicating IDP could not sign them in") do
   assert_text('Stub Idp Demo One couldn’t sign you in')
   assert_text('You may have selected the wrong company. Check your emails and text messages for confirmation of who verified you.')

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/apprule/HubResponseAppRuleTests.java
@@ -156,7 +156,7 @@ public class HubResponseAppRuleTests extends GatewayAppRuleTestBase {
         assertThat(response.getStatus()).isEqualTo(200);
 
         final List<HubResponseTranslatorRequest> translatorArgs = TEST_TRANSLATOR_RESOURCE.getTranslatorArgs();
-        assertThat(translatorArgs.get(0).getEidasIssuerEntityId()).isEqualTo(URI.create(SAMPLE_ENTITY_ID));
+        assertThat(translatorArgs.get(0).getConnectorEntityId()).isEqualTo(URI.create(SAMPLE_ENTITY_ID));
         assertThat(translatorArgs.size()).isOne();
     }
 

--- a/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
+++ b/proxy-node-gateway/src/test/java/uk/gov/ida/notification/resources/HubResponseResourceTest.java
@@ -106,7 +106,7 @@ public class HubResponseResourceTest {
         assertThat("hub_request_id_in_session").isEqualTo(request.getRequestId());
         assertThat(HubResponseResource.LEVEL_OF_ASSURANCE).isEqualTo(request.getLevelOfAssurance());
         assertThat("eidas_request_id_in_session").isEqualTo(request.getEidasRequestId());
-        assertThat(URI.create("http://entityId")).isEqualTo(request.getEidasIssuerEntityId());
+        assertThat(URI.create("http://entityId")).isEqualTo(request.getConnectorEntityId());
 
         assertThat("http://connector.node").isEqualTo(response.getPostUrl());
         assertThat("SAMLResponse").isEqualTo(response.getSamlMessageType());

--- a/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
+++ b/proxy-node-shared/src/main/java/uk/gov/ida/notification/contracts/HubResponseTranslatorRequest.java
@@ -39,7 +39,7 @@ public class HubResponseTranslatorRequest {
 
     @NotNull
     @JsonProperty
-    private URI eidasIssuerEntityId;
+    private URI connectorEntityId;
 
     @JsonProperty
     private boolean transientPidRequested;
@@ -54,14 +54,14 @@ public class HubResponseTranslatorRequest {
             String eidasRequestId,
             String levelOfAssurance,
             URI destinationUrl,
-            URI eidasIssuerEntityId,
+            URI connectorEntityId,
             boolean transientPidRequested) {
         this.samlResponse = samlResponse;
         this.requestId = requestId;
         this.eidasRequestId = eidasRequestId;
         this.levelOfAssurance = levelOfAssurance;
         this.destinationUrl = destinationUrl;
-        this.eidasIssuerEntityId = eidasIssuerEntityId;
+        this.connectorEntityId = connectorEntityId;
         this.transientPidRequested = transientPidRequested;
     }
 
@@ -77,8 +77,8 @@ public class HubResponseTranslatorRequest {
         return eidasRequestId;
     }
 
-    public URI getEidasIssuerEntityId() {
-        return eidasIssuerEntityId;
+    public URI getConnectorEntityId() {
+        return connectorEntityId;
     }
 
     public String getLevelOfAssurance() {

--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/contracts/verifyserviceprovider/TranslatedHubResponseTestAssertions.java
@@ -19,6 +19,7 @@ import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_D
 import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_DATE_OF_BIRTH_ATTRIBUTE_NAME;
 import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_FRIENDLY_NAME;
 import static se.litsec.eidas.opensaml.ext.attributes.AttributeConstants.EIDAS_PERSON_IDENTIFIER_ATTRIBUTE_NAME;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.PROXY_NODE_ENTITY_ID;
 
 public class TranslatedHubResponseTestAssertions {
 
@@ -86,5 +87,9 @@ public class TranslatedHubResponseTestAssertions {
 
     private static String getAttributeValue(Attribute attribute) {
         return AttributeUtils.getAttributeStringValue(attribute);
+    }
+
+    public static void checkResponseIssuer(Response response) {
+        assertThat(response.getIssuer().getValue()).isEqualTo(PROXY_NODE_ENTITY_ID);
     }
 }

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetadataResource.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetadataResource.java
@@ -25,8 +25,11 @@ import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_RP_PUBLIC_SI
 @Path("/")
 public class TestMetadataResource {
 
-    public static final String CONNECTOR_ENTITY_ID = "http://connector-node/Metadata";
     public static final String PROXY_NODE_ENTITY_ID = "http://proxy-node/Metadata";
+    public static final String CONNECTOR_ENTITY_ID = "http://connector-node/Metadata";
+    public static final String CONNECTOR_ENTITY_DESTINATION = "http://connector-node/Destination";
+    public static final String CONNECTOR_ENTITY_ID_2 = "http://connector-node2/Metadata";
+    public static final String CONNECTOR_ENTITY_ID_2_DESTINATION = "http://connector-node2/Destination";
 
     private String connectorMetadataXml;
     private String proxyNodeMetadataXml;

--- a/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetatronResource.java
+++ b/proxy-node-test/src/main/java/uk/gov/ida/notification/apprule/rules/TestMetatronResource.java
@@ -9,20 +9,33 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Map;
 
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.CONNECTOR_ENTITY_DESTINATION;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.CONNECTOR_ENTITY_ID;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.CONNECTOR_ENTITY_ID_2;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.CONNECTOR_ENTITY_ID_2_DESTINATION;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_PRIMARY_CERT;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.STUB_COUNTRY_PUBLIC_SECONDARY_CERT;
 
 @Path("/")
 public class TestMetatronResource {
 
+    private final Map<String, String> map = Map.of(
+            CONNECTOR_ENTITY_ID, CONNECTOR_ENTITY_DESTINATION,
+            CONNECTOR_ENTITY_ID_2, CONNECTOR_ENTITY_ID_2_DESTINATION
+    );
+
     @GET
     @Path("metadata/{entity-id}")
     public CountryMetadataResponse get(@PathParam("entity-id") String entityId) {
+
+        String destination = map.getOrDefault(entityId, CONNECTOR_ENTITY_DESTINATION);
+
         return new CountryMetadataResponse(
                 STUB_COUNTRY_PUBLIC_SECONDARY_CERT,
                 STUB_COUNTRY_PUBLIC_PRIMARY_CERT,
-                Collections.singletonList(new AssertionConsumerService(URI.create("http://assertionConsumerService.net"), 0, true)),
+                Collections.singletonList(new AssertionConsumerService(URI.create(destination), 0, true)),
                 entityId,
                 "CC");
     }

--- a/proxy-node-translator/src/dist/config.yml
+++ b/proxy-node-translator/src/dist/config.yml
@@ -35,3 +35,5 @@ credentialConfiguration:
     key: ${TRANSLATOR_SIGNING_KEY}
 
 metatronUri: ${METATRON_URL}
+
+proxyNodeEntityId: ${PROXY_NODE_ENTITY_ID}

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/TranslatorApplication.java
@@ -125,7 +125,8 @@ public class TranslatorApplication extends Application<TranslatorConfiguration> 
         MetatronProxy metatronProxy = createMetatronProxy(configuration, environment);
 
         final HubResponseTranslator hubResponseTranslator = new HubResponseTranslator(
-                EidasResponseBuilder::instance
+                EidasResponseBuilder::instance,
+                configuration.getProxyNodeEntityId()
         );
 
         final EidasFailureResponseGenerator failureResponseGenerator = new EidasFailureResponseGenerator(

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/configuration/TranslatorConfiguration.java
@@ -25,6 +25,10 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
     @JsonProperty
     private URI metatronUri;
 
+    @NotNull
+    @JsonProperty
+    private URI proxyNodeEntityId;
+
     public VerifyServiceProviderConfiguration getVspConfiguration() {
         return vspConfiguration;
     }
@@ -40,5 +44,9 @@ public class TranslatorConfiguration extends Configuration implements Prometheus
 
     public URI getMetatronUri() {
         return metatronUri;
+    }
+
+    public URI getProxyNodeEntityId() {
+        return proxyNodeEntityId;
     }
 }

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/EidasResponseGenerator.java
@@ -36,7 +36,7 @@ public class EidasResponseGenerator {
     }
 
     public Response generateFromHubResponse(final HubResponseContainer hubResponseContainer) {
-        final CountryMetadataResponse countryMetadataResponse = metatronProxy.getCountryMetadata(hubResponseContainer.getIssuer().toString());
+        final CountryMetadataResponse countryMetadataResponse = metatronProxy.getCountryMetadata(hubResponseContainer.getConnectorEntityId().toString());
         final Response eidasResponse = hubResponseTranslator.getTranslatedHubResponse(hubResponseContainer, countryMetadataResponse);
         final Response encryptedEidasResponse = encryptAssertions(eidasResponse, countryMetadataResponse.getSamlEncryptionCertX509());
 

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseContainer.java
@@ -14,7 +14,7 @@ public class HubResponseContainer {
     private final String pid;
     private final String eidasRequestId;
     private final URI destinationURL;
-    private final URI issuer;
+    private final URI connectorEntityId;
     private final Attributes attributes;
     private final VspScenario vspScenario;
     private final VspLevelOfAssurance levelOfAssurance;
@@ -27,7 +27,7 @@ public class HubResponseContainer {
         this.pid = translatedHubResponse.getPid().orElse(null);
         this.eidasRequestId = hubResponseTranslatorRequest.getEidasRequestId();
         this.destinationURL = hubResponseTranslatorRequest.getDestinationUrl();
-        this.issuer = hubResponseTranslatorRequest.getEidasIssuerEntityId();
+        this.connectorEntityId = hubResponseTranslatorRequest.getConnectorEntityId();
         this.transientPidRequested = hubResponseTranslatorRequest.isTransientPidRequested();
         this.attributes = translatedHubResponse.getAttributes().orElse(null);
         this.vspScenario = translatedHubResponse.getScenario();
@@ -46,8 +46,8 @@ public class HubResponseContainer {
         return destinationURL.toString();
     }
 
-    URI getIssuer() {
-        return issuer;
+    URI getConnectorEntityId() {
+        return connectorEntityId;
     }
 
     public boolean isTransientPidRequested() {

--- a/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
+++ b/proxy-node-translator/src/main/java/uk/gov/ida/notification/translator/saml/HubResponseTranslator.java
@@ -19,6 +19,7 @@ import uk.gov.ida.notification.saml.EidasAttributeBuilder;
 import uk.gov.ida.notification.saml.EidasResponseBuilder;
 import uk.gov.ida.saml.core.domain.NonMatchingVerifiableAttribute;
 
+import java.net.URI;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -34,11 +35,14 @@ public class HubResponseTranslator {
     private static final String TRANSIENT_PREFIX = "_tr";
     private static final SecureRandomIdentifierGenerationStrategy ID_GENERATOR_STRATEGY = new SecureRandomIdentifierGenerationStrategy();
     private Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier;
+    private final URI issuerId;
 
 
     public HubResponseTranslator(
-            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier) {
+            Supplier<EidasResponseBuilder> eidasResponseBuilderSupplier,
+            URI issuerId) {
         this.eidasResponseBuilderSupplier = eidasResponseBuilderSupplier;
+        this.issuerId = issuerId;
     }
 
     Response getTranslatedHubResponse(HubResponseContainer hubResponseContainer, CountryMetadataResponse countryMetadataResponse) {
@@ -82,7 +86,7 @@ public class HubResponseTranslator {
                 .collect(Collectors.toList());
 
         return eidasResponseBuilderSupplier.get()
-                .withIssuer(hubResponseContainer.getIssuer().toString())
+                .withIssuer(issuerId.toString())
                 .withStatus(getMappedStatusCode(hubResponseContainer.getVspScenario()))
                 .withInResponseTo(hubResponseContainer.getEidasRequestId())
                 .withIssueInstant(now)

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/apprule/base/TranslatorAppRuleTestBase.java
@@ -10,6 +10,7 @@ import uk.gov.ida.notification.translator.TranslatorApplication;
 import uk.gov.ida.notification.translator.apprule.rules.StubVspResource;
 import uk.gov.ida.notification.translator.configuration.TranslatorConfiguration;
 
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.PROXY_NODE_ENTITY_ID;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PRIVATE_EC_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PRIVATE_KEY;
 import static uk.gov.ida.saml.core.test.TestCertificateStrings.TEST_PUBLIC_CERT;
@@ -28,6 +29,7 @@ public class TranslatorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
             TranslatorApplication.class,
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri().toString()),
             ConfigOverride.config("metatronUri", metatronClientRule.baseUri().toString()),
+            ConfigOverride.config("proxyNodeEntityId", PROXY_NODE_ENTITY_ID),
             ConfigOverride.config("credentialConfiguration.type", "file"),
             ConfigOverride.config("credentialConfiguration.publicKey.type", "x509"),
             ConfigOverride.config("credentialConfiguration.publicKey.cert", TEST_PUBLIC_CERT),
@@ -39,6 +41,7 @@ public class TranslatorAppRuleTestBase extends AbstractSamlAppRuleTestBase {
             TranslatorApplication.class,
             ConfigOverride.config("vspConfiguration.url", vspClientRule.baseUri().toString()),
             ConfigOverride.config("metatronUri", metatronClientRule.baseUri().toString()),
+            ConfigOverride.config("proxyNodeEntityId", PROXY_NODE_ENTITY_ID),
             ConfigOverride.config("credentialConfiguration.type", "file"),
             ConfigOverride.config("credentialConfiguration.publicKey.type", "x509"),
             ConfigOverride.config("credentialConfiguration.publicKey.cert", TEST_PUBLIC_EC_CERT),

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.gov.ida.notification.apprule.rules.TestMetadataResource.PROXY_NODE_ENTITY_ID;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createDateTime;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.AttributesBuilder.createNonMatchingTransliterableAttribute;
 import static uk.gov.ida.notification.contracts.verifyserviceprovider.TranslatedHubResponseBuilder.buildTranslatedHubResponseAuthenticationFailed;
@@ -45,7 +46,7 @@ public class HubResponseTranslatorTest {
         }
     }
 
-    private static final HubResponseTranslator TRANSLATOR = new HubResponseTranslator(EidasResponseBuilder::instance);
+    private static final HubResponseTranslator TRANSLATOR = new HubResponseTranslator(EidasResponseBuilder::instance, URI.create(PROXY_NODE_ENTITY_ID));
 
     private AttributesBuilder attributesBuilder;
     private CountryMetadataResponse countryMetaDataResponse;

--- a/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
+++ b/proxy-node-translator/src/test/java/uk/gov/ida/notification/translator/saml/HubResponseTranslatorTest.java
@@ -73,6 +73,7 @@ public class HubResponseTranslatorTest {
         TranslatedHubResponseTestAssertions.checkAssertionStatementsValid(identityVerifiedResponse);
         TranslatedHubResponseTestAssertions.checkAllAttributesValid(identityVerifiedResponse);
         TranslatedHubResponseTestAssertions.checkResponseStatusCodeValidForIdentityVerifiedStatus(identityVerifiedResponse);
+        TranslatedHubResponseTestAssertions.checkResponseIssuer(identityVerifiedResponse);
     }
 
     @Test

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/exceptions/mappers/TemplatedResponseWebApplicationExceptionMapper.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/exceptions/mappers/TemplatedResponseWebApplicationExceptionMapper.java
@@ -26,7 +26,7 @@ public class TemplatedResponseWebApplicationExceptionMapper implements Exception
 
         attributesByName.add(new AbstractMap.SimpleEntry<String,String>("response", exception.getMessage()));
 
-        ResponseView rv = new ResponseView(attributesByName, null, ValidationResult.INVALID.toString(), null, null);
+        ResponseView rv = new ResponseView(attributesByName, null, ValidationResult.INVALID.toString(), null, null, null);
         Response r = Response.status(400).entity(rv).build();
         return r;
     }

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/ReceiveResponseResource.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/resources/ReceiveResponseResource.java
@@ -104,15 +104,17 @@ public class ReceiveResponseResource {
         ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_REQUEST_ID, eidasRequestId);
 
         Issuer issuer = response.getIssuer();
+        String issuerId = "";
         if (issuer != null) {
-            ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, eidasRequestId);
+            issuerId = response.getIssuer().getValue();
+            ProxyNodeLogger.addContext(ProxyNodeMDCKey.EIDAS_ISSUER, issuerId);
         }
 
         ProxyNodeLogger.info(format(
                 "Response from Proxy Node with decrypted attributes: {0}",
                 String.join(",", attributesByName.toString())));
 
-        return new ResponseView(attributesByName, loa, validate.toString(), eidasRequestId, SAML_OBJECT_MARSHALLER.transformToString(decrypted));
+        return new ResponseView(attributesByName, loa, validate.toString(), eidasRequestId, issuerId, SAML_OBJECT_MARSHALLER.transformToString(decrypted));
     }
 
     private Map<String, Object> buildStaticParameters(String authnRequestId) {

--- a/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
+++ b/stub-connector/src/main/java/uk/gov/ida/notification/stubconnector/views/ResponseView.java
@@ -10,14 +10,16 @@ public class ResponseView extends View {
     private final String loa;
     private final String validity;
     private final String eidasRequestId;
+    private final String issuerId;
     private String samlMessage;
 
-    public ResponseView(List<Entry<String, String>> attributes, String loa, String validity, String eidasRequestId, String samlMessage) {
+    public ResponseView(List<Entry<String, String>> attributes, String loa, String validity, String eidasRequestId, String issuerId, String samlMessage) {
         super("response.mustache");
         this.attributes = attributes;
         this.loa = loa;
         this.validity = validity;
         this.eidasRequestId = eidasRequestId;
+        this.issuerId = issuerId;
         this.samlMessage = samlMessage;
     }
 

--- a/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
+++ b/stub-connector/src/main/resources/uk/gov/ida/notification/stubconnector/views/response.mustache
@@ -3,6 +3,7 @@
 <h2>Saml Validity: {{validity}}</h2>
 <h2>eIDAS Request Id: {{eidasRequestId}}</h2>
 <h2>LOA: {{loa}}</h2>
+<h2>Issuer: {{issuerId}}</h2>
 
 <h2>Attributes</h2>
 <ul style="list-style: none;">


### PR DESCRIPTION
Set an `issuerId` field in `HubResponseTranslator`. Use this `issuerId` field to be the SAML `Issuer` of the response.
We're presently incorrectly setting the `Issuer` to be the country entity id.

The value of `issuerId` is helm templated into the translator deployment with `{{ include "gateway.entityID" . }}`

Unit, integration (apprule) and acceptance tests have been updated. 