### PR TITLE
BAU Test for expired metadata entity descriptor

### DIFF
--- a/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/metadata/MetadataTest.java
+++ b/proxy-node-shared/src/test/java/uk/gov/ida/notification/saml/metadata/MetadataTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 public class MetadataTest {
 
     private static final String TEST_CONNECTOR_NODE_METADATA_FILE = "connector_node_metadata_template.xml";
+    private static final String TEST_EXPIRED_CONNECTOR_NODE_METADATA_FILE = "expired_connector_node_metadata_template.xml";
     private static final String TEST_CONNECTOR_NODE_METADATA_ENTITY_ID = "http://connector-node:8080/ConnectorResponderMetadata";
     private static final String TEST_HUB_METADATA_FILE = "hub_metadata.xml";
     private static final String TEST_HUB_METADATA_ENTITY_ID = "http://stub-idp-one.local/SSO/POST";
@@ -46,6 +47,22 @@ public class MetadataTest {
         PublicKey connectorNodeEncryptionPublicKey = metadata.getCredential(UsageType.ENCRYPTION, TEST_CONNECTOR_NODE_METADATA_ENTITY_ID, IDPSSODescriptor.DEFAULT_ELEMENT_NAME).getPublicKey();
 
         assertThat(expectedPublicKey).isEqualTo(connectorNodeEncryptionPublicKey);
+    }
+
+    @Test(expected = InvalidMetadataException.class)
+    public void shouldErrorIfMetadataEntityDescriptorIsExpired() throws Exception {
+        X509Certificate encryptionCert = new TestKeyPair().certificate;
+
+        MetadataResolver metadataResolver = new TestMetadataBuilder(TEST_EXPIRED_CONNECTOR_NODE_METADATA_FILE)
+                .withEncryptionCert(encryptionCert)
+                .buildResolver("someId");
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolverInitializer(metadataResolver).initialize();
+
+        new Metadata(metadataCredentialResolver).getCredential(
+                UsageType.ENCRYPTION,
+                TEST_CONNECTOR_NODE_METADATA_ENTITY_ID,
+                IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+
     }
 
     @Test

--- a/proxy-node-test/src/main/resources/expired_connector_node_metadata_template.xml
+++ b/proxy-node-test/src/main/resources/expired_connector_node_metadata_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
                      entityID="http://connector-node:8080/ConnectorResponderMetadata"
-                     validUntil="2030-09-29T12:12:32.337Z">
+                     validUntil="2020-09-29T12:12:32.337Z">
   <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
     <ds:SignedInfo>
       <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>


### PR DESCRIPTION
Unit tests are failing as its past the expiry date on the test metadata template `connector_node_metadata_template.xml`.

Update this expiry date to the future, and introduce a new test that asserts expired metadata entity descriptor should make that metadata invalid.