### PR TITLE
BAU: Fix Italian proxy node test

### DIFF
--- a/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
+++ b/proxy-node-acceptance-tests/features/step_definitions/country_journeys.rb
@@ -88,4 +88,8 @@ def navigate_italy_journey_to_uk
   find(:label, for: '13').click
   page.execute_script('document.getElementsByName("submitButton")[0].disabled = false')
   find_button('submitButton').click
+  # We've seen the Italian page refuse to auto-submit its form, possibly a race condition. If the journey stalls, give it a kick
+  if page.has_title? 'eIDAS Authentication Service'
+    page.execute_script('document.getElementsByName("redirectForm")[0].submit()')
+  end
 end


### PR DESCRIPTION
The Italian proxy node test is _very_ flaky. We often see the test
failing at the Italians connector-node. There are a series of pages
which are auto-submitted with JS. One particular page's JS is fired by a
`load` event on the window. There may be a race condition as a lot of
the time this doesn't happen with Selenium and the journey stalls.

This adds a conditional check to see if we've stalled. If so, we
manually call the JS required to submit the page.