### PR TITLE
EID-2019 remove legacy proxy node deployments

### DIFF
--- a/ci/integration/deploy-pipeline.yaml
+++ b/ci/integration/deploy-pipeline.yaml
@@ -225,3 +225,36 @@ spec:
                     -f ./manifests/
                   echo "deleting ${RELEASE_NAMESPACE} connector pod"
                   kubectl -n ${RELEASE_NAMESPACE} delete pod -l app.kubernetes.io/name=connector
+
+    - name: delete-prod-deployments
+      serial: true
+      plan:
+        - task: delete-deployments
+          timeout: 10m
+          config:
+            platform: linux
+            image_resource: *task_toolbox
+            params:
+              KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+              KUBERNETES_TOKEN: ((namespace-deployer.token))
+              KUBERNETES_API: kubernetes.default.svc
+              RELEASE_NAMESPACE: ((namespace-deployer.namespace))
+            run:
+              path: /bin/bash
+              args:
+                - -euc
+                - |
+                  echo "configuring kubectl"
+                  echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                  kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                  kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                  kubectl config set-context deployer --user deployer --cluster self
+                  kubectl config use-context deployer
+
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "cz-integration-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "dk-integration-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "hmrc-integration-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "it-integration-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "mt-integration-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "se-integration-proxy-node"
+

--- a/ci/prod/deploy-pipeline.yaml
+++ b/ci/prod/deploy-pipeline.yaml
@@ -146,3 +146,33 @@ spec:
                 --app "${RELEASE_NAME}-${APP_NAME}" \
                 --diff-changes \
                 -f ./manifests/
+
+    - name: delete-prod-deployments
+      serial: true
+      plan:
+        - task: delete-deployments
+          timeout: 10m
+          config:
+            platform: linux
+            image_resource: *task_toolbox
+            params:
+              KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+              KUBERNETES_TOKEN: ((namespace-deployer.token))
+              KUBERNETES_API: kubernetes.default.svc
+              RELEASE_NAMESPACE: ((namespace-deployer.namespace))
+            run:
+              path: /bin/bash
+              args:
+                - -euc
+                - |
+                  echo "configuring kubectl"
+                  echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                  kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                  kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                  kubectl config set-context deployer --user deployer --cluster self
+                  kubectl config use-context deployer
+
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "cz-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "it-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "mt-proxy-node"
+                  kapp delete --namespace "${RELEASE_NAMESPACE}" --app "se-proxy-node"


### PR DESCRIPTION
Create one-off pipeline jobs to `kapp delete` deployments we don't need anymore. Note this is on the `release/single-country-legacy` branch.

This follows the merged [PR to remove the jobs to deploy these apps](https://github.com/alphagov/verify-proxy-node/pull/647).

I'm assuming the `kubectl config` that is set up in the task is required by `kapp`.