### PR TITLE
EID-2081 Proxy Node  integration kill switch

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,7 +5,7 @@ ignore:
   SNYK-JAVA-CAJULIUSDAVIES-30073:
     - '*':
         reason: Fix not available
-        expires: 2020-12-15T00:00:00.000Z
+        expires: 2021-01-01
   SNYK-JAVA-ORGGLASSFISHJERSEYMEDIA-595972:
     - '*':
         reason: Not used directly by us; Fix not available
@@ -15,6 +15,22 @@ ignore:
         reason: Not used directly by user input, fix not available unless we move to Dropwizard 2
         expires: 2021-01-01
   SNYK-JAVA-ORGECLIPSEJETTY-1021614:
+    - '*':
+        reason: fix not available unless we move to Dropwizard 2
+        expires: 2021-01-01
+  SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302:
+    - '*':
+        reason: fix not available unless we move to Dropwizard 2
+        expires: 2021-01-01
+  SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-1048058:
+    - '*':
+        reason: fix not available unless we move to Dropwizard 2
+        expires: 2021-01-01
+  SNYK-JAVA-ORGECLIPSEJETTY-1047304:
+    - '*':
+        reason: fix not available unless we move to Dropwizard 2
+        expires: 2021-01-01
+  SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: fix not available unless we move to Dropwizard 2
         expires: 2021-01-01

--- a/ci/deploy/integration-lock.yaml
+++ b/ci/deploy/integration-lock.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.govsvc.uk/v1beta1
+kind: S3Bucket
+metadata:
+  name: integration-lock
+  namespace: verify-eidas-proxy-node-deploy
+  labels:
+    group.access.govsvc.uk: pipeline
+spec:
+  aws: {}
+  secret: integration-lock

--- a/ci/deploy/killswitch-pipeline.yaml
+++ b/ci/deploy/killswitch-pipeline.yaml
@@ -68,12 +68,28 @@ spec:
               "is_locked": false
             }
 
+      - name: integration-lock
+        type: s3
+        source:
+          bucket: ((integration-lock.S3BucketName))
+          region_name: ((integration-lock.S3BucketRegion))
+          access_key_id: ((pipeline.AccessKeyID))
+          secret_access_key: ((pipeline.SecretAccessKey))
+          session_token: ((pipeline.SessionToken))
+          regexp: lock/(.*).lock
+          initial_path: 0.lock
+          initial_content_text: |
+            {
+              "is_locked": false
+            }
+
+
     jobs:
 
     - name: lock-prod-deploy
       serial: true
       plan:
-        - do: &lock-proxy-node-pipeline
+        - do: &lock-proxy-node-pipeline-production
           - task: create-lockfile
             config:
               platform: linux
@@ -149,8 +165,93 @@ spec:
                   kubectl config use-context deployer
 
                   kubectl -n "${NAMESPACE}" delete virtualservices,deployments,gateways -l app.kubernetes.io/instance=production
-        - do: *lock-proxy-node-pipeline
+        - do: *lock-proxy-node-pipeline-production
         - put: verify-slack
           params:
             << : *slack_defaults
             text: "The Proxy-Node Production :skull: killswitch :skull: has been pulled, which means the Production instance has been deleted and the Production deploy pipeline has been locked. See $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME"
+
+    - name: lock-integration-deploy
+      serial: true
+      plan:
+        - do: &lock-proxy-node-pipeline-integration
+            - task: create-lockfile
+              config:
+                platform: linux
+                image_resource:
+                  type: docker-image
+                  source:
+                    repository: govsvc/aws-ruby
+                    tag: 2.6.1
+                    username: ((dockerhubpull-concourse.username))
+                    password: ((dockerhubpull-concourse.password))
+                outputs:
+                  - name: lock-dir
+                params:
+                  IS_LOCKED: 'true'
+                run: *create-lock-file
+            - put: integration-lock
+              params:
+                file: lock-dir/*.lock
+        - put: verify-slack
+          params:
+            << : *slack_defaults
+            text: "The Proxy-Node integration deploy pipeline has been locked"
+
+    - name: unlock-integration-deploy
+      serial: true
+      plan:
+        - do:
+            - task: create-lockfile
+              config:
+                platform: linux
+                image_resource:
+                  type: docker-image
+                  source:
+                    repository: govsvc/aws-ruby
+                    tag: 2.6.1
+                    username: ((dockerhubpull-concourse.username))
+                    password: ((dockerhubpull-concourse.password))
+                outputs:
+                  - name: lock-dir
+                params:
+                  IS_LOCKED: 'false'
+                run: *create-lock-file
+            - put: integration-lock
+              params:
+                file: lock-dir/*.lock
+        - put: verify-slack
+          params:
+            << : *slack_defaults
+            text: "The Proxy-Node integration deploy pipeline has been unlocked"
+            icon_emoji: ':unlock:'
+
+    - name: kill-and-lock-integration
+      plan:
+        - task: delete-resources
+          timeout: 10m
+          config:
+            platform: linux
+            image_resource: *task_toolbox
+            params:
+              KUBERNETES_SERVICE_ACCOUNT: ((namespace-deployer))
+              KUBERNETES_TOKEN: ((namespace-deployer.token))
+              NAMESPACE: ((namespace-deployer.namespace))
+            run:
+              path: /bin/bash
+              args:
+                - -euc
+                - |
+                  echo "configuring kubectl"
+                  echo "${KUBERNETES_SERVICE_ACCOUNT}" | jq -r .["ca.crt"] > ca.crt
+                  kubectl config set-cluster self --server=https://kubernetes.default --certificate-authority=ca.crt
+                  kubectl config set-credentials deployer --token "${KUBERNETES_TOKEN}"
+                  kubectl config set-context deployer --user deployer --cluster self
+                  kubectl config use-context deployer
+
+                  kubectl -n "${NAMESPACE}" delete virtualservices,deployments,gateways -l app.kubernetes.io/instance=integration
+        - do: *lock-proxy-node-pipeline-integration
+        - put: verify-slack
+          params:
+            << : *slack_defaults
+            text: "The Proxy-Node integration :skull: killswitch :skull: has been pulled, which means the integration instance has been deleted and the integration deploy pipeline has been locked. See $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME"


### PR DESCRIPTION
## What
A way to remove the deployment of the Integration Proxy Node, via a concourse pipeline.

## Why
We already have a kill switch for production, but not integration. This will give us the confidence that the kill switch mechanics work, but won't affect production. We need more confidence as we may have to switch off the Proxy Node at a very specific out-of-hours time.

The change is mostly a copy-paste of the prod jobs, plus a new S3Bucket type to hold the integration lockfile.