### PR TITLE
EID-2020: Sweden prod proxy node smoke

### DIFF
--- a/proxy-node-acceptance-tests/features/smoke/production/sweden.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/sweden.feature
@@ -1,0 +1,6 @@
+Feature: eIDAS Proxy Node Smoke Test - Sweden - Production
+
+  Scenario: Proxy Node Sweden happy path - LOA Substantial
+    Given   the user visits the "SwedenProduction" Stub Connector Node page
+    And     they navigate the "Sweden" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -11,6 +11,8 @@ def country_stub_connector_url(country)
     'https://qa.test.swedenconnect.se/'
   when 'Spain'
     'https://eidas.redsara.es/demosp/'
+  when 'SwedenProduction'
+    'https://test.swedenconnect.se/'
   else
     raise ArgumentError.new("Invalid country name: #{country}")
   end


### PR DESCRIPTION
Currently Sweden has an integration smoke test which use the same steps.
Named the first step 'SwedenProduction' as that is the easiest way to determine them apart.
It uses the same steps following that as the integration journey, it just uses a different url.

This feature can be tested locally by:

- updating the `run-tests.sh` on line 80 to point at `features/smoke/production`
- and then run the `run-tests.sh` script 

Subsequent PR in `verify-terraform`: https://github.com/alphagov/verify-terraform/pull/1340

https://govukverify.atlassian.net/browse/EID-2020