### PR TITLE
EID-2020: Attempt #2 fix Netherlands smoke test

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -24,7 +24,7 @@ def navigate_netherlands_journey_to_uk
   assert_text('EU Login')
   find('.select-dropdown').click
   find('li span', text: 'Demo portaal - PseudoID - 21').click
-  click_link('Log in')
+  find("a", :text => "Log in").click 
   assert_text('Which country is your ID from?')
   find('#country-GB').click
   click_button('Continue')


### PR DESCRIPTION
Currently the smoke test is being flakey.
The `click_link` is what ive discovered to cause the issues.
Netherlands anchor tag is set up like this `href="#"`
So being more specific looking for the tag to click on might solve this.

https://github.com/teamcapybara/capybara/issues/379 <-- using a solution from this thread