### PR TITLE
EID-2020: Fix Netherlands smoke test

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -21,7 +21,7 @@ end
 def navigate_netherlands_journey_to_uk
   assert_text('EU Login')
   find('.select-dropdown').click
-  find('span', text: 'Demo portaal - PseudoID - 21').click
+  find('li span', text: 'Demo portaal - PseudoID - 21').click
   click_link('Log in')
   assert_text('Which country is your ID from?')
   find('#country-GB').click


### PR DESCRIPTION
Although running locally with'-c' flag  works fine, concourse is complaining:
`Element <a href="#"> is not clickable at point (537.75,377.75) because another element <span> obscures it`

So running without the '-c' flag gives the same error locally as what is seen on concourse. This change has fixed this error locally, but the final step seems to fail.
But the last step seems to pass in all the tests on concourse so we can assume that it will work.