### PR TITLE
EID-2020: Spain proxy node smoke test

### DIFF
--- a/proxy-node-acceptance-tests/features/smoke/production/spain.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/spain.feature
@@ -1,0 +1,6 @@
+Feature: eIDAS Proxy Node Smoke Test - Spain - Production
+
+  Scenario: Proxy Node Spain happy path - LOA Substantial
+    Given   the user visits the "Spain" Stub Connector Node page
+    And     they navigate the "Spain" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -9,6 +9,8 @@ def country_stub_connector_url(country)
     'https://tara-demo.herokuapp.com/auth?scope=eidas'
   when 'Sweden'
     'https://qa.test.swedenconnect.se/'
+  when 'Spain'
+    'https://eidas.redsara.es/demosp/'
   else
     raise ArgumentError.new("Invalid country name: #{country}")
   end
@@ -57,4 +59,16 @@ def arrive_at_sweden_success_page
   assert_text("1984-02-29")
   assert_text("GB")
   assert_text('Your authentication was made according to eIDAS assurance level "Substantial".')
+end
+
+# Spain
+
+def navigate_spain_journey_to_uk
+  assert_text('Demo Service Provider')
+  find('#submit_button').click
+  assert_text('Select an identification method')
+  find("#tooltip4").find(".css3").click
+  assert_text("European authentication with foreign eID")
+  find(".countrySelectorButtons option[value='UK']").select_option
+  find('input[value="Login"]').click
 end


### PR DESCRIPTION
Add the Capybara smoke test with feature spain.feature.

The smoke test will be run by the hub smoke test pipeline.

This feature can be tested locally by:

- updating the `run-tests.sh` on line 80 to point at `features/smoke/production`
- and then run the `run-tests.sh` script  (use the `run-tests.sh -c` to run using chrome, this avoids selenium errors for me)

Subsequent PR in `verify-terraform`: https://github.com/alphagov/verify-terraform/pull/1335

https://govukverify.atlassian.net/browse/EID-2020 