### PR TITLE
EID-2020: Italy proxy node smoketest

### DIFF
--- a/proxy-node-acceptance-tests/features/smoke/production/italy.feature
+++ b/proxy-node-acceptance-tests/features/smoke/production/italy.feature
@@ -1,0 +1,6 @@
+Feature: eIDAS Proxy Node Smoke Test - Italy - Production
+
+  Scenario: Proxy Node Italy happy path - LOA Substantial
+    Given   the user visits the "Italy" Stub Connector Node page
+    And     they navigate the "Italy" journey to verify with UK identity
+    Then    they should arrive at the Verify Hub start page

--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -13,6 +13,8 @@ def country_stub_connector_url(country)
     'https://eidas.redsara.es/demosp/'
   when 'SwedenProduction'
     'https://test.swedenconnect.se/'
+  when 'Italy'
+    'https://www.impresainungiorno.gov.it/sso/go'
   else
     raise ArgumentError.new("Invalid country name: #{country}")
   end
@@ -73,4 +75,17 @@ def navigate_spain_journey_to_uk
   click_button("Belgium")
   find('li', text: 'United Kingdom').click 
   find('input[value="Login"]').click
+end
+
+# Italy
+
+def navigate_italy_journey_to_uk
+  assert_text('Cittadini Europei')
+  find('#lang_en').click
+  assert_text('European citizens')
+  find('.button-eidas').click
+  assert_text('Select your country')
+  find(:label, for: '13').click
+  page.execute_script('document.getElementsByName("submitButton")[0].disabled = false')
+  find_button('submitButton').click
 end


### PR DESCRIPTION
Add the Capybara smoke test with feature italy.feature.

The smoke test will be run by the hub smoke test pipeline.

This feature can be tested locally by:

- updating the `run-tests.sh` on line 80 to point at `features/smoke/production`
- and then run the `run-tests.sh` script

Subsequent PR in `verify-terraform`: https://github.com/alphagov/verify-terraform/pull/1346

https://govukverify.atlassian.net/browse/EID-2020 