### PR TITLE
EID-2059 Update Proxy Node repo markdown docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - curl -u ida-codacy-bot:$GITHUB_PAT -LSs $(curl -u ida-codacy-bot:$GITHUB_PAT -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets[] | select(.browser_download_url | contains("codacy-coverage-reporter-assembly"))'.browser_download_url) -o codacy-coverage-reporter-assembly.jar
 
 install:
-  - npm install -g snyk@1.305.0
+  - npm install -g snyk@1.425.3
 
 script:
   - ./gradlew --no-daemon --parallel test

--- a/README.md
+++ b/README.md
@@ -4,17 +4,27 @@
 
 # eIDAS Proxy Node
 
-This repository contains the eIDAS Proxy Node implementation, which consists of the following services:
+This repository contains the eIDAS Proxy Node implementation, which supplies UK eIDs to notified EU Member States, according to the [eIDAS Regulation](https://ec.europa.eu/cefdigital/wiki/download/attachments/82773108/eIDAS%20Interoperability%20Architecture%20v.1.2%20Final.pdf?version=3&modificationDate=1571068651790&api=v2).
 
-* `proxy-node-gateway`
-* `proxy-node-translator`
-* `eidas-saml-parser`
-* `stub-idp`
-* `stub-connector`
+The UK Proxy Node is a service located between an EU Member State Connector Node, and a UK eID provider (Verify Hub). The Proxy Node is responsible for:
 
-The eIDAS Proxy Node also runs the [verify-service-provider](https://github.com/alphagov/verify-service-provider) to build Verify SAML AuthnRequests and parse SAML Responses from the Verify Hub.
+* transforming [eIDAS SAML requests](https://ec.europa.eu/cefdigital/wiki/download/attachments/82773108/eidas_message_format_v1.0.pdf?version=1&modificationDate=1497252920416&api=v2) from an EU Connector Node to Verify [SAML](https://en.wikipedia.org/wiki/SAML_2.0) requests
+* transforming [eIDAS SAML responses](https://ec.europa.eu/cefdigital/wiki/download/attachments/82773108/eidas_message_format_v1.0.pdf?version=1&modificationDate=1497252920416&api=v2) from Verify SAML responses
+* validating eIDAS SAML requests
+* signing and encrypting eIDAS SAML responses
 
-The eIDAS Proxy Node does not perform matching.
+The Proxy Node consists of the following services:
+
+| Service                 	| Role                                                                                 	|
+|-------------------------	|--------------------------------------------------------------------------------------	|
+| gateway                 	| public facing gateway that accepts and provides eIDAS SAML                           	|
+| eidas-saml-parser       	| parses and validates eIDAS SAML requests from EU Member States                       	|
+| verify-service-provider 	| creates and signs Verify SAML request payloads and parses, decrypts and validates Hub SAML responses 	|
+| metatron                	| provides data on how to connect to country connector nodes                                         	|
+| translator              	| creates signed and encrypted eIDAS SAML responses for EU Member States               	|
+| stub-connector          	| represents a country connector node, for testing                              	|
+
+The eIDAS Proxy Node does not perform [matching](https://www.docs.verify.service.gov.uk/using-verify-data/about-matching/#introduction-to-matching).
 
 ## Architectural Decision Records and documentation
 
@@ -27,31 +37,6 @@ A technical overview of the Proxy Node is available [here](doc/overview.md).
 ### Running locally with Docker
 
 See [instructions](local-startup/running-proxy-node-locally.md) to run the Proxy Node locally with minimal set-up using Docker.
-
-#### Preparing your environment (MacOS)
-`./Brewfile` defines system dependencies for this project, notably Docker, Minikube and Kubernetes.
-First install [homebrew](https://brew.sh/), then run
-`brew bundle` 
-to install these dependencies.
-
-This will allow `minikube` to manage a `virtualbox` 
-VM containing a Kubernetes cluster of the eIDAS Proxy Node services.
-
-#### Startup
-1. Run `./startup.sh`
-1. Visit `http://$(minikube ip):31100/Request` to start a journey from `stub-connector`.
-
-#### Troubleshooting the minikube cluster
-* use `startup.sh` to rebuild services which have changed, in preference to using `shutdown.sh` then `startup.sh`.
-The latter will rebuild all services and possibly reassign the minikube ip address.
-* view logs on the VM with `minikube logs`
-* ssh onto the VM with `minikube ssh`
-* if minikube will not initialise the VM, run: `./shutdown.sh`, and remove `~/.minikube` directory.
-* to use hyperkit in preference to virtualbox, first [install hyperkit ](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver), then run:
-    ```
-    minikube stop
-    minikube config set vm-driver hyperkit
-    ```
 
 ## Running unit tests
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -58,13 +58,17 @@ Once the eIDAS SAML response is signed, the Translator service passes it on to t
 The Verify Service Provider (VSP) generates and translates Security Assertion Markup Language (SAML) messages to and from the GOV.UK Verify Hub. 
 The Gateway service uses the VSP to generate SAML requests to send to the Verify Hub. For responses, the Translator service uses the VSP to validate SAML responses and translate them to JSON. 
 
+### Metatron
+
+The Metatron evaluates Connector Node metadata supplied by each connected EU Member State, which allows services to have data on how to validate eIDAS SAML requests and encrypt eIDAS SAML responses for each Connector. 
+
 ## Connecting to Countries
 
-We will host one instance of the proxy node services and infrastructure isolation per requesting Country connector node. All instances will share a single hardware security module (HSM) but will each have independent credentials to access the HSM, and an independent signing key held by the HSM.
+We host one instance of the UK Proxy Node for all Country Connector Nodes. The [Metatron](#metatron) provides data on how to communicate with each Connector Node.
 
 ## Infrastructure
 
-The eIDAS Proxy Node is hosted on an Amazon AWS cloud infrastructure and runs on Kubernetes. This is isolated from all Verify Hub deployments to ensure that it is treated as a separate component. Public and private subnets are used to isolate the Translator service. Access to environments and deployments is controlled using AWS’s identity and access management permissions.
+The eIDAS Proxy Node is hosted on an Amazon AWS cloud infrastructure and runs on the [GDS Supported Platform (GSP)](https://github.com/alphagov/gsp). This is isolated from all Verify Hub deployments to ensure that it is treated as a separate component. Public and private subnets are used to isolate the Translator service. Access to environments and deployments is controlled using AWS’s identity and access management permissions.
 
 ## Security operations monitoring
 
@@ -72,9 +76,9 @@ Security operations within the organisation will monitor transactions and access
 
 ## UK Proxy Node key management
 
-SAML responses going to EU member state connector nodes will be signed with keys stored on an HSM. These are keys with self-signed certificates. The same key will be used to sign the proxy node metadata. 
+SAML responses for EU member state connector nodes will be signed with keys stored on an HSM. These are keys with self-signed certificates. The same key will be used to sign the proxy node metadata. 
 
-The Verify Service Provider will be responsible for signing AuthnRequests and decrypting Responses from the Verify Hub. The keys it uses to do this will be stored as sealed secrets.
+The Verify Service Provider is responsible for signing AuthnRequests and decrypting Responses from the Verify Hub. The keys it uses to do this will be stored as sealed secrets. The certificates are managed in the [Verify Manage Certificates Service](https://github.com/alphagov/verify-self-service).
 
 |           Key type.          |        Key location        |
 | ---------------------------- | -------------------------- |


### PR DESCRIPTION
A non-exhaustive update to Proxy Node docs so that they make sense if the project is mothballed, and knowledge lost.

* Introduce what the Proxy Node does at top of README.md
* Add metatron docs
* Remove running locally in minikube
* Add useful links