### PR TITLE
EID-2020: Fix netherlands smoketest

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -24,7 +24,7 @@ def navigate_netherlands_journey_to_uk
   assert_text('EU Login')
   find('.select-dropdown').click
   find('li span', text: 'Demo portaal - PseudoID - 21').click
-  click_on("Log in") 
+  page.execute_script('document.getElementById("serviceForm").submit();')
   assert_text('Which country is your ID from?')
   find('#country-GB').click
   click_button('Continue')


### PR DESCRIPTION
We are executing a javascript to click button. This should stop the error of element obscuring the link