### PR TITLE
Update README.md to indicate this repo is archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.com/alphagov/verify-proxy-node.svg?branch=master)](https://travis-ci.com/alphagov/verify-proxy-node)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/a24b4d2c6a834006a3c06fb8d7c47164)](https://www.codacy.com/app/alphagov/verify-proxy-node?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=alphagov/verify-proxy-node&amp;utm_campaign=Badge_Grade)
-[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a24b4d2c6a834006a3c06fb8d7c47164)](https://www.codacy.com/app/alphagov/verify-proxy-node?utm_source=github.com&utm_medium=referral&utm_content=alphagov/verify-proxy-node&utm_campaign=Badge_Coverage)
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
 
 # eIDAS Proxy Node
 


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.